### PR TITLE
Make `brial`, `sagemath_brial` standard again for now

### DIFF
--- a/build/pkgs/brial/type
+++ b/build/pkgs/brial/type
@@ -1,1 +1,1 @@
-optional
+standard

--- a/build/pkgs/sagemath_brial/type
+++ b/build/pkgs/sagemath_brial/type
@@ -1,1 +1,1 @@
-optional
+standard


### PR DESCRIPTION
to match upstream
