### PR TITLE
`src/sage/libs/flint/flint_wrap.h`: Work around 'I' symbol clash

### DIFF
--- a/src/sage/libs/flint/flint_wrap.h
+++ b/src/sage/libs/flint/flint_wrap.h
@@ -26,6 +26,10 @@
 #pragma push_macro("ulong")
 #undef ulong
 
+/* Reserved in C99, needed for FLINT without https://github.com/flintlib/flint/pull/2027 */
+#pragma push_macro("I")
+#define I Iv
+
 #include <flint/flint.h>
 
 /* If flint was already previously included via another header (e.g.
@@ -169,6 +173,7 @@
 #undef mp_bitcnt_t
 
 #pragma pop_macro("ulong")
+#pragma pop_macro("I")
 
 /* CPU_SIZE_1 and SIZE_RED_FAILURE_THRESH are defined as macros in flint/fmpz_lll.h
  * and as variables in fplll/defs.h, which breaks build if linbox is compiled with fplll */


### PR DESCRIPTION
Cherry-picked from https://github.com/sagemath/sage/pull/38227

Fixes https://github.com/sagemath/sage/issues/38242
