### PR TITLE
configure.ac: Make --disable-editable the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ in the Installation Guide.
       where `SAGE_LOCAL` is the desired installation prefix, which
       must be writable by the user.
 
-      If you use this option in combination with `--disable-editable`,
+      Unless you use this option in combination with `--enable-editable`,
       you can delete the entire Sage source tree after completing
       the build process.  What is installed in `SAGE_LOCAL` will be
       a self-contained installation of Sage.

--- a/configure.ac
+++ b/configure.ac
@@ -127,10 +127,10 @@ AC_ARG_ENABLE([debug],
 AC_ARG_VAR(SAGE_DEBUG, controls debugging support: "no" debugging; debugging "symbols" (default); build debug version ("yes"))
 
 AC_ARG_ENABLE([editable],
-              [AS_HELP_STRING([--disable-editable],
-                              [do not use an editable install of the Sage library: changes to Python files will require "sage -b" to rebuild the Sage library])],
+              [AS_HELP_STRING([--enable-editable],
+                              [use an editable install of the Sage library (experimental)])],
               [AC_SUBST([SAGE_EDITABLE], [$enableval])],
-              [AC_SUBST([SAGE_EDITABLE], [yes])])
+              [AC_SUBST([SAGE_EDITABLE], [no])])
 
 AC_ARG_ENABLE([wheels],
               [AS_HELP_STRING([--enable-wheels],


### PR DESCRIPTION
Marking `--enable-editable` as experimental.

Currently the editable (monolithic) Sage library does not properly interop with modularized distributions such as **sagemath-brial**.

- https://github.com/sagemath/sage/pull/38439

