### PR TITLE
`dist.yml` (wheels): Do not try to upload passagemath-giac wheel for now (too large)

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -490,6 +490,10 @@ jobs:
           path: wheelhouse
           merge-multiple: true
 
+      - name: Remove wheels that are too large
+        run: |
+          find wheelhouse -size +96M -delete
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
Workaround for
- #105
