### PR TITLE
build/make/install: Do not print ALL-ENVIRONMENT-VARIABLES

### DIFF
--- a/build/make/install
+++ b/build/make/install
@@ -54,19 +54,6 @@ if $MAKE -q "$@" >/dev/null 2>/dev/null; then
     exit 0
 fi
 
-# Dump environment for debugging purposes:
-if [ -n "$GITHUB_ACTIONS" ]; then
-    echo "::group::*** ALL ENVIRONMENT VARIABLES BEFORE BUILD: ***"
-else
-    echo "*** ALL ENVIRONMENT VARIABLES BEFORE BUILD: ***"
-fi
-env | sort
-printf '\E[m'
-echo "***********************************************"
-if [ -n "$GITHUB_ACTIONS" ]; then
-    echo "::endgroup::"
-fi
-
 # look_for_errors: search log files for error messages and print a summary.
 # arguments:
 # - $1: glob pattern for log files to search


### PR DESCRIPTION
Rarely helpful and too much noise.