### PR TITLE
sagemath-standard-no-symbolics: Include everything not shipped by another distribution

### DIFF
--- a/pkgs/sagemath-standard-no-symbolics/MANIFEST.in
+++ b/pkgs/sagemath-standard-no-symbolics/MANIFEST.in
@@ -2,6 +2,8 @@ prune .tox
 exclude *.m4
 include requirements.txt
 
+graft sage
+
 prune sage/symbolic
 prune sage/manifolds
 prune sage/lfunctions


### PR DESCRIPTION
This takes care of #102, but in follow-ups various modules should be sorted into proper distributions.