### PR TITLE
docker.yml: Disambiguate log artifact names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -260,10 +260,11 @@ jobs:
           cp -r .tox/$TOX_ENV/* "artifacts/$LOGS_ARTIFACT_NAME"
           rm -rf "artifacts/$LOGS_ARTIFACT_NAME"/{bin,lib,pyvenv.cfg}
         if: always()
-      - uses: actions/upload-artifact@v4
+      - name: Upload log artifact
+        uses: actions/upload-artifact@v4
         with:
           path: artifacts
-          name: ${{ env.LOGS_ARTIFACT_NAME }}
+          name: ${{ env.LOGS_ARTIFACT_NAME }}-${{ job.container.id }}
         if: always()
       - name: Print out logs for immediate inspection
         # and markup the output with GitHub Actions logging commands


### PR DESCRIPTION
After the upgrade to upload-artifact v4, we see `Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`
https://github.com/passagemath/passagemath/actions/runs/11431706897/job/31801071603#step:13:29

The reason is that we run the default platform (ubuntu-jammy) twice in one workflow. 
