### PR TITLE
sagemath-standard-no-symbolics: Do not prune what is still needed

### DIFF
--- a/pkgs/sagemath-standard-no-symbolics/MANIFEST.in
+++ b/pkgs/sagemath-standard-no-symbolics/MANIFEST.in
@@ -6,13 +6,13 @@ graft sage
 
 prune sage/symbolic
 prune sage/manifolds
-prune sage/lfunctions
+#prune sage/lfunctions
 prune sage/geometry/riemannian_manifolds
 prune sage/geometry/hyperbolic_space
 prune sage/dynamics/complex_dynamics
 prune sage/groups/lie_gps
 prune sage/modular/modform_hecketriangle
-prune sage/rings/asymptotic
+#prune sage/rings/asymptotic
 
 prune sage/plot
 


### PR DESCRIPTION
- see #114
