### PR TITLE
pkgs/sagemath-{singular,eclib}: Add dependencies

### DIFF
--- a/pkgs/sagemath-eclib/pyproject.toml.m4
+++ b/pkgs/sagemath-eclib/pyproject.toml.m4
@@ -10,6 +10,7 @@ requires = [
     SPKG_INSTALL_REQUIRES_sagemath_linbox
     SPKG_INSTALL_REQUIRES_sagemath_modules
     SPKG_INSTALL_REQUIRES_sagemath_ntl
+    SPKG_INSTALL_REQUIRES_sagemath_flint
     SPKG_INSTALL_REQUIRES_sagemath_objects
     SPKG_INSTALL_REQUIRES_cython
     SPKG_INSTALL_REQUIRES_memory_allocator

--- a/pkgs/sagemath-singular/pyproject.toml.m4
+++ b/pkgs/sagemath-singular/pyproject.toml.m4
@@ -9,6 +9,7 @@ requires = [
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_ntl
     SPKG_INSTALL_REQUIRES_sagemath_flint
+    SPKG_INSTALL_REQUIRES_sagemath_linbox
     SPKG_INSTALL_REQUIRES_sagemath_modules
     SPKG_INSTALL_REQUIRES_cython
     SPKG_INSTALL_REQUIRES_cysignals
@@ -28,6 +29,7 @@ dependencies = [
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_modules
     SPKG_INSTALL_REQUIRES_sagemath_flint
+    SPKG_INSTALL_REQUIRES_sagemath_linbox
 ]
 dynamic = ["version"]
 include(`pyproject_toml_metadata.m4')dnl'


### PR DESCRIPTION
To fix:
```
  from sage.rings.rational cimport Rational
  from sage.structure.element cimport Element
  from sage.rings.integer cimport Integer
  from sage.rings.finite_rings.integer_mod cimport IntegerMod_abstract
  from sage.rings.finite_rings.element_givaro cimport Cache_givaro
  ^
  ------------------------------------------------------------
  sage/libs/singular/singular.pxd:9:0: 'sage/rings/finite_rings/element_givaro.pxd' not found
```