### PR TITLE
passagemath-modules README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The packages may also cover a wide range of generalizations/applications of the 
 
 [![PyPI: passagemath-groups](https://img.shields.io/pypi/v/passagemath-groups.svg?label=passagemath-groups)](https://pypi.python.org/pypi/passagemath-groups) provides groups and invariant theory.
 
-[![PyPI: passagemath-modules](https://img.shields.io/pypi/v/passagemath-modules.svg?label=passagemath-modules)](https://pypi.python.org/pypi/passagemath-modules) provides vector spaces, modules, matrices, tensors, homology, coding theory, abelian groups, etc.
+[![PyPI: passagemath-modules](https://img.shields.io/pypi/v/passagemath-modules.svg?label=passagemath-modules)](https://pypi.python.org/pypi/passagemath-modules) provides vector spaces, modules, matrices, tensors, homology, coding theory, abelian groups, etc. It consists of over 440 first-party Python and Cython modules and depends on the [GNU Scientific Library](http://www.gnu.org/software/gsl/) and [NumPy](https://numpy.org/).
 
 [![PyPI: passagemath-polyhedra](https://img.shields.io/pypi/v/passagemath-polyhedra.svg?label=passagemath-polyhedra)](https://pypi.python.org/pypi/passagemath-polyhedra) provides convex polyhedra in arbitrary dimension on the basis of the [Parma Polyhedra Library](https://www.bugseng.com/ppl), but also provides fans, hyperplane arrangements, polyhedral complexes, linear and mixed-integer optimization, lattice point sets, and toric varieties.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The packages may also cover a wide range of generalizations/applications of the 
 
 [![PyPI: passagemath-groups](https://img.shields.io/pypi/v/passagemath-groups.svg?label=passagemath-groups)](https://pypi.python.org/pypi/passagemath-groups) provides groups and invariant theory.
 
-[![PyPI: passagemath-modules](https://img.shields.io/pypi/v/passagemath-modules.svg?label=passagemath-modules)](https://pypi.python.org/pypi/passagemath-modules) provides vector spaces, modules, matrices, tensors, homology, coding theory, abelian groups, etc. It consists of over 440 first-party Python and Cython modules and depends on the [GNU Scientific Library](http://www.gnu.org/software/gsl/) and [NumPy](https://numpy.org/).
+[![PyPI: passagemath-modules](https://img.shields.io/pypi/v/passagemath-modules.svg?label=passagemath-modules)](https://pypi.python.org/pypi/passagemath-modules) provides vector spaces, modules, matrices, tensors, homology, coding theory, abelian groups, matroids, etc. It consists of over 440 first-party Python and Cython modules and depends on the [GNU Scientific Library](http://www.gnu.org/software/gsl/) and [NumPy](https://numpy.org/).
 
 [![PyPI: passagemath-polyhedra](https://img.shields.io/pypi/v/passagemath-polyhedra.svg?label=passagemath-polyhedra)](https://pypi.python.org/pypi/passagemath-polyhedra) provides convex polyhedra in arbitrary dimension on the basis of the [Parma Polyhedra Library](https://www.bugseng.com/ppl), but also provides fans, hyperplane arrangements, polyhedral complexes, linear and mixed-integer optimization, lattice point sets, and toric varieties.
 

--- a/pkgs/sagemath-modules/README.rst
+++ b/pkgs/sagemath-modules/README.rst
@@ -61,6 +61,31 @@ What is included
 * `Probability Spaces and Distributions <https://doc.sagemath.org/html/en/reference/probability/index.html>`_, `Statistics <https://doc.sagemath.org/html/en/reference/stats/index.html>`_
 
 
+Examples
+--------
+
+A quick way to try it out interactively:
+
+```
+    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-modules[test]" IPython
+```
+
+```
+    In [1]: from sage.all__sagemath_modules import *
+
+    In [2]: M = matroids.Wheel(5); M
+    Out[2]: Wheel(5): Regular matroid of rank 5 on 10 elements with 121 bases
+
+    In [3]: M.representation()
+    Out[3]:
+    [ 1  0  0  0  0  1  0  0  0 -1]
+    [ 0  1  0  0  0 -1  1  0  0  0]
+    [ 0  0  1  0  0  0 -1  1  0  0]
+    [ 0  0  0  1  0  0  0 -1  1  0]
+    [ 0  0  0  0  1  0  0  0 -1  1]
+```
+
+
 Available as extras, from other distributions
 ---------------------------------------------
 

--- a/pkgs/sagemath-modules/README.rst
+++ b/pkgs/sagemath-modules/README.rst
@@ -112,3 +112,16 @@ Available as extras, from other distributions
 
 `pip install "sagemath-modules[standard]"`
  All related features as in a standard installation of SageMath
+
+
+Development
+-----------
+
+```
+    $ git clone --origin passagemath https://github.com/passagemath/passagemath.git
+    $ cd passagemath
+    passagemath $ ./bootstrap
+    passagemath $ python3 -m venv modules-venv
+    passagemath $ source modules-venv/bin/activate
+    (modules-venv) passagemath $ pip install -v -e pkgs/sagemath-modules
+```


### PR DESCRIPTION
This pip-installable package is now available:
- https://pypi.org/project/passagemath-modules/

Here we add:

- Examples that illustrate how to get started and the scope of the distribution
- Instructions how to develop separately
- Attribution and citations
...?

In particular this package includes `sage.matroids` @gmou3 @xuluze and `sage.tensor` @egourgoulhon 

Help and suggestions welcome 