### PR TITLE
passagemath-flint README

### DIFF
--- a/pkgs/sagemath-flint/README.rst
+++ b/pkgs/sagemath-flint/README.rst
@@ -1,5 +1,5 @@
 ====================================================================================
- passagemath: Fast computations with MPFI, FLINT and arb
+ passagemath: Fast computations with MPFI and FLINT
 ====================================================================================
 
 About SageMath
@@ -23,6 +23,43 @@ About this pip-installable source distribution
 ----------------------------------------------
 
 This pip-installable source distribution ``sagemath-flint`` provides
-Cython interfaces to the ``MPFI``, ``FLINT`` and ``arb`` libraries.
+Cython interfaces to the ``MPFI`` and ``FLINT`` libraries.
 
 It also ships the implementation of number fields.
+
+
+What is included
+----------------
+
+* see https://github.com/passagemath/passagemath/blob/main/pkgs/sagemath-flint/MANIFEST.in
+
+
+Examples
+--------
+
+A quick way to try it out interactively:
+
+```
+    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-flint[test]" IPython
+```
+
+```
+    In [1]: from sage.all__sagemath_flint import *
+
+    In [2]: RealBallField(128).pi()
+    Out[2]: [3.1415926535897932384626433832795028842 +/- 1.06e-38]
+
+```
+
+
+Development
+-----------
+
+```
+    $ git clone --origin passagemath https://github.com/passagemath/passagemath.git
+    $ cd passagemath
+    passagemath $ ./bootstrap
+    passagemath $ python3 -m venv flint-venv
+    passagemath $ source flint-venv/bin/activate
+    (flint-venv) passagemath $ pip install -v -e pkgs/sagemath-flint
+```

--- a/pkgs/sagemath-flint/README.rst
+++ b/pkgs/sagemath-flint/README.rst
@@ -40,7 +40,7 @@ Examples
 A quick way to try it out interactively:
 
 ```
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-flint[test]" IPython
+    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-flint[test]" ipython
 ```
 
 ```


### PR DESCRIPTION
This pip-installable package is now available:
- https://pypi.org/project/passagemath-flint/

Here we add:

- Examples that illustrate how to get started and the scope of the distribution
- Instructions how to develop separately
- Attribution and citations
...?

Help and suggestions welcome @fredrik-johansson @oscarbenjamin @mezzarobba 
