### PR TITLE
`dist.yml` (wheels): Remove linux-aarch64

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -194,7 +194,7 @@ jobs:
         arch: >-
           ${{ github.event_name == 'pull_request'
                 && fromJson('["x86_64"]')
-                || fromJson('["x86_64", "i686", "aarch64"]') }}
+                || fromJson('["x86_64", "i686"]') }}
         build: >-
           ${{ github.event_name == 'pull_request'
                 && fromJson('["manylinux"]')


### PR DESCRIPTION
The build (using QEMU) exceeds 6 hours, so we skip it for now