### PR TITLE
passagemath-gap README

### DIFF
--- a/pkgs/sagemath-gap/README.rst
+++ b/pkgs/sagemath-gap/README.rst
@@ -34,17 +34,19 @@ A quick way to try it out interactively::
 
     $ pipx run --pip-args="--prefer-binary" --spec "passagemath-gap[test]" IPython
 
-    In [1]: from sage.all__sagemath_gap import *
+    In [1]: from sage.all__sagemath_modules import *
 
-    In [2]: G = libgap.eval("Group([(1,2,3), (1,2)(3,4), (1,7)])")
+    In [2]: from sage.all__sagemath_gap import *
 
-    In [3]: CG = G.ConjugacyClasses()
+    In [3]: G = libgap.eval("Group([(1,2,3), (1,2)(3,4), (1,7)])")
 
-    In [4]: gamma = CG[2]
+    In [4]: CG = G.ConjugacyClasses()
 
-    In [5]: g = gamma.Representative()
+    In [5]: gamma = CG[2]
 
-    In [6]: CG; gamma; g
+    In [6]: g = gamma.Representative()
+
+    In [7]: CG; gamma; g
     [ ()^G, (4,7)^G, (3,4,7)^G, (2,3)(4,7)^G, (2,3,4,7)^G, (1,2)(3,4,7)^G, (1,2,3,4,7)^G ]
     (3,4,7)^G
     (3,4,7)

--- a/pkgs/sagemath-gap/README.rst
+++ b/pkgs/sagemath-gap/README.rst
@@ -27,6 +27,18 @@ distribution that provides modules that depend on the GAP system, see
 https://www.gap-system.org
 
 
+What is included
+----------------
+
+- `Cython interface to libgap <https://doc.sagemath.org/html/en/reference/libs/sage/libs/gap/libgap.html>`_
+
+- `Pexpect interface to GAP <https://doc.sagemath.org/html/en/reference/interfaces/sage/interfaces/gap.html>`_
+
+- numerous modules with build-time dependencies on GAP, see https://github.com/passagemath/passagemath/blob/main/pkgs/sagemath-gap/MANIFEST.in
+
+- the binary wheels on PyPI ship a prebuilt copy of GAP 4.13.1
+
+
 Examples
 --------
 

--- a/pkgs/sagemath-gap/README.rst
+++ b/pkgs/sagemath-gap/README.rst
@@ -22,7 +22,7 @@ for general installation instructions.
 About this pip-installable source distribution
 ----------------------------------------------
 
-This pip-installable source distribution ``sagemath-gap`` is a small
+This pip-installable source distribution ``passagemath-gap`` is a small
 distribution that provides modules that depend on the GAP system, see
 https://www.gap-system.org
 

--- a/pkgs/sagemath-gap/README.rst
+++ b/pkgs/sagemath-gap/README.rst
@@ -8,18 +8,15 @@ About SageMath
    "Creating a Viable Open Source Alternative to
     Magma, Maple, Mathematica, and MATLAB"
 
-   Copyright (C) 2005-2022 The Sage Development Team
+   Copyright (C) 2005-2024 The Sage Development Team
 
    https://www.sagemath.org
 
 SageMath fully supports all major Linux distributions, recent versions of
-macOS, and Windows (using Cygwin or Windows Subsystem for Linux).
+macOS, and Windows (Windows Subsystem for Linux).
 
-The traditional and recommended way to install SageMath is from source via
-Sage-the-distribution (https://www.sagemath.org/download-source.html).
-Sage-the-distribution first builds a large number of open source packages from
-source (unless it finds suitable versions installed in the system) and then
-installs the Sage Library (sagelib, implemented in Python and Cython).
+See https://doc.sagemath.org/html/en/installation/index.html
+for general installation instructions.
 
 
 About this pip-installable source distribution
@@ -28,3 +25,26 @@ About this pip-installable source distribution
 This pip-installable source distribution ``sagemath-gap`` is a small
 distribution that provides modules that depend on the GAP system, see
 https://www.gap-system.org
+
+
+Examples
+--------
+
+A quick way to try it out interactively::
+
+    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-gap[test]" IPython
+
+    In [1]: from sage.all__sagemath_gap import *
+
+    In [2]: G = libgap.eval("Group([(1,2,3), (1,2)(3,4), (1,7)])")
+
+    In [3]: CG = G.ConjugacyClasses()
+
+    In [4]: gamma = CG[2]
+
+    In [5]: g = gamma.Representative()
+
+    In [6]: CG; gamma; g
+    [ ()^G, (4,7)^G, (3,4,7)^G, (2,3)(4,7)^G, (2,3,4,7)^G, (1,2)(3,4,7)^G, (1,2,3,4,7)^G ]
+    (3,4,7)^G
+    (3,4,7)


### PR DESCRIPTION
This pip-installable package is now available:
- https://pypi.org/project/passagemath-gap/

Here we add:

- Examples that illustrate how to get started and the scope of the distribution
- Instructions how to develop separately
- Attribution and citations
- ...?

Help and suggestions welcome @fingolfin @hulpke
