### PR TITLE
build/pkgs/tox/install-requires.txt: >= 4.11

### DIFF
--- a/build/pkgs/tox/spkg-configure.m4
+++ b/build/pkgs/tox/spkg-configure.m4
@@ -2,7 +2,8 @@ SAGE_SPKG_CONFIGURE([tox], [
        dnl Early 4.0.x versions have bugs regarding complex factor conditions
        dnl [pkgenv] added in 4.2 - https://tox.wiki/en/latest/upgrading.html#packaging-configuration-and-inheritance
        dnl 4.2.7 for repaired numerical factors
-       m4_pushdef([TOX4_MIN_VERSION], [4.2.7])
+       dnl 4.11 needed for editable builds (https://tox.wiki/en/4.11.3/config.html#config_settings_build_editable)
+       m4_pushdef([TOX4_MIN_VERSION], [4.11])
        AC_CACHE_CHECK([for tox >= ]TOX4_MIN_VERSION, [ac_cv_path_TOX], [
          AC_PATH_PROGS_FEATURE_CHECK([TOX], [tox], [
             tox_version=$($ac_path_TOX --version 2> /dev/null | tail -n 1)

--- a/build/pkgs/tox/version_requirements.txt
+++ b/build/pkgs/tox/version_requirements.txt
@@ -1,2 +1,2 @@
 # see spkg-configure.m4
-tox >= 4.2.7
+tox >= 4.11


### PR DESCRIPTION
Needed for testing editable installations