### PR TITLE
sagemath-repl fixes

### DIFF
--- a/pkgs/sagemath-categories/known-test-failures.json
+++ b/pkgs/sagemath-categories/known-test-failures.json
@@ -1085,10 +1085,6 @@
     "sage.misc.banner": {
         "ntests": 12
     },
-    "sage.misc.benchmark": {
-        "failed": true,
-        "ntests": 18
-    },
     "sage.misc.binary_tree": {
         "ntests": 61
     },
@@ -1303,7 +1299,6 @@
         "ntests": 61
     },
     "sage.misc.sh": {
-        "failed": true,
         "ntests": 1
     },
     "sage.misc.stopgap": {

--- a/pkgs/sagemath-repl/known-test-failures.json
+++ b/pkgs/sagemath-repl/known-test-failures.json
@@ -1,14 +1,7 @@
 {
-    "sage.doctest.__main__": {
-        "ntests": 9
-    },
     "sage.doctest.check_tolerance": {
         "failed": true,
         "ntests": 19
-    },
-    "sage.doctest.control": {
-        "failed": true,
-        "ntests": 228
     },
     "sage.doctest.external": {
         "ntests": 40
@@ -18,7 +11,7 @@
     },
     "sage.doctest.forker": {
         "failed": true,
-        "ntests": 413
+        "ntests": 373
     },
     "sage.doctest.marked_output": {
         "failed": true,
@@ -26,7 +19,7 @@
     },
     "sage.doctest.parsing": {
         "failed": true,
-        "ntests": 273
+        "ntests": 266
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -39,7 +32,7 @@
         "ntests": 23
     },
     "sage.doctest.util": {
-        "ntests": 137
+        "ntests": 166
     },
     "sage.misc.sage_eval": {
         "failed": true,
@@ -81,7 +74,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 105
+        "ntests": 104
     },
     "sage.repl.ipython_extension": {
         "failed": true,

--- a/src/sage/all.py
+++ b/src/sage/all.py
@@ -73,8 +73,6 @@ import sage.misc.lazy_import
 
 from sage.misc.all       import *         # takes a while
 
-from sage.misc.sh import sh
-
 from sage.libs.all import *
 from sage.data_structures.all import *
 

--- a/src/sage/misc/all.py
+++ b/src/sage/misc/all.py
@@ -11,24 +11,6 @@ from sage.misc.misc import (BackslashOperator,
                             newton_method_sizes, compose,
                             nest)
 
-from sage.misc.dev_tools import import_statements
-
-from sage.misc.edit_module import edit
-
-from sage.misc.remote_file import get_remote_file
-
-lazy_import('sage.misc.pager', 'pager')
-
-lazy_import("sage.misc.cython", "cython_lambda")
-lazy_import("sage.misc.cython", "cython_compile", "cython")
-
-# Following will go to all__sagemath_repl.py in #36566
-from sage.misc.explain_pickle import (explain_pickle, unpickle_newobj, unpickle_build,
-                                      unpickle_instantiate, unpickle_persistent,
-                                      unpickle_extension, unpickle_appends)
-
-lazy_import('sage.misc.inline_fortran', 'fortran')
-
 lazy_import('sage.misc.banner', 'banner', deprecation=34259)
 lazy_import('sage.misc.dev_tools', 'runsnake', deprecation=34259)
 lazy_import('sage.misc.edit_module', 'set_edit_template', deprecation=34259)

--- a/src/sage/misc/all.py
+++ b/src/sage/misc/all.py
@@ -19,8 +19,6 @@ from sage.misc.remote_file import get_remote_file
 
 lazy_import('sage.misc.pager', 'pager')
 
-from sage.misc.classgraph import class_graph
-
 lazy_import("sage.misc.cython", "cython_lambda")
 lazy_import("sage.misc.cython", "cython_compile", "cython")
 

--- a/src/sage/misc/all__sagemath_repl.py
+++ b/src/sage/misc/all__sagemath_repl.py
@@ -37,6 +37,8 @@ lazy_import('sage.misc.edit_module', 'set_edit_template', deprecation=34259)
 
 lazy_import('sage.misc.pager', 'pager')
 
+lazy_import('sage.misc.remote_file', 'get_remote_file')
+
 lazy_import('sage.misc.sh', 'sh')
 
 lazy_import("sage.misc.cython", "cython_lambda")

--- a/src/sage/misc/all__sagemath_repl.py
+++ b/src/sage/misc/all__sagemath_repl.py
@@ -25,6 +25,8 @@ lazy_import('sage.misc.trace', 'trace', deprecation=34259)
 
 lazy_import('sage.misc.profiler', 'Profiler', deprecation=34259)
 
+lazy_import('sage.misc.classgraph', 'class_graph')
+
 from sage.misc.dev_tools import import_statements
 
 lazy_import('sage.misc.dev_tools', 'runsnake', deprecation=34259)

--- a/src/sage/misc/all__sagemath_repl.py
+++ b/src/sage/misc/all__sagemath_repl.py
@@ -35,6 +35,7 @@ lazy_import('sage.misc.edit_module', 'set_edit_template', deprecation=34259)
 
 lazy_import('sage.misc.pager', 'pager')
 
+lazy_import('sage.misc.sh', 'sh')
 
 lazy_import("sage.misc.cython", "cython_lambda")
 lazy_import("sage.misc.cython", "cython_compile", "cython")

--- a/src/sage/misc/benchmark.py
+++ b/src/sage/misc/benchmark.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-repl
+# sage.doctest: needs sage.all
 "Benchmarks"
 
 from sage.misc.misc import cputime

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -2230,7 +2230,7 @@ def sage_getsourcelines(obj):
         sage: # needs sage.modules
         sage: from sage.matrix.constructor import matrix
         sage: sage_getsourcelines(matrix)[1]
-        21
+        22
         sage: sage_getsourcelines(matrix)[0][0]
         'def matrix(*args, **kwds):\n'
 


### PR DESCRIPTION
- **src/sage/misc/all__sagemath_repl.py: Move import from sage.misc.sh here**
- **src/sage/misc/all__sagemath_repl.py: Move import from sage.misc.classgraph here**
- **src/sage/misc/benchmark.py: Add # needs**
- **src/sage/misc/sageinspect.py: Update self-referential doctest**
- **src/sage/misc/all__sagemath_repl.py: Move import from sage.misc.remote_file here; remove some duplicates in sage.misc.all**
- **./sage --fixdoctests --distribution 'sagemath-repl' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-categories' --update-known-test-failures**
