### PR TITLE
sage.graphs: Modularization fixes

### DIFF
--- a/pkgs/sagemath-graphs/known-test-failures--modules.json
+++ b/pkgs/sagemath-graphs/known-test-failures--modules.json
@@ -846,7 +846,6 @@
         "ntests": 11
     },
     "sage.combinat.designs.covering_array": {
-        "failed": true,
         "ntests": 31
     },
     "sage.combinat.designs.covering_design": {
@@ -859,7 +858,6 @@
         "ntests": 2
     },
     "sage.combinat.designs.designs_pyx": {
-        "failed": true,
         "ntests": 75
     },
     "sage.combinat.designs.difference_family": {
@@ -1234,6 +1232,10 @@
     "sage.databases.knotinfo_db": {
         "ntests": 100
     },
+    "sage.databases.sql_db": {
+        "failed": true,
+        "ntests": 292
+    },
     "sage.doctest.check_tolerance": {
         "failed": true,
         "ntests": 19
@@ -1569,7 +1571,7 @@
     },
     "sage.graphs.connectivity": {
         "failed": true,
-        "ntests": 580
+        "ntests": 571
     },
     "sage.graphs.convexity_properties": {
         "ntests": 67
@@ -1641,7 +1643,7 @@
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1209
+        "ntests": 1192
     },
     "sage.graphs.graph_coloring": {
         "ntests": 151
@@ -1749,12 +1751,11 @@
         "ntests": 103
     },
     "sage.graphs.spanning_tree": {
-        "failed": true,
-        "ntests": 169
+        "ntests": 165
     },
     "sage.graphs.strongly_regular_db": {
         "failed": true,
-        "ntests": 254
+        "ntests": 247
     },
     "sage.graphs.traversals": {
         "ntests": 222
@@ -3285,7 +3286,6 @@
         "ntests": 23
     },
     "sage.sets.recursively_enumerated_set": {
-        "failed": true,
         "ntests": 336
     },
     "sage.sets.set": {

--- a/pkgs/sagemath-graphs/known-test-failures.json
+++ b/pkgs/sagemath-graphs/known-test-failures.json
@@ -716,7 +716,6 @@
         "ntests": 11
     },
     "sage.combinat.designs.covering_array": {
-        "failed": true,
         "ntests": 31
     },
     "sage.combinat.designs.covering_design": {
@@ -729,7 +728,6 @@
         "ntests": 2
     },
     "sage.combinat.designs.designs_pyx": {
-        "failed": true,
         "ntests": 75
     },
     "sage.combinat.designs.difference_family": {
@@ -907,6 +905,10 @@
     },
     "sage.databases.knotinfo_db": {
         "ntests": 100
+    },
+    "sage.databases.sql_db": {
+        "failed": true,
+        "ntests": 292
     },
     "sage.doctest.check_tolerance": {
         "failed": true,
@@ -1225,7 +1227,7 @@
     },
     "sage.graphs.connectivity": {
         "failed": true,
-        "ntests": 580
+        "ntests": 570
     },
     "sage.graphs.convexity_properties": {
         "ntests": 67
@@ -1297,7 +1299,7 @@
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1129
+        "ntests": 1112
     },
     "sage.graphs.graph_coloring": {
         "ntests": 151
@@ -1405,12 +1407,11 @@
         "ntests": 103
     },
     "sage.graphs.spanning_tree": {
-        "failed": true,
-        "ntests": 169
+        "ntests": 165
     },
     "sage.graphs.strongly_regular_db": {
         "failed": true,
-        "ntests": 251
+        "ntests": 244
     },
     "sage.graphs.traversals": {
         "ntests": 222
@@ -2341,7 +2342,6 @@
         "ntests": 23
     },
     "sage.sets.recursively_enumerated_set": {
-        "failed": true,
         "ntests": 336
     },
     "sage.sets.set": {

--- a/src/sage/combinat/designs/covering_array.py
+++ b/src/sage/combinat/designs/covering_array.py
@@ -239,13 +239,13 @@ def covering_array(strength, number_columns, levels):
         sage: from sage.combinat.designs.designs_pyx import is_covering_array
         sage: from sage.combinat.designs.covering_array import covering_array
         sage: C1 = covering_array(2, 7, 3)
-        sage: is_covering_array(C1,parameters=True)
+        sage: is_covering_array(C1, parameters=True)
         (True, (12, 2, 7, 3))
         sage: C2 = covering_array(2, 11, 2)
-        sage: is_covering_array(C2,parameters=True)
+        sage: is_covering_array(C2, parameters=True)
         (True, (7, 2, 11, 2))
-        sage: C3 = covering_array(2, 8, 7)
-        sage: is_covering_array(C3,parameters=True)
+        sage: C3 = covering_array(2, 8, 7)                                              # needs sage.schemes
+        sage: is_covering_array(C3, parameters=True)                                    # needs sage.schemes
         (True, (49, 2, 8, 7))
         sage: C4 = covering_array(2, 50, 7)
         No direct construction known and/or implemented for a CA(N; 2, 50, 7)

--- a/src/sage/combinat/designs/designs_pyx.pyx
+++ b/src/sage/combinat/designs/designs_pyx.pyx
@@ -278,7 +278,7 @@ def is_orthogonal_array(OA, int k, int n, int t=2, verbose=False, terminology='O
         sage: for a in product(product((0,1), repeat=3), repeat=4):                     # needs sage.schemes
         ....:     if is_orthogonal_array(a,3,2):
         ....:          n += 1
-        sage: n
+        sage: n                                                                         # needs sage.schemes
         48
     """
     cdef int n2 = n*n

--- a/src/sage/graphs/connectivity.pyx
+++ b/src/sage/graphs/connectivity.pyx
@@ -1692,6 +1692,7 @@ def vertex_connectivity(G, value_only=True, sets=False, k=None, solver=None, ver
 
     Check that :issue:`38723` is fixed::
 
+        sage: # needs sage.modules
         sage: G = graphs.SierpinskiGasketGraph(3)
         sage: G.vertex_connectivity(k=1)                                                # needs sage.numerical.mip
         True
@@ -2871,6 +2872,7 @@ def spqr_tree_to_graph(T):
 
     Check that :issue:`38527` is fixed::
 
+        sage: # needs sage.numerical.mip
         sage: from sage.graphs.connectivity import spqr_tree, spqr_tree_to_graph
         sage: G = Graph('LlCG{O@?GBoMw?')
         sage: T1 = spqr_tree(G, algorithm="Hopcroft_Tarjan")

--- a/src/sage/graphs/domination.py
+++ b/src/sage/graphs/domination.py
@@ -361,7 +361,7 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
     Subgraph induced by the dominating set is connected::
 
         sage: G = graphs.PetersenGraph()
-        sage: all(G.subgraph(vertices=dom).is_connected()
+        sage: all(G.subgraph(vertices=dom).is_connected()                               # needs sage.numerical.mip
         ....:     for dom in G.dominating_set(k=1, connected=True))
         True
 
@@ -1325,7 +1325,7 @@ def maximum_leaf_number(G, solver=None, verbose=0, integrality_tolerance=1e-3):
     Petersen graph::
 
         sage: G = graphs.PetersenGraph()
-        sage: G.maximum_leaf_number()
+        sage: G.maximum_leaf_number()                                                   # needs sage.numerical.mip
         6
 
     TESTS:

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -10294,18 +10294,15 @@ class GenericGraph(GenericGraph_pyx):
             raise ValueError("this method does not support both "
                              "vertex_bound=True and algorithm='" + algorithm + "'")
         if use_edge_labels:
-            from sage.rings.real_mpfr import RR
             if integer:
                 from math import floor
 
                 def capacity(z):
-                    return floor(z) if z in RR else 1
+                    return floor(z) if z in Reals else 1
             else:
-                def capacity(z):
-                    return z if z in RR else 1
+                capacity = _weight_if_real
         else:
-            def capacity(z):
-                return 1
+            capacity = _weight_1
 
         if algorithm is None:
             if vertex_bound:

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -3971,11 +3971,11 @@ class Graph(GenericGraph):
 
         TESTS::
 
-            sage: Graph([]).chromatic_symmetric_function() == 1
+            sage: Graph([]).chromatic_symmetric_function() == 1                         # needs sage.combinat sage.modules
             True
 
-            sage: e = SymmetricFunctions(ZZ).e()
-            sage: e(graphs.CompleteGraph(5).chromatic_symmetric_function())
+            sage: e = SymmetricFunctions(ZZ).e()                                        # needs sage.combinat sage.modules
+            sage: e(graphs.CompleteGraph(5).chromatic_symmetric_function())             # needs sage.combinat sage.modules
             120*e[5]
         """
         from sage.combinat.sf.sf import SymmetricFunctions
@@ -4729,6 +4729,7 @@ class Graph(GenericGraph):
         Trying to find an induced minor isomorphic to `C_5` in a graph
         containing an induced `C_6`::
 
+            sage: # needs sage.numerical.mip
             sage: g = graphs.CycleGraph(6)
             sage: for i in range(randint(10, 30)):
             ....:     g.add_edge(randint(0, 5), g.add_vertex())
@@ -4744,6 +4745,7 @@ class Graph(GenericGraph):
         A graph `g` may have a minor isomorphic to a given graph `h` but no
         induced minor isomorphic to `h`::
 
+            sage: # needs sage.numerical.mip
             sage: g = Graph([(0, 1), (0, 2), (1, 2), (2, 3), (3, 4), (3, 5), (4, 5), (6, 5)])
             sage: h = Graph([(9, 10), (9, 11), (9, 12), (9, 13)])
             sage: l = g.minor(h, induced=False)
@@ -4755,6 +4757,7 @@ class Graph(GenericGraph):
         Checking that the returned induced minor is isomorphic to the given
         graph::
 
+            sage: # needs sage.numerical.mip
             sage: g = Graph([(0, 1), (0, 2), (1, 2), (2, 3), (3, 4), (3, 5), (4, 5), (6, 5)])
             sage: h = Graph([(7, 8), (8, 9), (9, 10), (10, 11)])
             sage: L = g.minor(h, induced=True)

--- a/src/sage/graphs/graph_decompositions/slice_decomposition.pyx
+++ b/src/sage/graphs/graph_decompositions/slice_decomposition.pyx
@@ -327,7 +327,7 @@ def slice_decomposition(G, initial_vertex=None):
         sage: from sage.graphs.graph_latex import check_tkz_graph
         sage: check_tkz_graph()  # random - depends on Tex installation
         sage: view(G)  # not tested
-        sage: latex(G)  # to obtain the corresponding LaTeX code
+        sage: latex(G)  # to obtain the corresponding LaTeX code                        # needs sage.plot
         \begin{tikzpicture}
         ...
         \end{tikzpicture}

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -554,7 +554,7 @@ def is_factor_critical(G, matching=None, algorithm='Edmonds', solver=None, verbo
         sage: G = graphs.RandomGNP(15, .2)
         sage: G.add_path([0..14])
         sage: G.add_edge(14, 0)
-        sage: G.is_hamiltonian()
+        sage: G.is_hamiltonian()                                                    # needs sage.numerical.mip
         True
         sage: G.is_factor_critical()                                                # needs networkx
         True

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -1220,13 +1220,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
         ...
         ValueError: algorithm must be set to either "Edmonds" or "LP"
     """
-    from sage.rings.real_mpfr import RR
-
-    def weight(x):
-        if x in RR:
-            return x
-        else:
-            return 1
+    from sage.graphs.generic_graph import _weight_if_real as weight
 
     W = {}
     L = {}

--- a/src/sage/graphs/spanning_tree.pyx
+++ b/src/sage/graphs/spanning_tree.pyx
@@ -1313,6 +1313,7 @@ def edge_disjoint_spanning_trees(G, k, by_weight=False, weight_function=None, ch
 
     Check that the method is robust to incomparable vertices::
 
+        sage: # needs sage.numerical.mip
         sage: G = Graph()
         sage: G.add_clique([0, 1, 2, 'a', 'b'])
         sage: F = G.edge_disjoint_spanning_trees(k=2)

--- a/src/sage/graphs/strongly_regular_db.pyx
+++ b/src/sage/graphs/strongly_regular_db.pyx
@@ -2806,7 +2806,7 @@ def strongly_regular_graph(int v, int k, int l, int mu=-1, bint existence=False,
 
         sage: graphs.strongly_regular_graph(10,3,0,1,existence=True)                    # needs sage.libs.pari
         True
-        sage: graphs.strongly_regular_graph(10,3,0,1)
+        sage: graphs.strongly_regular_graph(10,3,0,1)           # needs database_graphs
         complement(Johnson graph with parameters 5,2): Graph on 10 vertices
 
     Now without specifying `\mu`::
@@ -2919,6 +2919,7 @@ def strongly_regular_graph_lazy(int v, int k, int l, int mu=-1, bint existence=F
 
     TESTS::
 
+        sage: # needs database_graphs
         sage: from sage.graphs.strongly_regular_db import strongly_regular_graph_lazy
         sage: g,p=strongly_regular_graph_lazy(10,6,3); g,p
         (<cyfunction is_johnson.<locals>.<lambda> at ...>, 5)

--- a/src/sage/sets/recursively_enumerated_set.pyx
+++ b/src/sage/sets/recursively_enumerated_set.pyx
@@ -945,7 +945,7 @@ cdef class RecursivelyEnumeratedSet_generic(Parent):
 
             sage: f = lambda a: [a+1, a+I]
             sage: C = RecursivelyEnumeratedSet([0], f, structure='graded')
-            sage: C.to_digraph(max_depth=4)                                             # needs sage.graphs
+            sage: C.to_digraph(max_depth=4)                                             # needs sage.graphs sage.symbolic
             Looped multi-digraph on 21 vertices
         """
         successors = self.successors


### PR DESCRIPTION
- **src/sage/graphs/generic_graph.py (flow): Make numerical weights work without mpfr**
- **src/sage/graphs/graph.py: Add # needs**
- **src/sage/sets/recursively_enumerated_set.pyx: Add # needs**
- **src/sage/graphs/strongly_regular_db.pyx: Add # needs**
- **src/sage/graphs/spanning_tree.pyx: Add # needs**
- **src/sage/graphs/matching.py: Make numerical weights work without mpfr**
- **src/sage/graphs/matching.py: Add # needs**
- **src/sage/graphs/domination.py: Add # needs**
- **src/sage/graphs/connectivity.pyx: Add # needs**
- **src/sage/combinat/designs/covering_array.py: Add # needs**
- **src/sage/combinat/designs/designs_pyx.pyx: Add # needs**
- **src/sage/graphs/graph_decompositions/slice_decomposition.pyx: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-graphs' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-graphs[modules]' --update-known-test-failures**
