### PR TITLE
sage.modules modularization 2

### DIFF
--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -379,7 +379,6 @@
         "ntests": 31
     },
     "sage.categories.finite_monoids": {
-        "failed": true,
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
@@ -957,11 +956,9 @@
         "ntests": 135
     },
     "sage.combinat.root_system.type_super_A": {
-        "failed": true,
         "ntests": 127
     },
     "sage.combinat.root_system.weight_lattice_realizations": {
-        "failed": true,
         "ntests": 135
     },
     "sage.combinat.root_system.weight_space": {
@@ -1399,7 +1396,6 @@
         "ntests": 54
     },
     "sage.groups.generic": {
-        "failed": true,
         "ntests": 120
     },
     "sage.groups.group": {
@@ -1539,7 +1535,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2064
+        "ntests": 2058
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -1746,7 +1742,6 @@
         "ntests": 32
     },
     "sage.misc.functional": {
-        "failed": true,
         "ntests": 296
     },
     "sage.misc.gperftools": {
@@ -1948,7 +1943,6 @@
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "failed": true,
         "ntests": 169
     },
     "sage.modules.free_module": {
@@ -1993,7 +1987,6 @@
         "ntests": 57
     },
     "sage.modules.multi_filtered_vector_space": {
-        "failed": true,
         "ntests": 122
     },
     "sage.modules.quotient_module": {
@@ -2038,12 +2031,11 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "failed": true,
         "ntests": 151
     },
     "sage.modules.with_basis.indexed_element": {
         "failed": true,
-        "ntests": 179
+        "ntests": 166
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353

--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -23,8 +23,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "failed": true,
-        "ntests": 83
+        "ntests": 73
     },
     "sage.algebras.orlik_terao": {
         "failed": true,
@@ -771,7 +770,8 @@
         "ntests": 2
     },
     "sage.coding.linear_code": {
-        "ntests": 40
+        "failed": true,
+        "ntests": 0
     },
     "sage.coding.linear_code_no_metric": {
         "ntests": 2
@@ -1396,6 +1396,7 @@
         "ntests": 54
     },
     "sage.groups.generic": {
+        "failed": true,
         "ntests": 120
     },
     "sage.groups.group": {
@@ -1416,7 +1417,7 @@
     },
     "sage.groups.matrix_gps.matrix_group": {
         "failed": true,
-        "ntests": 64
+        "ntests": 55
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -2090,16 +2091,11 @@
         "failed": true,
         "ntests": 303
     },
-    "sage.quadratic_forms.bqf_class_group": {
-        "failed": true,
-        "ntests": 158
-    },
     "sage.quadratic_forms.constructions": {
         "ntests": 5
     },
     "sage.quadratic_forms.count_local_2": {
-        "failed": true,
-        "ntests": 23
+        "ntests": 16
     },
     "sage.quadratic_forms.extras": {
         "failed": true,
@@ -2998,8 +2994,7 @@
         "ntests": 170
     },
     "sage.tensor.modules.free_module_automorphism": {
-        "failed": true,
-        "ntests": 266
+        "ntests": 259
     },
     "sage.tensor.modules.free_module_basis": {
         "ntests": 187

--- a/src/sage/algebras/orlik_solomon.py
+++ b/src/sage/algebras/orlik_solomon.py
@@ -550,6 +550,7 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         EXAMPLES::
 
+            sage: # needs sage.geometry.polyhedron
             sage: OS = hyperplane_arrangements.braid(3).orlik_solomon_algebra(QQ)
             sage: gens = OS.algebra_generators()
             sage: AC = OS.aomoto_complex(gens[0])
@@ -562,7 +563,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
             {0: Vector space of dimension 0 over Rational Field,
              1: Vector space of dimension 0 over Rational Field,
              2: Vector space of dimension 0 over Rational Field}
-
             sage: AC = OS.aomoto_complex(-2*gens[0] + gens[1] + gens[2]); ascii_art(AC)
                                          [ 1]
                         [-1 -1 -1]       [ 1]
@@ -575,6 +575,7 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         TESTS::
 
+            sage: # needs sage.geometry.polyhedron
             sage: OS = hyperplane_arrangements.braid(4).orlik_solomon_algebra(QQ)
             sage: gens = OS.algebra_generators()
             sage: OS.aomoto_complex(gens[0] * gens[1] * gens[3])

--- a/src/sage/groups/matrix_gps/matrix_group.py
+++ b/src/sage/groups/matrix_gps/matrix_group.py
@@ -404,8 +404,7 @@ class MatrixGroup_base(Group):
             sage: V
             Natural representation of Special Linear Group of degree 6
              over Finite Field of size 3
-            sage: e = prod(G.gens())
-            sage: e
+            sage: e = prod(G.gens()); e                                                 # needs sage.libs.gap
             [2 0 0 0 0 1]
             [2 0 0 0 0 0]
             [0 2 0 0 0 0]
@@ -415,7 +414,7 @@ class MatrixGroup_base(Group):
             sage: v = V.an_element()
             sage: v
             2*e[0] + 2*e[1]
-            sage: e * v
+            sage: e * v                                                                 # needs sage.libs.gap
             e[0] + e[1] + e[2]
         """
         from sage.modules.with_basis.representation import NaturalMatrixRepresentation
@@ -593,6 +592,7 @@ class MatrixGroup_generic(MatrixGroup_base):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.gap
             sage: MatrixGroup([identity_matrix(3)]).is_trivial()
             True
             sage: SL(2, ZZ).is_trivial()
@@ -602,6 +602,7 @@ class MatrixGroup_generic(MatrixGroup_base):
 
         TESTS::
 
+            sage: # needs sage.libs.gap
             sage: CoxeterGroup(['A',0], implementation='matrix').is_trivial()
             True
             sage: MatrixGroup([matrix(SR, [[1,x], [0,1]])]).is_trivial()

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -771,7 +771,7 @@ cdef class Matrix(Matrix1):
 
             sage: A = matrix(ZZ, [[1, 2, 3], [2, 0, 2], [3, 2, 5]])
             sage: b = vector(RDF, [1, 1, 1])
-            sage: A.solve_right(b) == A.change_ring(RDF).solve_right(b)
+            sage: A.solve_right(b) == A.change_ring(RDF).solve_right(b)                 # needs scipy
             ...
             True
 
@@ -1730,7 +1730,7 @@ cdef class Matrix(Matrix1):
             sage: (Mx * M).norm()  # huge error                                         # needs scipy
             11.5...
             sage: Mx = M.pseudoinverse(algorithm='numpy')                               # needs numpy
-            sage: (Mx * M).norm()  # still OK
+            sage: (Mx * M).norm()  # still OK                                           # needs scipy
             1.00...
 
         When multiplying the given matrix with the pseudoinverse, the
@@ -7293,6 +7293,7 @@ cdef class Matrix(Matrix1):
         Running this test independently, without adjusting the eigenvectors
         could indicate this situation on your hardware.  ::
 
+            sage: # needs scipy
             sage: A = matrix(QQ, 3, 3, range(9))
             sage: em = A.change_ring(RDF).eigenmatrix_left()
             sage: evalues = em[0]; evalues.dense_matrix()  # abs tol 1e-13

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -3911,7 +3911,11 @@ cdef class Matrix(Matrix1):
         """
         from sage.matrix.matrix_space import MatrixSpace
         tm = verbose("computing right kernel matrix over a number field for %sx%s matrix" % (self.nrows(), self.ncols()), level=2)
-        basis = self.__pari__().matker()
+        try:
+            self_pari = self.__pari__()
+        except ImportError:
+            return None, None
+        basis = self_pari.matker()
         # Coerce PARI representations into the number field
         R = self.base_ring()
         basis = [[R(x) for x in row] for row in basis]

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -367,6 +367,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         We can get the ascii art when there is no ``one_basis`` method
         (and the basis keys do not compare with ``None``)::
 
+            sage: # needs sage.groups
             sage: DC3 = groups.permutation.DiCyclic(3)
             sage: L = DC3.regular_representation(QQ, side='left')
             sage: E2 = L.exterior_power(2)
@@ -462,6 +463,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         We can get the unicode art when there is no ``one_basis`` method
         (and the basis keys do not compare with ``None``)::
 
+            sage: # needs sage.groups
             sage: DC3 = groups.permutation.DiCyclic(3)
             sage: L = DC3.regular_representation(QQ, side='left')
             sage: E2 = L.exterior_power(2)
@@ -1002,6 +1004,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
             ...
             TypeError: unsupported operand type(s) for /: 'str' and 'CombinatorialFreeModule_with_category.element_class'
 
+            sage: # needs sage.combinat
             sage: L = LazyPowerSeriesRing(QQ, 't')
             sage: t = L.gen()
             sage: F = algebras.Free(L, ['A', 'B'])

--- a/src/sage/modules/with_basis/invariant.py
+++ b/src/sage/modules/with_basis/invariant.py
@@ -23,7 +23,6 @@ from sage.categories.finitely_generated_semigroups import FinitelyGeneratedSemig
 from sage.categories.finite_dimensional_modules_with_basis import FiniteDimensionalModulesWithBasis
 from sage.sets.family import Family
 from sage.matrix.constructor import Matrix
-from sage.libs.gap.libgap import libgap
 
 
 class FiniteDimensionalInvariantModule(SubmoduleWithBasis):
@@ -809,6 +808,7 @@ class FiniteDimensionalTwistedInvariantModule(SubmoduleWithBasis):
             ValueError: chi must be a list/tuple or a class function of the group G
         """
         from sage.groups.class_function import ClassFunction, ClassFunction_libgap
+        from sage.libs.gap.libgap import libgap
 
         if isinstance(chi, (list, tuple)):
             chi = ClassFunction(G, libgap(chi))

--- a/src/sage/quadratic_forms/binary_qf.py
+++ b/src/sage/quadratic_forms/binary_qf.py
@@ -212,7 +212,7 @@ class BinaryQF(SageObject):
             sage: Q = BinaryQF.principal(D)
             sage: Q.discriminant() == D     # correct discriminant
             True
-            sage: (Q*Q).is_equivalent(Q)    # idempotent (hence identity)
+            sage: (Q*Q).is_equivalent(Q)    # idempotent (hence identity)  # needs sage.libs.pari
             True
         """
         D = ZZ(D)

--- a/src/sage/quadratic_forms/bqf_class_group.py
+++ b/src/sage/quadratic_forms/bqf_class_group.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-modules
+# sage.doctest: needs sage.libs.pari
 r"""
 Class groups of binary quadratic forms
 

--- a/src/sage/quadratic_forms/count_local_2.pyx
+++ b/src/sage/quadratic_forms/count_local_2.pyx
@@ -305,6 +305,7 @@ def count_all_local_good_types_normal_form(Q, p, k, m, zvec, nzvec):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.pari
         sage: from sage.quadratic_forms.count_local_2 import count_all_local_good_types_normal_form
         sage: Q = DiagonalQuadraticForm(ZZ, [1,2,3])
         sage: Q_local_at2 = Q.local_normal_form(2)

--- a/src/sage/tensor/modules/free_module_automorphism.py
+++ b/src/sage/tensor/modules/free_module_automorphism.py
@@ -1075,6 +1075,7 @@ class FreeModuleAutomorphism(FreeModuleTensor, MultiplicativeGroupElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: M = FiniteRankFreeModule(QQ, 2, name='M')
             sage: e = M.basis('e')
             sage: a = M.automorphism([[1,1],[0,2]], name='a')


### PR DESCRIPTION
- **sage.matrix, sage.modules: Add # needs**
- **src/sage/matrix/matrix2.pyx: Fall back to more generic computation when pari is not available**
- **./sage --fixdoctests --distribution 'sagemath-modules' --update-known-test-failures**
- **src/sage/algebras/orlik_solomon.py: Add # needs**
- **src/sage/modules/with_basis/invariant.py: Move import into method**
- **src/sage/groups/matrix_gps: Add # needs**
- **src/sage/quadratic_forms: Add # needs**
- **src/sage/tensor/modules: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-modules' --update-known-test-failures**
