### PR TITLE
Define feature `cddexec_gmp`, override SPKG feature `giac` by runtime feature

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -496,7 +496,7 @@ class DocTestController(SageObject):
                         if pkg.name in options.hide:
                             continue
                         # Skip features for which we have a more specific runtime feature test.
-                        if pkg.name in ['bliss', 'coxeter3', 'mcqd', 'meataxe', 'sirocco', 'tdlib']:
+                        if pkg.name in ['bliss', 'coxeter3', 'giac', 'mcqd', 'meataxe', 'sirocco', 'tdlib']:
                             continue
                         if pkg.is_installed() and pkg.installed_version == pkg.remote_version:
                             options.optional.add(pkg.name)

--- a/src/sage/features/cddlib.py
+++ b/src/sage/features/cddlib.py
@@ -36,3 +36,7 @@ class CddExecutable(Executable):
         """
         Executable.__init__(self, name=name, executable=name, spkg='cddlib',
                             url='https://github.com/cddlib/cddlib', type='standard')
+
+
+def all_features():
+    return [CddExecutable()]


### PR DESCRIPTION
- **src/sage/doctest/control.py: Add giac to list of features not to read from SPKG install record**
- **src/sage/features/cddlib.py: Add cddexec_gmp to all_features**
