### PR TITLE
sagemath-modules: Add sage.combinat.integer_vector_weighted, sage.algebras.{commutative_dga,finite_gca}

### DIFF
--- a/pkgs/sagemath-categories/MANIFEST.in
+++ b/pkgs/sagemath-categories/MANIFEST.in
@@ -212,6 +212,7 @@ include sage/rings/big_oh.p*
 include sage/ext/fast_*.p*
 
 include sage/combinat/integer_vector.p*
+include sage/combinat/integer_vector_weighted.p*
 graft sage/combinat/integer_lists
 include sage/combinat/backtrack.p*
 include sage/combinat/combinat.p*

--- a/pkgs/sagemath-combinat/MANIFEST.in
+++ b/pkgs/sagemath-combinat/MANIFEST.in
@@ -24,6 +24,7 @@ graft sage/libs/symmetrica
 # included in sagemath-categories
 prune sage/combinat/integer_lists
 exclude sage/combinat/integer_vector.p*
+exclude sage/combinat/integer_vector_weighted.p*
 exclude sage/combinat/backtrack.p*
 exclude sage/combinat/combinat.p*
 exclude sage/combinat/combinat_cython.p*

--- a/pkgs/sagemath-combinat/MANIFEST.in
+++ b/pkgs/sagemath-combinat/MANIFEST.in
@@ -71,6 +71,7 @@ prune sage/algebras/finite_dimensional_algebras
 exclude sage/algebras/group_algebra.py
 exclude sage/algebras/orlik_solomon.p*
 exclude sage/algebras/orlik_terao.p*
+exclude sage/algebras/commutative_dga.p*
 exclude sage/algebras/finite_gca.p*
 exclude sage/algebras/clifford_algebra*.p*
 exclude sage/algebras/exterior_algebra*.p*

--- a/pkgs/sagemath-combinat/MANIFEST.in
+++ b/pkgs/sagemath-combinat/MANIFEST.in
@@ -71,7 +71,7 @@ prune sage/algebras/finite_dimensional_algebras
 exclude sage/algebras/group_algebra.py
 exclude sage/algebras/orlik_solomon.p*
 exclude sage/algebras/orlik_terao.p*
-
+exclude sage/algebras/finite_gca.p*
 exclude sage/algebras/clifford_algebra*.p*
 exclude sage/algebras/exterior_algebra*.p*
 exclude sage/algebras/octonion_algebra.p*

--- a/pkgs/sagemath-modules/MANIFEST.in
+++ b/pkgs/sagemath-modules/MANIFEST.in
@@ -143,6 +143,7 @@ include sage/algebras/algebra.py
 include sage/algebras/catalog.py
 graft sage/algebras/finite_dimensional_algebras  # for hyperplane arrangements
 include sage/algebras/group_algebra.py
+include sage/algebras/commutative_dga.p*
 include sage/algebras/finite_gca.p*
 
 graft sage/matrix

--- a/pkgs/sagemath-modules/MANIFEST.in
+++ b/pkgs/sagemath-modules/MANIFEST.in
@@ -143,6 +143,7 @@ include sage/algebras/algebra.py
 include sage/algebras/catalog.py
 graft sage/algebras/finite_dimensional_algebras  # for hyperplane arrangements
 include sage/algebras/group_algebra.py
+include sage/algebras/finite_gca.p*
 
 graft sage/matrix
 exclude sage/matrix/misc.p*             # Matrix_integer_sparse

--- a/src/sage/algebras/all__sagemath_combinat.py
+++ b/src/sage/algebras/all__sagemath_combinat.py
@@ -22,8 +22,6 @@ lazy_import('sage.algebras.jordan_algebra', 'JordanAlgebra')
 
 lazy_import('sage.algebras.shuffle_algebra', 'ShuffleAlgebra')
 
-lazy_import('sage.algebras.commutative_dga', 'GradedCommutativeAlgebra')
-
 lazy_import('sage.algebras.rational_cherednik_algebra',
             'RationalCherednikAlgebra')
 

--- a/src/sage/algebras/all__sagemath_modules.py
+++ b/src/sage/algebras/all__sagemath_modules.py
@@ -3,6 +3,8 @@ from sage.misc.lazy_import import lazy_import
 
 lazy_import('sage.algebras.group_algebra', 'GroupAlgebra')
 
+lazy_import('sage.algebras.commutative_dga', 'GradedCommutativeAlgebra')
+
 # old-style class for associative algebras, use Parent instead
 from sage.rings.ring import Algebra
 

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -80,6 +80,7 @@ from sage.structure.sage_object import SageObject
 from sage.misc.cachefunc import cached_method
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
 from sage.misc.functional import is_odd, is_even
+from sage.misc.lazy_import import lazy_import
 from sage.misc.misc_c import prod
 from sage.categories.chain_complexes import ChainComplexes
 from sage.categories.algebras import Algebras
@@ -87,7 +88,6 @@ from sage.categories.morphism import Morphism
 from sage.categories.modules import Modules
 from sage.categories.homset import Hom
 
-from sage.algebras.free_algebra import FreeAlgebra
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.combinat.integer_vector_weighted import WeightedIntegerVectors
@@ -104,6 +104,8 @@ from sage.rings.quotient_ring_element import QuotientRingElement
 from sage.misc.cachefunc import cached_function
 
 import sage.interfaces.abc
+
+lazy_import('sage.algebras.free_algebra', 'FreeAlgebra')
 
 
 def sorting_keys(element):

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-combinat
+# sage_setup: distribution = sagemath-modules
 # sage.doctest: needs sage.combinat sage.modules
 r"""
 Commutative Differential Graded Algebras

--- a/src/sage/algebras/finite_gca.py
+++ b/src/sage/algebras/finite_gca.py
@@ -110,7 +110,7 @@ class FiniteGCAlgebra(CombinatorialFreeModule):
 
     We can also return the basis::
 
-        sage: list(A.basis())
+        sage: list(A.basis())                                                           # needs sage.combinat
         [1, x, z, y, t, x*z, x*y, x*t, z^2, y*z, y^2, z*t, y*t, x*z^2, x*y*z, x*y^2]
 
     Depending on the context, the multiplication can be given a different
@@ -186,6 +186,7 @@ class FiniteGCAlgebra(CombinatorialFreeModule):
 
         TESTS::
 
+            sage: # needs sage.combinat
             sage: A.<x,y,z,t> = GradedCommutativeAlgebra(QQ, max_degree=6)
             sage: TestSuite(A).run()
             sage: A = GradedCommutativeAlgebra(QQ, ('x','y','z'), [2,3,4], max_degree=8)

--- a/src/sage/algebras/finite_gca.py
+++ b/src/sage/algebras/finite_gca.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-combinat
+# sage_setup: distribution = sagemath-modules
 # sage.doctest: needs sage.modules
 r"""
 Finite dimensional graded commutative algebras

--- a/src/sage/combinat/all__sagemath_categories.py
+++ b/src/sage/combinat/all__sagemath_categories.py
@@ -6,6 +6,7 @@ from sage.misc.lazy_import import lazy_import
 # Integer lists
 from sage.combinat.integer_lists import IntegerListsLex
 from sage.combinat.integer_vector import IntegerVectors
+lazy_import('sage.combinat.integer_vector_weighted', 'WeightedIntegerVectors')
 
 from sage.combinat.combinat import (CombinatorialObject,
                                     bell_number, bell_polynomial, bernoulli_polynomial,

--- a/src/sage/combinat/all__sagemath_combinat.py
+++ b/src/sage/combinat/all__sagemath_combinat.py
@@ -145,7 +145,6 @@ from sage.combinat.ncsym.all import *
 lazy_import('sage.combinat.fqsym', 'FreeQuasisymmetricFunctions')
 from sage.combinat.matrices.all import *
 
-lazy_import('sage.combinat.integer_vector_weighted', 'WeightedIntegerVectors')
 lazy_import('sage.combinat.integer_vectors_mod_permgroup',
             'IntegerVectorsModPermutationGroup')
 

--- a/src/sage/combinat/integer_vector_weighted.py
+++ b/src/sage/combinat/integer_vector_weighted.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-combinat
+# sage_setup: distribution = sagemath-categories
 """
 Weighted Integer Vectors
 

--- a/src/sage/combinat/integer_vector_weighted.py
+++ b/src/sage/combinat/integer_vector_weighted.py
@@ -48,6 +48,8 @@ class WeightedIntegerVectors(Parent, UniqueRepresentation):
 
         sage: WeightedIntegerVectors(8, [1,1,2])
         Integer vectors of 8 weighted by [1, 1, 2]
+
+        sage: # needs sage.combinat
         sage: WeightedIntegerVectors(8, [1,1,2]).first()
         [0, 0, 4]
         sage: WeightedIntegerVectors(8, [1,1,2]).last()
@@ -60,6 +62,8 @@ class WeightedIntegerVectors(Parent, UniqueRepresentation):
 
         sage: WeightedIntegerVectors([1,1,2])
         Integer vectors weighted by [1, 1, 2]
+
+        sage: # needs sage.combinat
         sage: WeightedIntegerVectors([1,1,2]).cardinality()
         +Infinity
         sage: WeightedIntegerVectors([1,1,2]).first()
@@ -258,6 +262,7 @@ class WeightedIntegerVectors_all(DisjointUnionEnumeratedSets):
         sage: W.cardinality()
         +Infinity
 
+        sage: # needs sage.combinat
         sage: W12 = W.graded_component(12)
         sage: W12.an_element()
         [4, 0, 0, 0, 0]
@@ -281,7 +286,7 @@ class WeightedIntegerVectors_all(DisjointUnionEnumeratedSets):
             sage: C = WeightedIntegerVectors([2,1,3])
             sage: C.category()
             Category of facade infinite enumerated sets with grading
-            sage: TestSuite(C).run()
+            sage: TestSuite(C).run()                                                    # needs sage.combinat
         """
         self._weights = weight
         from sage.sets.family import Family


### PR DESCRIPTION
- **pkgs/sagemath-categories: Move sage.combinat.integer_vector_weighted here from -combinat**
- **pkgs/sagemath-modules: Move sage.algebras.finite_gca here from -combinat**
- **src/sage/combinat/all__sagemath_categories.py: lazy_import WeightedIntegerVectors here**
- **src/sage/combinat/integer_vector_weighted.py: Add # needs**
- **pkgs/sagemath-modules: Move sage.algebras.commutative_dga here from -combinat**
- **src/sage/algebras/commutative_dga.py: Use lazy_import for FreeAlgebra**
- **src/sage/algebras/finite_gca.py: Add # needs**
