### PR TITLE
sagemath categories doctest fixes

### DIFF
--- a/pkgs/sagemath-categories/known-test-failures.json
+++ b/pkgs/sagemath-categories/known-test-failures.json
@@ -773,8 +773,7 @@
         "ntests": 230
     },
     "sage.doctest.check_tolerance": {
-        "failed": true,
-        "ntests": 19
+        "ntests": 9
     },
     "sage.doctest.control": {
         "ntests": 3
@@ -786,16 +785,14 @@
         "ntests": 59
     },
     "sage.doctest.forker": {
-        "failed": true,
-        "ntests": 374
+        "ntests": 254
     },
     "sage.doctest.marked_output": {
         "failed": true,
         "ntests": 21
     },
     "sage.doctest.parsing": {
-        "failed": true,
-        "ntests": 270
+        "ntests": 233
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -813,7 +810,6 @@
         "ntests": 166
     },
     "sage.env": {
-        "failed": true,
         "ntests": 40
     },
     "sage.ext.fast_callable": {
@@ -1175,10 +1171,9 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 211
+        "ntests": 212
     },
     "sage.misc.latex_macros": {
-        "failed": true,
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
@@ -1749,8 +1744,7 @@
         "ntests": 241
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
-        "ntests": 471
+        "ntests": 463
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 72

--- a/pkgs/sagemath-repl/known-test-failures.json
+++ b/pkgs/sagemath-repl/known-test-failures.json
@@ -1,17 +1,16 @@
 {
     "sage.doctest.check_tolerance": {
-        "failed": true,
-        "ntests": 19
+        "ntests": 9
     },
     "sage.doctest.external": {
-        "ntests": 40
+        "ntests": 41
     },
     "sage.doctest.fixtures": {
         "ntests": 58
     },
     "sage.doctest.forker": {
         "failed": true,
-        "ntests": 373
+        "ntests": 253
     },
     "sage.doctest.marked_output": {
         "failed": true,
@@ -19,7 +18,7 @@
     },
     "sage.doctest.parsing": {
         "failed": true,
-        "ntests": 266
+        "ntests": 229
     },
     "sage.doctest.reporting": {
         "ntests": 126

--- a/src/sage/combinat/integer_vector_weighted.py
+++ b/src/sage/combinat/integer_vector_weighted.py
@@ -113,7 +113,7 @@ class WeightedIntegerVectors(Parent, UniqueRepresentation):
         TESTS::
 
             sage: WIV = WeightedIntegerVectors(8, [1,1,2])
-            sage: TestSuite(WIV).run()
+            sage: TestSuite(WIV).run()                                                  # needs sage.combinat
         """
         self._n = n
         self._weights = weight

--- a/src/sage/doctest/check_tolerance.py
+++ b/src/sage/doctest/check_tolerance.py
@@ -56,6 +56,7 @@ def check_tolerance_real_domain(want: MarkedOutput, got: str) -> tuple[str, str]
 
     EXAMPLES::
 
+        sage: # needs sage.rings.real_interval_field
         sage: from sage.doctest.check_tolerance import check_tolerance_real_domain
         sage: from sage.doctest.marked_output import MarkedOutput
         sage: check_tolerance_real_domain(
@@ -215,6 +216,7 @@ def check_tolerance_complex_domain(want: MarkedOutput, got: str) -> tuple[str, s
 
     EXAMPLES::
 
+        sage: # needs sage.rings.real_interval_field
         sage: from sage.doctest.check_tolerance import check_tolerance_complex_domain
         sage: from sage.doctest.marked_output import MarkedOutput
         sage: check_tolerance_complex_domain(

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -122,6 +122,7 @@ def init_sage(controller=None):
 
     EXAMPLES::
 
+        sage: # needs sage.all
         sage: from sage.doctest.forker import init_sage
         sage: sage.doctest.DOCTEST_MODE = False
         sage: init_sage()
@@ -130,6 +131,7 @@ def init_sage(controller=None):
 
     Check that pexpect interfaces are invalidated, but still work::
 
+        sage: # needs sage.all
         sage: gap.eval("my_test_var := 42;")
         '42'
         sage: gap.eval("my_test_var;")
@@ -1719,6 +1721,7 @@ class DocTestDispatcher(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.all
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
             sage: from sage.doctest.forker import DocTestDispatcher
             sage: DocTestDispatcher(DocTestController(DocTestDefaults(), []))
@@ -1736,6 +1739,7 @@ class DocTestDispatcher(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.all
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
             sage: from sage.doctest.forker import DocTestDispatcher
             sage: from sage.doctest.reporting import DocTestReporter
@@ -1782,6 +1786,7 @@ class DocTestDispatcher(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.all
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
             sage: from sage.doctest.forker import DocTestDispatcher
             sage: from sage.doctest.reporting import DocTestReporter
@@ -1806,6 +1811,7 @@ class DocTestDispatcher(SageObject):
         module will be immediately printed and any other ongoing tests
         canceled::
 
+            sage: # needs sage.all
             sage: from tempfile import NamedTemporaryFile as NTF
             sage: with NTF(suffix='.py', mode='w+t') as f1, \
             ....:      NTF(suffix='.py', mode='w+t') as f2:
@@ -2168,6 +2174,7 @@ class DocTestWorker(multiprocessing.Process):
 
     EXAMPLES::
 
+        sage: # needs sage.all
         sage: from sage.doctest.forker import DocTestWorker, DocTestTask
         sage: from sage.doctest.sources import FileDocTestSource
         sage: from sage.doctest.reporting import DocTestReporter
@@ -2190,6 +2197,7 @@ class DocTestWorker(multiprocessing.Process):
 
         TESTS::
 
+            sage: # needs sage.all
             sage: run_doctests(sage.rings.big_oh) # indirect doctest
             Running doctests with ID ...
             Doctesting 1 file.
@@ -2331,6 +2339,7 @@ class DocTestWorker(multiprocessing.Process):
 
         EXAMPLES::
 
+            sage: # needs sage.all
             sage: from sage.doctest.forker import DocTestWorker, DocTestTask
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.reporting import DocTestReporter
@@ -2365,6 +2374,7 @@ class DocTestWorker(multiprocessing.Process):
 
         EXAMPLES::
 
+            sage: # needs sage.all
             sage: from sage.doctest.forker import DocTestWorker, DocTestTask
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.reporting import DocTestReporter
@@ -2436,6 +2446,7 @@ class DocTestWorker(multiprocessing.Process):
         We set up the worker to start by blocking ``SIGQUIT``, such that
         killing will fail initially::
 
+            sage: # needs sage.all
             sage: from cysignals.pselect import PSelecter
             sage: import signal
             sage: def block_hup():
@@ -2495,6 +2506,7 @@ class DocTestTask:
 
     EXAMPLES::
 
+        sage: # needs sage.all
         sage: from sage.doctest.forker import DocTestTask
         sage: from sage.doctest.sources import FileDocTestSource
         sage: from sage.doctest.control import DocTestDefaults, DocTestController
@@ -2559,6 +2571,7 @@ class DocTestTask:
 
         EXAMPLES::
 
+            sage: # needs sage.all
             sage: from sage.doctest.forker import DocTestTask
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults, DocTestController

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -991,6 +991,7 @@ class SageDocTestParser(doctest.DocTestParser):
 
         TESTS::
 
+            sage: # needs sage.combinat
             sage: parse("::\n\n    sage: # needs sage.combinat\n    sage: from sage.geometry.polyhedron.combinatorial_polyhedron.conversions \\\n    ....:         import incidence_matrix_to_bit_rep_of_Vrep\n    sage: P = polytopes.associahedron(['A',3])\n\n")
             ['::\n\n',
             '',
@@ -1287,6 +1288,7 @@ class SageOutputChecker(doctest.OutputChecker):
             sage: OC.check_output(rndstr,nf,optflag)
             True
 
+            sage: # needs sage.rings.real_interval_field
             sage: OC.check_output(tentol,nf,optflag)
             True
             sage: OC.check_output(tentol,ten,optflag)
@@ -1294,6 +1296,7 @@ class SageOutputChecker(doctest.OutputChecker):
             sage: OC.check_output(tentol,zero,optflag)
             False
 
+            sage: # needs sage.rings.real_interval_field
             sage: OC.check_output(tenabs,nf,optflag)
             False
             sage: OC.check_output(tenabs,ten,optflag)
@@ -1301,6 +1304,7 @@ class SageOutputChecker(doctest.OutputChecker):
             sage: OC.check_output(tenabs,zero,optflag)
             False
 
+            sage: # needs sage.rings.real_interval_field
             sage: OC.check_output(tenrel,nf,optflag)
             True
             sage: OC.check_output(tenrel,ten,optflag)
@@ -1308,6 +1312,7 @@ class SageOutputChecker(doctest.OutputChecker):
             sage: OC.check_output(tenrel,zero,optflag)
             False
 
+            sage: # needs sage.rings.real_interval_field
             sage: OC.check_output(zerotol,zero,optflag)
             True
             sage: OC.check_output(zerotol,eps,optflag)
@@ -1315,6 +1320,7 @@ class SageOutputChecker(doctest.OutputChecker):
             sage: OC.check_output(zerotol,ten,optflag)
             False
 
+            sage: # needs sage.rings.real_interval_field
             sage: OC.check_output(zeroabs,zero,optflag)
             True
             sage: OC.check_output(zeroabs,eps,optflag)
@@ -1322,6 +1328,7 @@ class SageOutputChecker(doctest.OutputChecker):
             sage: OC.check_output(zeroabs,ten,optflag)
             False
 
+            sage: # needs sage.rings.real_interval_field
             sage: OC.check_output(zerorel,zero,optflag)
             True
             sage: OC.check_output(zerorel,eps,optflag)
@@ -1331,6 +1338,7 @@ class SageOutputChecker(doctest.OutputChecker):
 
         More explicit tolerance checks::
 
+            sage: # needs sage.rings.real_interval_field
             sage: _ = x  # rel tol 1e10                                                 # needs sage.symbolic
             sage: raise RuntimeError   # rel tol 1e10
             Traceback (most recent call last):
@@ -1347,11 +1355,13 @@ class SageOutputChecker(doctest.OutputChecker):
 
         Abs tol checks over the complex domain::
 
+            sage: # needs sage.rings.real_interval_field sage.symbolic
             sage: [1, -1.3, -1.5 + 0.1*I, 0.5 - 0.1*I, -1.5*I]  # abs tol 1.0
             [1, -1, -1, 1, -I]
 
         Spaces before numbers or between the sign and number are ignored::
 
+            sage: # needs sage.rings.real_interval_field
             sage: print("[ - 1, 2]")  # abs tol 1e-10
             [-1,2]
 
@@ -1562,6 +1572,7 @@ class SageOutputChecker(doctest.OutputChecker):
 
         ::
 
+            sage: # needs sage.rings.real_interval_field
             sage: print(OC.output_difference(tenabs,nf,optflag))
             Expected:
                 10.0
@@ -1569,7 +1580,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 9.5
             Tolerance exceeded:
                 10.0 vs 9.5, tolerance 5e-1 > 1e-1
-
             sage: print(OC.output_difference(tentol,zero,optflag))
             Expected:
                 10.0
@@ -1577,7 +1587,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 0.0
             Tolerance exceeded:
                 10.0 vs 0.0, tolerance 1e0 > 1e-1
-
             sage: print(OC.output_difference(tentol,eps,optflag))
             Expected:
                 10.0
@@ -1585,7 +1594,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 -0.05
             Tolerance exceeded:
                 10.0 vs -0.05, tolerance 2e0 > 1e-1
-
             sage: print(OC.output_difference(tlist,L,optflag))
             Expected:
                 [10.0, 10.0, 10.0, 10.0, 10.0, 10.0]
@@ -1597,6 +1605,7 @@ class SageOutputChecker(doctest.OutputChecker):
 
         TESTS::
 
+            sage: # needs sage.rings.real_interval_field
             sage: print(OC.output_difference(tenabs,zero,optflag))
             Expected:
                 10.0
@@ -1604,7 +1613,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 0.0
             Tolerance exceeded:
                 10.0 vs 0.0, tolerance 1e1 > 1e-1
-
             sage: print(OC.output_difference(tenrel,zero,optflag))
             Expected:
                 10.0
@@ -1612,7 +1620,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 0.0
             Tolerance exceeded:
                 10.0 vs 0.0, tolerance 1e0 > 1e-1
-
             sage: print(OC.output_difference(tenrel,eps,optflag))
             Expected:
                 10.0
@@ -1620,7 +1627,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 -0.05
             Tolerance exceeded:
                 10.0 vs -0.05, tolerance 2e0 > 1e-1
-
             sage: print(OC.output_difference(zerotol,ten,optflag))
             Expected:
                 0.0
@@ -1628,7 +1634,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 10.05
             Tolerance exceeded:
                 0.0 vs 10.05, tolerance 2e1 > 1e-1
-
             sage: print(OC.output_difference(zeroabs,ten,optflag))
             Expected:
                 0.0
@@ -1636,7 +1641,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 10.05
             Tolerance exceeded:
                 0.0 vs 10.05, tolerance 2e1 > 1e-1
-
             sage: print(OC.output_difference(zerorel,eps,optflag))
             Expected:
                 0.0
@@ -1644,7 +1648,6 @@ class SageOutputChecker(doctest.OutputChecker):
                 -0.05
             Tolerance exceeded:
                 0.0 vs -0.05, tolerance +infinity > 1e-1
-
             sage: print(OC.output_difference(zerorel,ten,optflag))
             Expected:
                 0.0

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -308,7 +308,7 @@ def sage_include_directories(use_sources=False):
     Expected output while using Sage::
 
         sage: import sage.env
-        sage: sage.env.sage_include_directories()
+        sage: sage.env.sage_include_directories()                                       # needs numpy
         ['...',
          '.../numpy/...core/include',
          '.../include/python...']

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -564,6 +564,11 @@ def latex_extra_preamble():
         <BLANKLINE>
         \newcommand{\ZZ}{\Bold{Z}}
         \newcommand{\NN}{\Bold{N}}
+        ...
+        sage: print(latex_extra_preamble())                                             # needs sage.all
+        <BLANKLINE>
+        \newcommand{\ZZ}{\Bold{Z}}
+        \newcommand{\NN}{\Bold{N}}
         \newcommand{\RR}{\Bold{R}}
         \newcommand{\CC}{\Bold{C}}
         \newcommand{\QQ}{\Bold{Q}}

--- a/src/sage/misc/latex_macros.py
+++ b/src/sage/misc/latex_macros.py
@@ -230,6 +230,6 @@ def sage_mathjax_macros():
 
         sage: from sage.misc.latex_macros import sage_mathjax_macros
         sage: sage_mathjax_macros()
-        {'Bold': ['\\mathbf{#1}', 1], 'CC': '\\Bold{C}', ...
+        {'Bold': ['\\mathbf{#1}', 1], ... 'QQ': '\\Bold{Q}', ...
     """
     return dict(convert_latex_macro_to_mathjax(m) for m in sage_latex_macros())

--- a/src/sage/rings/power_series_ring_element.pyx
+++ b/src/sage/rings/power_series_ring_element.pyx
@@ -1541,7 +1541,9 @@ cdef class PowerSeries(AlgebraElement):
             1 + 1/2*t - 1/8*t^2 + 1/16*t^3 - 5/128*t^4 + O(t^5)
             sage: sqrt(4 + t)
             2 + 1/4*t - 1/64*t^2 + 1/512*t^3 - 5/16384*t^4 + O(t^5)
-            sage: u = sqrt(2 + t, prec=2, extend=True, name = 'alpha'); u
+
+            sage: # needs sage.libs.singular
+            sage: u = sqrt(2 + t, prec=2, extend=True, name='alpha'); u
             alpha
             sage: u^2
             2 + t
@@ -1549,6 +1551,7 @@ cdef class PowerSeries(AlgebraElement):
             Univariate Quotient Polynomial Ring in alpha
              over Power Series Ring in t over Rational Field
              with modulus x^2 - 2 - t
+
             sage: K.<t> = PowerSeriesRing(QQ, 't', 50)
             sage: sqrt(1 + 2*t + t^2)
             1 + t
@@ -1573,6 +1576,7 @@ cdef class PowerSeries(AlgebraElement):
 
         A formal square root::
 
+            sage: # needs sage.libs.singular
             sage: K.<t> = PowerSeriesRing(QQ, 5)
             sage: f = 2*t + t^3 + O(t^4)
             sage: s = f.sqrt(extend=True, name='sqrtf'); s


### PR DESCRIPTION
- **./sage --fixdoctests --distribution 'sagemath-categories' --update-known-test-failures**
- **src/sage/combinat/integer_vector_weighted.py: Add # needs**
- **src/sage/doctest: Add # needs**
- **src/sage/env.py: Add # needs**
- **src/sage/misc/latex.py: Add # needs**
- **src/sage/misc/latex_macros.py: Adjust doctest**
- **src/sage/rings/power_series_ring_element.pyx: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-categories' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-repl' --update-known-test-failures**
