### PR TITLE
sagemath-flint: Add various modules from sage.modular

### DIFF
--- a/pkgs/sagemath-flint/MANIFEST.in
+++ b/pkgs/sagemath-flint/MANIFEST.in
@@ -57,6 +57,12 @@ include sage/rings/qqbar.p*
 
 include sage/rings/imaginary_unit.p*
 
+include sage/modular/modform/eis_series_cython.p*
+include sage/modular/modsym/apply.p*
+include sage/modular/modsym/heilbronn.p*
+include sage/modular/pollack_stevens/dist.p*
+include sage/schemes/elliptic_curves/descent_two_isogeny.p*
+
 global-exclude    all__sagemath_*.p*
 global-include    all__sagemath_flint.py
 

--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -159,7 +159,6 @@
         "ntests": 66
     },
     "sage.categories.action": {
-        "failed": true,
         "ntests": 107
     },
     "sage.categories.additive_groups": {
@@ -2429,7 +2428,6 @@
         "ntests": 150
     },
     "sage.misc.cachefunc": {
-        "failed": true,
         "ntests": 688
     },
     "sage.misc.call": {
@@ -2682,7 +2680,6 @@
         "ntests": 637
     },
     "sage.modular.abvar.abvar_ambient_jacobian": {
-        "failed": true,
         "ntests": 53
     },
     "sage.modular.abvar.abvar_newform": {
@@ -2690,7 +2687,6 @@
         "ntests": 32
     },
     "sage.modular.abvar.constructor": {
-        "failed": true,
         "ntests": 15
     },
     "sage.modular.abvar.cuspidal_subgroup": {
@@ -2714,11 +2710,9 @@
         "ntests": 57
     },
     "sage.modular.abvar.morphism": {
-        "failed": true,
         "ntests": 170
     },
     "sage.modular.abvar.torsion_point": {
-        "failed": true,
         "ntests": 45
     },
     "sage.modular.abvar.torsion_subgroup": {
@@ -2739,7 +2733,6 @@
         "ntests": 45
     },
     "sage.modular.arithgroup.congroup_gamma0": {
-        "failed": true,
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gamma1": {
@@ -2747,7 +2740,6 @@
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gammaH": {
-        "failed": true,
         "ntests": 158
     },
     "sage.modular.arithgroup.congroup_sl2z": {
@@ -2766,7 +2758,6 @@
         "ntests": 388
     },
     "sage.modular.buzzard": {
-        "failed": true,
         "ntests": 7
     },
     "sage.modular.cusps": {
@@ -2798,7 +2789,6 @@
         "ntests": 102
     },
     "sage.modular.hecke.algebra": {
-        "failed": true,
         "ntests": 91
     },
     "sage.modular.hecke.ambient_module": {
@@ -2857,7 +2847,6 @@
         "ntests": 90
     },
     "sage.modular.modform.ambient": {
-        "failed": true,
         "ntests": 113
     },
     "sage.modular.modform.ambient_R": {
@@ -2873,7 +2862,6 @@
         "ntests": 13
     },
     "sage.modular.modform.ambient_g1": {
-        "failed": true,
         "ntests": 25
     },
     "sage.modular.modform.constructor": {
@@ -2888,6 +2876,9 @@
         "failed": true,
         "ntests": 41
     },
+    "sage.modular.modform.eis_series_cython": {
+        "ntests": 6
+    },
     "sage.modular.modform.eisenstein_submodule": {
         "failed": true,
         "ntests": 89
@@ -2901,15 +2892,12 @@
         "ntests": 9
     },
     "sage.modular.modform.half_integral": {
-        "failed": true,
         "ntests": 7
     },
     "sage.modular.modform.hecke_operator_on_qexp": {
-        "failed": true,
         "ntests": 33
     },
     "sage.modular.modform.j_invariant": {
-        "failed": true,
         "ntests": 3
     },
     "sage.modular.modform.l_series_gross_zagier": {
@@ -2921,7 +2909,6 @@
         "ntests": 20
     },
     "sage.modular.modform.numerical": {
-        "failed": true,
         "ntests": 46
     },
     "sage.modular.modform.ring": {
@@ -2943,11 +2930,9 @@
         "ntests": 15
     },
     "sage.modular.modform.vm_basis": {
-        "failed": true,
         "ntests": 27
     },
     "sage.modular.modform.weight1": {
-        "failed": true,
         "ntests": 10
     },
     "sage.modular.modform_hecketriangle.abstract_ring": {
@@ -2964,6 +2949,9 @@
         "failed": true,
         "ntests": 442
     },
+    "sage.modular.modsym.apply": {
+        "ntests": 6
+    },
     "sage.modular.modsym.boundary": {
         "failed": true,
         "ntests": 200
@@ -2979,11 +2967,13 @@
         "ntests": 23
     },
     "sage.modular.modsym.hecke_operator": {
-        "failed": true,
         "ntests": 6
     },
-    "sage.modular.modsym.manin_symbol": {
+    "sage.modular.modsym.heilbronn": {
         "failed": true,
+        "ntests": 66
+    },
+    "sage.modular.modsym.manin_symbol": {
         "ntests": 111
     },
     "sage.modular.modsym.manin_symbol_list": {
@@ -2995,7 +2985,6 @@
         "ntests": 80
     },
     "sage.modular.modsym.modular_symbols": {
-        "failed": true,
         "ntests": 65
     },
     "sage.modular.modsym.p1list": {
@@ -3005,7 +2994,6 @@
         "ntests": 271
     },
     "sage.modular.modsym.relation_matrix": {
-        "failed": true,
         "ntests": 29
     },
     "sage.modular.modsym.relation_matrix_pyx": {
@@ -3029,6 +3017,9 @@
     "sage.modular.overconvergent.hecke_series": {
         "failed": true,
         "ntests": 76
+    },
+    "sage.modular.pollack_stevens.dist": {
+        "ntests": 168
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
@@ -3778,7 +3769,6 @@
         "ntests": 166
     },
     "sage.rings.laurent_series_ring_element": {
-        "failed": true,
         "ntests": 402
     },
     "sage.rings.localization": {
@@ -4468,6 +4458,10 @@
         "failed": true,
         "ntests": 227
     },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "failed": true,
+        "ntests": 37
+    },
     "sage.schemes.elliptic_curves.ec_database": {
         "failed": true,
         "ntests": 9
@@ -4949,7 +4943,6 @@
         "ntests": 160
     },
     "sage.structure.factorization": {
-        "failed": true,
         "ntests": 240
     },
     "sage.structure.factorization_integer": {
@@ -5101,7 +5094,6 @@
         "ntests": 245
     },
     "sage.tests.book_stein_modform": {
-        "failed": true,
         "ntests": 237
     },
     "sage.tests.cmdline": {

--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -75,7 +75,6 @@
         "ntests": 88
     },
     "sage.algebras.orlik_terao": {
-        "failed": true,
         "ntests": 89
     },
     "sage.algebras.quatalg.quaternion_algebra": {
@@ -674,14 +673,12 @@
         "ntests": 3
     },
     "sage.categories.polyhedra": {
-        "failed": true,
         "ntests": 8
     },
     "sage.categories.poor_man_map": {
         "ntests": 59
     },
     "sage.categories.primer": {
-        "failed": true,
         "ntests": 163
     },
     "sage.categories.principal_ideal_domains": {
@@ -1564,26 +1561,21 @@
         "ntests": 24
     },
     "sage.game_theory.catalog_normal_form_games": {
-        "failed": true,
         "ntests": 100
     },
     "sage.game_theory.cooperative_game": {
-        "failed": true,
         "ntests": 101
     },
     "sage.game_theory.matching_game": {
         "ntests": 3
     },
     "sage.game_theory.normal_form_game": {
-        "failed": true,
         "ntests": 602
     },
     "sage.game_theory.parser": {
-        "failed": true,
         "ntests": 65
     },
     "sage.geometry.abc": {
-        "failed": true,
         "ntests": 15
     },
     "sage.geometry.cone": {
@@ -1591,7 +1583,6 @@
         "ntests": 1130
     },
     "sage.geometry.cone_catalog": {
-        "failed": true,
         "ntests": 101
     },
     "sage.geometry.cone_critical_angles": {
@@ -1599,14 +1590,12 @@
         "ntests": 125
     },
     "sage.geometry.convex_set": {
-        "failed": true,
         "ntests": 148
     },
     "sage.geometry.fan": {
         "ntests": 7
     },
     "sage.geometry.fan_isomorphism": {
-        "failed": true,
         "ntests": 65
     },
     "sage.geometry.hasse_diagram": {
@@ -1620,7 +1609,6 @@
         "ntests": 461
     },
     "sage.geometry.hyperplane_arrangement.check_freeness": {
-        "failed": true,
         "ntests": 8
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
@@ -1636,11 +1624,9 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "failed": true,
         "ntests": 51
     },
     "sage.geometry.integral_points.pxi": {
-        "failed": true,
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
@@ -1654,7 +1640,6 @@
         "ntests": 110
     },
     "sage.geometry.point_collection": {
-        "failed": true,
         "ntests": 111
     },
     "sage.geometry.polyhedral_complex": {
@@ -1665,38 +1650,30 @@
         "ntests": 33
     },
     "sage.geometry.polyhedron.backend_cdd_rdf": {
-        "failed": true,
         "ntests": 34
     },
     "sage.geometry.polyhedron.backend_field": {
-        "failed": true,
         "ntests": 64
     },
     "sage.geometry.polyhedron.backend_normaliz": {
         "ntests": 22
     },
     "sage.geometry.polyhedron.backend_number_field": {
-        "failed": true,
         "ntests": 27
     },
     "sage.geometry.polyhedron.backend_polymake": {
-        "failed": true,
         "ntests": 73
     },
     "sage.geometry.polyhedron.backend_ppl": {
-        "failed": true,
         "ntests": 90
     },
     "sage.geometry.polyhedron.base": {
-        "failed": true,
         "ntests": 150
     },
     "sage.geometry.polyhedron.base0": {
-        "failed": true,
         "ntests": 212
     },
     "sage.geometry.polyhedron.base1": {
-        "failed": true,
         "ntests": 144
     },
     "sage.geometry.polyhedron.base2": {
@@ -1704,14 +1681,12 @@
         "ntests": 96
     },
     "sage.geometry.polyhedron.base3": {
-        "failed": true,
         "ntests": 320
     },
     "sage.geometry.polyhedron.base4": {
         "ntests": 11
     },
     "sage.geometry.polyhedron.base5": {
-        "failed": true,
         "ntests": 382
     },
     "sage.geometry.polyhedron.base6": {
@@ -1719,15 +1694,12 @@
         "ntests": 202
     },
     "sage.geometry.polyhedron.base7": {
-        "failed": true,
         "ntests": 128
     },
     "sage.geometry.polyhedron.base_QQ": {
-        "failed": true,
         "ntests": 112
     },
     "sage.geometry.polyhedron.base_RDF": {
-        "failed": true,
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
@@ -1735,7 +1707,6 @@
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
-        "failed": true,
         "ntests": 57
     },
     "sage.geometry.polyhedron.base_number_field": {
@@ -1745,27 +1716,21 @@
         "ntests": 10
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.base": {
-        "failed": true,
         "ntests": 581
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.combinatorial_face": {
-        "failed": true,
         "ntests": 180
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.conversions": {
-        "failed": true,
         "ntests": 58
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.face_iterator": {
-        "failed": true,
         "ntests": 364
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.list_of_faces": {
-        "failed": true,
         "ntests": 67
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.polyhedron_face_lattice": {
-        "failed": true,
         "ntests": 52
     },
     "sage.geometry.polyhedron.constructor": {
@@ -1779,7 +1744,6 @@
         "ntests": 72
     },
     "sage.geometry.polyhedron.face": {
-        "failed": true,
         "ntests": 159
     },
     "sage.geometry.polyhedron.lattice_euclidean_group_element": {
@@ -1793,7 +1757,6 @@
         "ntests": 12
     },
     "sage.geometry.polyhedron.modules.formal_polyhedra_module": {
-        "failed": true,
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
@@ -1804,36 +1767,30 @@
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
-        "failed": true,
         "ntests": 199
     },
     "sage.geometry.polyhedron.ppl_lattice_polygon": {
         "ntests": 81
     },
     "sage.geometry.polyhedron.ppl_lattice_polytope": {
-        "failed": true,
         "ntests": 166
     },
     "sage.geometry.polyhedron.representation": {
-        "failed": true,
         "ntests": 343
     },
     "sage.geometry.pseudolines": {
         "ntests": 77
     },
     "sage.geometry.relative_interior": {
-        "failed": true,
         "ntests": 88
     },
     "sage.geometry.toric_lattice": {
-        "failed": true,
         "ntests": 302
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 80
     },
     "sage.geometry.toric_plotter": {
-        "failed": true,
         "ntests": 82
     },
     "sage.geometry.triangulation.base": {
@@ -1841,11 +1798,9 @@
         "ntests": 173
     },
     "sage.geometry.triangulation.element": {
-        "failed": true,
         "ntests": 116
     },
     "sage.geometry.triangulation.point_configuration": {
-        "failed": true,
         "ntests": 250
     },
     "sage.geometry.voronoi_diagram": {
@@ -1894,7 +1849,6 @@
         "ntests": 33
     },
     "sage.groups.affine_gps.group_element": {
-        "failed": true,
         "ntests": 92
     },
     "sage.groups.galois_group": {
@@ -2513,7 +2467,6 @@
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
-        "failed": true,
         "ntests": 210
     },
     "sage.misc.lazy_attribute": {
@@ -3052,7 +3005,6 @@
         "ntests": 2
     },
     "sage.modules.diamond_cutting": {
-        "failed": true,
         "ntests": 19
     },
     "sage.modules.fg_pid.fgp_element": {
@@ -3179,11 +3131,9 @@
         "ntests": 10
     },
     "sage.numerical.backends.generic_backend": {
-        "failed": true,
         "ntests": 60
     },
     "sage.numerical.backends.generic_sdp_backend": {
-        "failed": true,
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
@@ -3191,7 +3141,6 @@
         "ntests": 266
     },
     "sage.numerical.backends.logging_backend": {
-        "failed": true,
         "ntests": 45
     },
     "sage.numerical.backends.matrix_sdp_backend": {
@@ -3221,15 +3170,12 @@
         "ntests": 303
     },
     "sage.numerical.linear_tensor": {
-        "failed": true,
         "ntests": 78
     },
     "sage.numerical.linear_tensor_constraints": {
-        "failed": true,
         "ntests": 66
     },
     "sage.numerical.linear_tensor_element": {
-        "failed": true,
         "ntests": 80
     },
     "sage.numerical.mip": {
@@ -3241,7 +3187,6 @@
         "ntests": 74
     },
     "sage.numerical.sdp": {
-        "failed": true,
         "ntests": 239
     },
     "sage.parallel.decorate": {
@@ -4085,7 +4030,6 @@
         "ntests": 186
     },
     "sage.rings.polynomial.omega": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
@@ -4816,7 +4760,6 @@
         "ntests": 54
     },
     "sage.sets.condition_set": {
-        "failed": true,
         "ntests": 54
     },
     "sage.sets.disjoint_set": {

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -75,7 +75,6 @@
         "ntests": 88
     },
     "sage.algebras.orlik_terao": {
-        "failed": true,
         "ntests": 89
     },
     "sage.algebras.quatalg.quaternion_algebra": {
@@ -674,14 +673,12 @@
         "ntests": 3
     },
     "sage.categories.polyhedra": {
-        "failed": true,
         "ntests": 8
     },
     "sage.categories.poor_man_map": {
         "ntests": 59
     },
     "sage.categories.primer": {
-        "failed": true,
         "ntests": 163
     },
     "sage.categories.principal_ideal_domains": {
@@ -1241,7 +1238,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 42
+        "ntests": 43
     },
     "sage.doctest.fixtures": {
         "failed": true,
@@ -1409,7 +1406,7 @@
         "ntests": 16
     },
     "sage.features.macaulay2": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1564,26 +1561,21 @@
         "ntests": 24
     },
     "sage.game_theory.catalog_normal_form_games": {
-        "failed": true,
         "ntests": 100
     },
     "sage.game_theory.cooperative_game": {
-        "failed": true,
         "ntests": 101
     },
     "sage.game_theory.matching_game": {
         "ntests": 3
     },
     "sage.game_theory.normal_form_game": {
-        "failed": true,
         "ntests": 602
     },
     "sage.game_theory.parser": {
-        "failed": true,
         "ntests": 65
     },
     "sage.geometry.abc": {
-        "failed": true,
         "ntests": 15
     },
     "sage.geometry.cone": {
@@ -1591,7 +1583,6 @@
         "ntests": 1130
     },
     "sage.geometry.cone_catalog": {
-        "failed": true,
         "ntests": 101
     },
     "sage.geometry.cone_critical_angles": {
@@ -1599,14 +1590,12 @@
         "ntests": 125
     },
     "sage.geometry.convex_set": {
-        "failed": true,
         "ntests": 148
     },
     "sage.geometry.fan": {
         "ntests": 7
     },
     "sage.geometry.fan_isomorphism": {
-        "failed": true,
         "ntests": 65
     },
     "sage.geometry.hasse_diagram": {
@@ -1620,7 +1609,6 @@
         "ntests": 461
     },
     "sage.geometry.hyperplane_arrangement.check_freeness": {
-        "failed": true,
         "ntests": 8
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
@@ -1636,11 +1624,9 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "failed": true,
         "ntests": 51
     },
     "sage.geometry.integral_points.pxi": {
-        "failed": true,
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
@@ -1654,7 +1640,6 @@
         "ntests": 110
     },
     "sage.geometry.point_collection": {
-        "failed": true,
         "ntests": 111
     },
     "sage.geometry.polyhedral_complex": {
@@ -1665,38 +1650,30 @@
         "ntests": 33
     },
     "sage.geometry.polyhedron.backend_cdd_rdf": {
-        "failed": true,
         "ntests": 34
     },
     "sage.geometry.polyhedron.backend_field": {
-        "failed": true,
         "ntests": 64
     },
     "sage.geometry.polyhedron.backend_normaliz": {
         "ntests": 22
     },
     "sage.geometry.polyhedron.backend_number_field": {
-        "failed": true,
         "ntests": 27
     },
     "sage.geometry.polyhedron.backend_polymake": {
-        "failed": true,
         "ntests": 73
     },
     "sage.geometry.polyhedron.backend_ppl": {
-        "failed": true,
         "ntests": 90
     },
     "sage.geometry.polyhedron.base": {
-        "failed": true,
         "ntests": 150
     },
     "sage.geometry.polyhedron.base0": {
-        "failed": true,
         "ntests": 212
     },
     "sage.geometry.polyhedron.base1": {
-        "failed": true,
         "ntests": 144
     },
     "sage.geometry.polyhedron.base2": {
@@ -1704,14 +1681,12 @@
         "ntests": 96
     },
     "sage.geometry.polyhedron.base3": {
-        "failed": true,
         "ntests": 320
     },
     "sage.geometry.polyhedron.base4": {
         "ntests": 11
     },
     "sage.geometry.polyhedron.base5": {
-        "failed": true,
         "ntests": 382
     },
     "sage.geometry.polyhedron.base6": {
@@ -1719,15 +1694,12 @@
         "ntests": 202
     },
     "sage.geometry.polyhedron.base7": {
-        "failed": true,
         "ntests": 128
     },
     "sage.geometry.polyhedron.base_QQ": {
-        "failed": true,
         "ntests": 112
     },
     "sage.geometry.polyhedron.base_RDF": {
-        "failed": true,
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
@@ -1735,7 +1707,6 @@
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
-        "failed": true,
         "ntests": 57
     },
     "sage.geometry.polyhedron.base_number_field": {
@@ -1745,27 +1716,21 @@
         "ntests": 10
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.base": {
-        "failed": true,
         "ntests": 581
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.combinatorial_face": {
-        "failed": true,
         "ntests": 180
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.conversions": {
-        "failed": true,
         "ntests": 58
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.face_iterator": {
-        "failed": true,
         "ntests": 364
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.list_of_faces": {
-        "failed": true,
         "ntests": 67
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.polyhedron_face_lattice": {
-        "failed": true,
         "ntests": 52
     },
     "sage.geometry.polyhedron.constructor": {
@@ -1779,7 +1744,6 @@
         "ntests": 72
     },
     "sage.geometry.polyhedron.face": {
-        "failed": true,
         "ntests": 159
     },
     "sage.geometry.polyhedron.lattice_euclidean_group_element": {
@@ -1793,7 +1757,6 @@
         "ntests": 12
     },
     "sage.geometry.polyhedron.modules.formal_polyhedra_module": {
-        "failed": true,
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
@@ -1804,36 +1767,30 @@
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
-        "failed": true,
         "ntests": 199
     },
     "sage.geometry.polyhedron.ppl_lattice_polygon": {
         "ntests": 81
     },
     "sage.geometry.polyhedron.ppl_lattice_polytope": {
-        "failed": true,
         "ntests": 166
     },
     "sage.geometry.polyhedron.representation": {
-        "failed": true,
         "ntests": 343
     },
     "sage.geometry.pseudolines": {
         "ntests": 77
     },
     "sage.geometry.relative_interior": {
-        "failed": true,
         "ntests": 88
     },
     "sage.geometry.toric_lattice": {
-        "failed": true,
         "ntests": 302
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 80
     },
     "sage.geometry.toric_plotter": {
-        "failed": true,
         "ntests": 82
     },
     "sage.geometry.triangulation.base": {
@@ -1841,11 +1798,9 @@
         "ntests": 173
     },
     "sage.geometry.triangulation.element": {
-        "failed": true,
         "ntests": 116
     },
     "sage.geometry.triangulation.point_configuration": {
-        "failed": true,
         "ntests": 250
     },
     "sage.geometry.voronoi_diagram": {
@@ -1894,7 +1849,6 @@
         "ntests": 33
     },
     "sage.groups.affine_gps.group_element": {
-        "failed": true,
         "ntests": 92
     },
     "sage.groups.galois_group": {
@@ -2218,7 +2172,7 @@
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 441
+        "ntests": 447
     },
     "sage.matrix.matrix2": {
         "failed": true,
@@ -2513,7 +2467,6 @@
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
-        "failed": true,
         "ntests": 210
     },
     "sage.misc.lazy_attribute": {
@@ -3008,6 +2961,7 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
+        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3051,7 +3005,6 @@
         "ntests": 2
     },
     "sage.modules.diamond_cutting": {
-        "failed": true,
         "ntests": 19
     },
     "sage.modules.fg_pid.fgp_element": {
@@ -3073,11 +3026,11 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1484
+        "ntests": 1485
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 974
+        "ntests": 979
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
@@ -3178,11 +3131,9 @@
         "ntests": 10
     },
     "sage.numerical.backends.generic_backend": {
-        "failed": true,
         "ntests": 60
     },
     "sage.numerical.backends.generic_sdp_backend": {
-        "failed": true,
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
@@ -3190,7 +3141,6 @@
         "ntests": 266
     },
     "sage.numerical.backends.logging_backend": {
-        "failed": true,
         "ntests": 45
     },
     "sage.numerical.backends.matrix_sdp_backend": {
@@ -3220,15 +3170,12 @@
         "ntests": 303
     },
     "sage.numerical.linear_tensor": {
-        "failed": true,
         "ntests": 78
     },
     "sage.numerical.linear_tensor_constraints": {
-        "failed": true,
         "ntests": 66
     },
     "sage.numerical.linear_tensor_element": {
-        "failed": true,
         "ntests": 80
     },
     "sage.numerical.mip": {
@@ -3240,7 +3187,6 @@
         "ntests": 74
     },
     "sage.numerical.sdp": {
-        "failed": true,
         "ntests": 239
     },
     "sage.parallel.decorate": {
@@ -3397,7 +3343,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 116
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3566,7 +3512,7 @@
     },
     "sage.rings.finite_rings.finite_field_base": {
         "failed": true,
-        "ntests": 340
+        "ntests": 345
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "failed": true,
@@ -3608,7 +3554,8 @@
         "ntests": 583
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 367
+        "failed": true,
+        "ntests": 369
     },
     "sage.rings.finite_rings.maps_finite_field": {
         "ntests": 31
@@ -3740,7 +3687,8 @@
         "ntests": 55
     },
     "sage.rings.ideal": {
-        "ntests": 361
+        "failed": true,
+        "ntests": 370
     },
     "sage.rings.ideal_monoid": {
         "ntests": 48
@@ -3756,7 +3704,8 @@
         "ntests": 1
     },
     "sage.rings.integer_ring": {
-        "ntests": 229
+        "failed": true,
+        "ntests": 230
     },
     "sage.rings.invariants.invariant_theory": {
         "ntests": 883
@@ -4060,22 +4009,22 @@
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 532
+        "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true,
-        "ntests": 895
+        "ntests": 913
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
         "ntests": 25
     },
     "sage.rings.polynomial.multi_polynomial_libsingular": {
         "failed": true,
-        "ntests": 1234
+        "ntests": 1246
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 149
+        "ntests": 155
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "ntests": 249
@@ -4084,7 +4033,6 @@
         "ntests": 186
     },
     "sage.rings.polynomial.omega": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
@@ -4162,7 +4110,7 @@
     },
     "sage.rings.polynomial.polynomial_ring": {
         "failed": true,
-        "ntests": 534
+        "ntests": 536
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -4195,7 +4143,8 @@
         "ntests": 97
     },
     "sage.rings.polynomial.term_order": {
-        "ntests": 360
+        "failed": true,
+        "ntests": 361
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 51
@@ -4242,11 +4191,12 @@
         "ntests": 17
     },
     "sage.rings.quotient_ring": {
-        "ntests": 257
+        "failed": true,
+        "ntests": 261
     },
     "sage.rings.quotient_ring_element": {
         "failed": true,
-        "ntests": 191
+        "ntests": 200
     },
     "sage.rings.rational": {
         "failed": true,
@@ -4254,7 +4204,7 @@
     },
     "sage.rings.rational_field": {
         "failed": true,
-        "ntests": 212
+        "ntests": 213
     },
     "sage.rings.real_arb": {
         "failed": true,
@@ -4815,7 +4765,6 @@
         "ntests": 54
     },
     "sage.sets.condition_set": {
-        "failed": true,
         "ntests": 54
     },
     "sage.sets.disjoint_set": {

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -159,7 +159,6 @@
         "ntests": 66
     },
     "sage.categories.action": {
-        "failed": true,
         "ntests": 107
     },
     "sage.categories.additive_groups": {
@@ -1242,7 +1241,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 43
+        "ntests": 42
     },
     "sage.doctest.fixtures": {
         "failed": true,
@@ -1410,7 +1409,7 @@
         "ntests": 16
     },
     "sage.features.macaulay2": {
-        "ntests": 4
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -2219,7 +2218,7 @@
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 447
+        "ntests": 441
     },
     "sage.matrix.matrix2": {
         "failed": true,
@@ -2429,7 +2428,6 @@
         "ntests": 150
     },
     "sage.misc.cachefunc": {
-        "failed": true,
         "ntests": 688
     },
     "sage.misc.call": {
@@ -2682,7 +2680,6 @@
         "ntests": 637
     },
     "sage.modular.abvar.abvar_ambient_jacobian": {
-        "failed": true,
         "ntests": 53
     },
     "sage.modular.abvar.abvar_newform": {
@@ -2690,7 +2687,6 @@
         "ntests": 32
     },
     "sage.modular.abvar.constructor": {
-        "failed": true,
         "ntests": 15
     },
     "sage.modular.abvar.cuspidal_subgroup": {
@@ -2714,11 +2710,9 @@
         "ntests": 57
     },
     "sage.modular.abvar.morphism": {
-        "failed": true,
         "ntests": 170
     },
     "sage.modular.abvar.torsion_point": {
-        "failed": true,
         "ntests": 45
     },
     "sage.modular.abvar.torsion_subgroup": {
@@ -2739,7 +2733,6 @@
         "ntests": 45
     },
     "sage.modular.arithgroup.congroup_gamma0": {
-        "failed": true,
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gamma1": {
@@ -2747,7 +2740,6 @@
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gammaH": {
-        "failed": true,
         "ntests": 158
     },
     "sage.modular.arithgroup.congroup_sl2z": {
@@ -2766,7 +2758,6 @@
         "ntests": 388
     },
     "sage.modular.buzzard": {
-        "failed": true,
         "ntests": 7
     },
     "sage.modular.cusps": {
@@ -2798,7 +2789,6 @@
         "ntests": 102
     },
     "sage.modular.hecke.algebra": {
-        "failed": true,
         "ntests": 91
     },
     "sage.modular.hecke.ambient_module": {
@@ -2857,7 +2847,6 @@
         "ntests": 90
     },
     "sage.modular.modform.ambient": {
-        "failed": true,
         "ntests": 113
     },
     "sage.modular.modform.ambient_R": {
@@ -2873,7 +2862,6 @@
         "ntests": 13
     },
     "sage.modular.modform.ambient_g1": {
-        "failed": true,
         "ntests": 25
     },
     "sage.modular.modform.constructor": {
@@ -2888,6 +2876,9 @@
         "failed": true,
         "ntests": 41
     },
+    "sage.modular.modform.eis_series_cython": {
+        "ntests": 6
+    },
     "sage.modular.modform.eisenstein_submodule": {
         "failed": true,
         "ntests": 89
@@ -2901,15 +2892,12 @@
         "ntests": 9
     },
     "sage.modular.modform.half_integral": {
-        "failed": true,
         "ntests": 7
     },
     "sage.modular.modform.hecke_operator_on_qexp": {
-        "failed": true,
         "ntests": 33
     },
     "sage.modular.modform.j_invariant": {
-        "failed": true,
         "ntests": 3
     },
     "sage.modular.modform.l_series_gross_zagier": {
@@ -2921,7 +2909,6 @@
         "ntests": 20
     },
     "sage.modular.modform.numerical": {
-        "failed": true,
         "ntests": 46
     },
     "sage.modular.modform.ring": {
@@ -2943,11 +2930,9 @@
         "ntests": 15
     },
     "sage.modular.modform.vm_basis": {
-        "failed": true,
         "ntests": 27
     },
     "sage.modular.modform.weight1": {
-        "failed": true,
         "ntests": 10
     },
     "sage.modular.modform_hecketriangle.abstract_ring": {
@@ -2964,6 +2949,9 @@
         "failed": true,
         "ntests": 442
     },
+    "sage.modular.modsym.apply": {
+        "ntests": 6
+    },
     "sage.modular.modsym.boundary": {
         "failed": true,
         "ntests": 200
@@ -2979,11 +2967,13 @@
         "ntests": 23
     },
     "sage.modular.modsym.hecke_operator": {
-        "failed": true,
         "ntests": 6
     },
-    "sage.modular.modsym.manin_symbol": {
+    "sage.modular.modsym.heilbronn": {
         "failed": true,
+        "ntests": 66
+    },
+    "sage.modular.modsym.manin_symbol": {
         "ntests": 111
     },
     "sage.modular.modsym.manin_symbol_list": {
@@ -2995,7 +2985,6 @@
         "ntests": 80
     },
     "sage.modular.modsym.modular_symbols": {
-        "failed": true,
         "ntests": 65
     },
     "sage.modular.modsym.p1list": {
@@ -3005,7 +2994,6 @@
         "ntests": 271
     },
     "sage.modular.modsym.relation_matrix": {
-        "failed": true,
         "ntests": 29
     },
     "sage.modular.modsym.relation_matrix_pyx": {
@@ -3020,7 +3008,6 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3029,6 +3016,9 @@
     "sage.modular.overconvergent.hecke_series": {
         "failed": true,
         "ntests": 76
+    },
+    "sage.modular.pollack_stevens.dist": {
+        "ntests": 168
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
@@ -3083,11 +3073,11 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1485
+        "ntests": 1484
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 979
+        "ntests": 974
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
@@ -3407,7 +3397,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 116
+        "ntests": 113
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3576,7 +3566,7 @@
     },
     "sage.rings.finite_rings.finite_field_base": {
         "failed": true,
-        "ntests": 345
+        "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "failed": true,
@@ -3618,8 +3608,7 @@
         "ntests": 583
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "failed": true,
-        "ntests": 369
+        "ntests": 367
     },
     "sage.rings.finite_rings.maps_finite_field": {
         "ntests": 31
@@ -3751,8 +3740,7 @@
         "ntests": 55
     },
     "sage.rings.ideal": {
-        "failed": true,
-        "ntests": 370
+        "ntests": 361
     },
     "sage.rings.ideal_monoid": {
         "ntests": 48
@@ -3768,8 +3756,7 @@
         "ntests": 1
     },
     "sage.rings.integer_ring": {
-        "failed": true,
-        "ntests": 230
+        "ntests": 229
     },
     "sage.rings.invariants.invariant_theory": {
         "ntests": 883
@@ -3781,7 +3768,6 @@
         "ntests": 166
     },
     "sage.rings.laurent_series_ring_element": {
-        "failed": true,
         "ntests": 402
     },
     "sage.rings.localization": {
@@ -4074,22 +4060,22 @@
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 534
+        "ntests": 532
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true,
-        "ntests": 913
+        "ntests": 895
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
         "ntests": 25
     },
     "sage.rings.polynomial.multi_polynomial_libsingular": {
         "failed": true,
-        "ntests": 1246
+        "ntests": 1234
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 155
+        "ntests": 149
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "ntests": 249
@@ -4176,7 +4162,7 @@
     },
     "sage.rings.polynomial.polynomial_ring": {
         "failed": true,
-        "ntests": 536
+        "ntests": 534
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -4209,8 +4195,7 @@
         "ntests": 97
     },
     "sage.rings.polynomial.term_order": {
-        "failed": true,
-        "ntests": 361
+        "ntests": 360
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 51
@@ -4257,12 +4242,11 @@
         "ntests": 17
     },
     "sage.rings.quotient_ring": {
-        "failed": true,
-        "ntests": 261
+        "ntests": 257
     },
     "sage.rings.quotient_ring_element": {
         "failed": true,
-        "ntests": 200
+        "ntests": 191
     },
     "sage.rings.rational": {
         "failed": true,
@@ -4270,7 +4254,7 @@
     },
     "sage.rings.rational_field": {
         "failed": true,
-        "ntests": 213
+        "ntests": 212
     },
     "sage.rings.real_arb": {
         "failed": true,
@@ -4472,6 +4456,10 @@
     "sage.schemes.elliptic_curves.constructor": {
         "failed": true,
         "ntests": 227
+    },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "failed": true,
+        "ntests": 37
     },
     "sage.schemes.elliptic_curves.ec_database": {
         "failed": true,
@@ -4954,7 +4942,6 @@
         "ntests": 160
     },
     "sage.structure.factorization": {
-        "failed": true,
         "ntests": 240
     },
     "sage.structure.factorization_integer": {
@@ -5106,7 +5093,6 @@
         "ntests": 245
     },
     "sage.tests.book_stein_modform": {
-        "failed": true,
         "ntests": 237
     },
     "sage.tests.cmdline": {

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -75,7 +75,6 @@
         "ntests": 88
     },
     "sage.algebras.orlik_terao": {
-        "failed": true,
         "ntests": 89
     },
     "sage.algebras.quatalg.quaternion_algebra": {
@@ -674,14 +673,12 @@
         "ntests": 3
     },
     "sage.categories.polyhedra": {
-        "failed": true,
         "ntests": 8
     },
     "sage.categories.poor_man_map": {
         "ntests": 59
     },
     "sage.categories.primer": {
-        "failed": true,
         "ntests": 163
     },
     "sage.categories.principal_ideal_domains": {
@@ -1241,7 +1238,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 42
+        "ntests": 43
     },
     "sage.doctest.fixtures": {
         "failed": true,
@@ -1409,7 +1406,7 @@
         "ntests": 16
     },
     "sage.features.macaulay2": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1564,26 +1561,21 @@
         "ntests": 24
     },
     "sage.game_theory.catalog_normal_form_games": {
-        "failed": true,
         "ntests": 100
     },
     "sage.game_theory.cooperative_game": {
-        "failed": true,
         "ntests": 101
     },
     "sage.game_theory.matching_game": {
         "ntests": 3
     },
     "sage.game_theory.normal_form_game": {
-        "failed": true,
         "ntests": 602
     },
     "sage.game_theory.parser": {
-        "failed": true,
         "ntests": 65
     },
     "sage.geometry.abc": {
-        "failed": true,
         "ntests": 15
     },
     "sage.geometry.cone": {
@@ -1591,7 +1583,6 @@
         "ntests": 1130
     },
     "sage.geometry.cone_catalog": {
-        "failed": true,
         "ntests": 101
     },
     "sage.geometry.cone_critical_angles": {
@@ -1599,14 +1590,12 @@
         "ntests": 125
     },
     "sage.geometry.convex_set": {
-        "failed": true,
         "ntests": 148
     },
     "sage.geometry.fan": {
         "ntests": 7
     },
     "sage.geometry.fan_isomorphism": {
-        "failed": true,
         "ntests": 65
     },
     "sage.geometry.hasse_diagram": {
@@ -1620,7 +1609,6 @@
         "ntests": 461
     },
     "sage.geometry.hyperplane_arrangement.check_freeness": {
-        "failed": true,
         "ntests": 8
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
@@ -1636,11 +1624,9 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "failed": true,
         "ntests": 51
     },
     "sage.geometry.integral_points.pxi": {
-        "failed": true,
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
@@ -1654,7 +1640,6 @@
         "ntests": 110
     },
     "sage.geometry.point_collection": {
-        "failed": true,
         "ntests": 111
     },
     "sage.geometry.polyhedral_complex": {
@@ -1665,38 +1650,30 @@
         "ntests": 33
     },
     "sage.geometry.polyhedron.backend_cdd_rdf": {
-        "failed": true,
         "ntests": 34
     },
     "sage.geometry.polyhedron.backend_field": {
-        "failed": true,
         "ntests": 64
     },
     "sage.geometry.polyhedron.backend_normaliz": {
         "ntests": 22
     },
     "sage.geometry.polyhedron.backend_number_field": {
-        "failed": true,
         "ntests": 27
     },
     "sage.geometry.polyhedron.backend_polymake": {
-        "failed": true,
         "ntests": 73
     },
     "sage.geometry.polyhedron.backend_ppl": {
-        "failed": true,
         "ntests": 90
     },
     "sage.geometry.polyhedron.base": {
-        "failed": true,
         "ntests": 150
     },
     "sage.geometry.polyhedron.base0": {
-        "failed": true,
         "ntests": 212
     },
     "sage.geometry.polyhedron.base1": {
-        "failed": true,
         "ntests": 144
     },
     "sage.geometry.polyhedron.base2": {
@@ -1704,14 +1681,12 @@
         "ntests": 96
     },
     "sage.geometry.polyhedron.base3": {
-        "failed": true,
         "ntests": 320
     },
     "sage.geometry.polyhedron.base4": {
         "ntests": 11
     },
     "sage.geometry.polyhedron.base5": {
-        "failed": true,
         "ntests": 382
     },
     "sage.geometry.polyhedron.base6": {
@@ -1719,15 +1694,12 @@
         "ntests": 202
     },
     "sage.geometry.polyhedron.base7": {
-        "failed": true,
         "ntests": 128
     },
     "sage.geometry.polyhedron.base_QQ": {
-        "failed": true,
         "ntests": 112
     },
     "sage.geometry.polyhedron.base_RDF": {
-        "failed": true,
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
@@ -1735,7 +1707,6 @@
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
-        "failed": true,
         "ntests": 57
     },
     "sage.geometry.polyhedron.base_number_field": {
@@ -1745,27 +1716,21 @@
         "ntests": 10
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.base": {
-        "failed": true,
         "ntests": 581
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.combinatorial_face": {
-        "failed": true,
         "ntests": 180
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.conversions": {
-        "failed": true,
         "ntests": 58
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.face_iterator": {
-        "failed": true,
         "ntests": 364
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.list_of_faces": {
-        "failed": true,
         "ntests": 67
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.polyhedron_face_lattice": {
-        "failed": true,
         "ntests": 52
     },
     "sage.geometry.polyhedron.constructor": {
@@ -1779,7 +1744,6 @@
         "ntests": 72
     },
     "sage.geometry.polyhedron.face": {
-        "failed": true,
         "ntests": 159
     },
     "sage.geometry.polyhedron.lattice_euclidean_group_element": {
@@ -1793,7 +1757,6 @@
         "ntests": 12
     },
     "sage.geometry.polyhedron.modules.formal_polyhedra_module": {
-        "failed": true,
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
@@ -1804,36 +1767,30 @@
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
-        "failed": true,
         "ntests": 199
     },
     "sage.geometry.polyhedron.ppl_lattice_polygon": {
         "ntests": 81
     },
     "sage.geometry.polyhedron.ppl_lattice_polytope": {
-        "failed": true,
         "ntests": 166
     },
     "sage.geometry.polyhedron.representation": {
-        "failed": true,
         "ntests": 343
     },
     "sage.geometry.pseudolines": {
         "ntests": 77
     },
     "sage.geometry.relative_interior": {
-        "failed": true,
         "ntests": 88
     },
     "sage.geometry.toric_lattice": {
-        "failed": true,
         "ntests": 302
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 80
     },
     "sage.geometry.toric_plotter": {
-        "failed": true,
         "ntests": 82
     },
     "sage.geometry.triangulation.base": {
@@ -1841,11 +1798,9 @@
         "ntests": 173
     },
     "sage.geometry.triangulation.element": {
-        "failed": true,
         "ntests": 116
     },
     "sage.geometry.triangulation.point_configuration": {
-        "failed": true,
         "ntests": 250
     },
     "sage.geometry.voronoi_diagram": {
@@ -1894,7 +1849,6 @@
         "ntests": 33
     },
     "sage.groups.affine_gps.group_element": {
-        "failed": true,
         "ntests": 92
     },
     "sage.groups.galois_group": {
@@ -2218,7 +2172,7 @@
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 441
+        "ntests": 447
     },
     "sage.matrix.matrix2": {
         "failed": true,
@@ -2513,7 +2467,6 @@
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
-        "failed": true,
         "ntests": 210
     },
     "sage.misc.lazy_attribute": {
@@ -3051,7 +3004,6 @@
         "ntests": 2
     },
     "sage.modules.diamond_cutting": {
-        "failed": true,
         "ntests": 19
     },
     "sage.modules.fg_pid.fgp_element": {
@@ -3073,11 +3025,11 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1484
+        "ntests": 1485
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 974
+        "ntests": 979
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
@@ -3178,11 +3130,9 @@
         "ntests": 10
     },
     "sage.numerical.backends.generic_backend": {
-        "failed": true,
         "ntests": 60
     },
     "sage.numerical.backends.generic_sdp_backend": {
-        "failed": true,
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
@@ -3190,7 +3140,6 @@
         "ntests": 266
     },
     "sage.numerical.backends.logging_backend": {
-        "failed": true,
         "ntests": 45
     },
     "sage.numerical.backends.matrix_sdp_backend": {
@@ -3220,15 +3169,12 @@
         "ntests": 303
     },
     "sage.numerical.linear_tensor": {
-        "failed": true,
         "ntests": 78
     },
     "sage.numerical.linear_tensor_constraints": {
-        "failed": true,
         "ntests": 66
     },
     "sage.numerical.linear_tensor_element": {
-        "failed": true,
         "ntests": 80
     },
     "sage.numerical.mip": {
@@ -3240,7 +3186,6 @@
         "ntests": 74
     },
     "sage.numerical.sdp": {
-        "failed": true,
         "ntests": 239
     },
     "sage.parallel.decorate": {
@@ -3397,7 +3342,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 116
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3566,7 +3511,7 @@
     },
     "sage.rings.finite_rings.finite_field_base": {
         "failed": true,
-        "ntests": 340
+        "ntests": 345
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "failed": true,
@@ -3608,7 +3553,8 @@
         "ntests": 583
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 367
+        "failed": true,
+        "ntests": 369
     },
     "sage.rings.finite_rings.maps_finite_field": {
         "ntests": 31
@@ -3740,7 +3686,8 @@
         "ntests": 55
     },
     "sage.rings.ideal": {
-        "ntests": 361
+        "failed": true,
+        "ntests": 370
     },
     "sage.rings.ideal_monoid": {
         "ntests": 48
@@ -3756,7 +3703,8 @@
         "ntests": 1
     },
     "sage.rings.integer_ring": {
-        "ntests": 229
+        "failed": true,
+        "ntests": 230
     },
     "sage.rings.invariants.invariant_theory": {
         "ntests": 883
@@ -4060,22 +4008,22 @@
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 532
+        "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true,
-        "ntests": 895
+        "ntests": 913
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
         "ntests": 25
     },
     "sage.rings.polynomial.multi_polynomial_libsingular": {
         "failed": true,
-        "ntests": 1234
+        "ntests": 1246
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 149
+        "ntests": 155
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "ntests": 249
@@ -4084,7 +4032,6 @@
         "ntests": 186
     },
     "sage.rings.polynomial.omega": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
@@ -4162,7 +4109,7 @@
     },
     "sage.rings.polynomial.polynomial_ring": {
         "failed": true,
-        "ntests": 534
+        "ntests": 536
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -4195,7 +4142,8 @@
         "ntests": 97
     },
     "sage.rings.polynomial.term_order": {
-        "ntests": 360
+        "failed": true,
+        "ntests": 361
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 51
@@ -4242,11 +4190,12 @@
         "ntests": 17
     },
     "sage.rings.quotient_ring": {
-        "ntests": 257
+        "failed": true,
+        "ntests": 261
     },
     "sage.rings.quotient_ring_element": {
         "failed": true,
-        "ntests": 191
+        "ntests": 200
     },
     "sage.rings.rational": {
         "failed": true,
@@ -4254,7 +4203,7 @@
     },
     "sage.rings.rational_field": {
         "failed": true,
-        "ntests": 212
+        "ntests": 213
     },
     "sage.rings.real_arb": {
         "failed": true,
@@ -4815,7 +4764,6 @@
         "ntests": 54
     },
     "sage.sets.condition_set": {
-        "failed": true,
         "ntests": 54
     },
     "sage.sets.disjoint_set": {

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -159,7 +159,6 @@
         "ntests": 66
     },
     "sage.categories.action": {
-        "failed": true,
         "ntests": 107
     },
     "sage.categories.additive_groups": {
@@ -2429,7 +2428,6 @@
         "ntests": 150
     },
     "sage.misc.cachefunc": {
-        "failed": true,
         "ntests": 688
     },
     "sage.misc.call": {
@@ -2682,7 +2680,6 @@
         "ntests": 637
     },
     "sage.modular.abvar.abvar_ambient_jacobian": {
-        "failed": true,
         "ntests": 53
     },
     "sage.modular.abvar.abvar_newform": {
@@ -2690,7 +2687,6 @@
         "ntests": 32
     },
     "sage.modular.abvar.constructor": {
-        "failed": true,
         "ntests": 15
     },
     "sage.modular.abvar.cuspidal_subgroup": {
@@ -2714,11 +2710,9 @@
         "ntests": 57
     },
     "sage.modular.abvar.morphism": {
-        "failed": true,
         "ntests": 170
     },
     "sage.modular.abvar.torsion_point": {
-        "failed": true,
         "ntests": 45
     },
     "sage.modular.abvar.torsion_subgroup": {
@@ -2739,7 +2733,6 @@
         "ntests": 45
     },
     "sage.modular.arithgroup.congroup_gamma0": {
-        "failed": true,
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gamma1": {
@@ -2747,7 +2740,6 @@
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gammaH": {
-        "failed": true,
         "ntests": 158
     },
     "sage.modular.arithgroup.congroup_sl2z": {
@@ -2766,7 +2758,6 @@
         "ntests": 388
     },
     "sage.modular.buzzard": {
-        "failed": true,
         "ntests": 7
     },
     "sage.modular.cusps": {
@@ -2798,7 +2789,6 @@
         "ntests": 102
     },
     "sage.modular.hecke.algebra": {
-        "failed": true,
         "ntests": 91
     },
     "sage.modular.hecke.ambient_module": {
@@ -2857,7 +2847,6 @@
         "ntests": 90
     },
     "sage.modular.modform.ambient": {
-        "failed": true,
         "ntests": 113
     },
     "sage.modular.modform.ambient_R": {
@@ -2873,7 +2862,6 @@
         "ntests": 13
     },
     "sage.modular.modform.ambient_g1": {
-        "failed": true,
         "ntests": 25
     },
     "sage.modular.modform.constructor": {
@@ -2888,6 +2876,9 @@
         "failed": true,
         "ntests": 41
     },
+    "sage.modular.modform.eis_series_cython": {
+        "ntests": 6
+    },
     "sage.modular.modform.eisenstein_submodule": {
         "failed": true,
         "ntests": 89
@@ -2901,15 +2892,12 @@
         "ntests": 9
     },
     "sage.modular.modform.half_integral": {
-        "failed": true,
         "ntests": 7
     },
     "sage.modular.modform.hecke_operator_on_qexp": {
-        "failed": true,
         "ntests": 33
     },
     "sage.modular.modform.j_invariant": {
-        "failed": true,
         "ntests": 3
     },
     "sage.modular.modform.l_series_gross_zagier": {
@@ -2921,7 +2909,6 @@
         "ntests": 20
     },
     "sage.modular.modform.numerical": {
-        "failed": true,
         "ntests": 46
     },
     "sage.modular.modform.ring": {
@@ -2943,11 +2930,9 @@
         "ntests": 15
     },
     "sage.modular.modform.vm_basis": {
-        "failed": true,
         "ntests": 27
     },
     "sage.modular.modform.weight1": {
-        "failed": true,
         "ntests": 10
     },
     "sage.modular.modform_hecketriangle.abstract_ring": {
@@ -2964,6 +2949,9 @@
         "failed": true,
         "ntests": 442
     },
+    "sage.modular.modsym.apply": {
+        "ntests": 6
+    },
     "sage.modular.modsym.boundary": {
         "failed": true,
         "ntests": 200
@@ -2979,11 +2967,13 @@
         "ntests": 23
     },
     "sage.modular.modsym.hecke_operator": {
-        "failed": true,
         "ntests": 6
     },
-    "sage.modular.modsym.manin_symbol": {
+    "sage.modular.modsym.heilbronn": {
         "failed": true,
+        "ntests": 66
+    },
+    "sage.modular.modsym.manin_symbol": {
         "ntests": 111
     },
     "sage.modular.modsym.manin_symbol_list": {
@@ -2995,7 +2985,6 @@
         "ntests": 80
     },
     "sage.modular.modsym.modular_symbols": {
-        "failed": true,
         "ntests": 65
     },
     "sage.modular.modsym.p1list": {
@@ -3005,7 +2994,6 @@
         "ntests": 271
     },
     "sage.modular.modsym.relation_matrix": {
-        "failed": true,
         "ntests": 29
     },
     "sage.modular.modsym.relation_matrix_pyx": {
@@ -3020,7 +3008,6 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3029,6 +3016,9 @@
     "sage.modular.overconvergent.hecke_series": {
         "failed": true,
         "ntests": 76
+    },
+    "sage.modular.pollack_stevens.dist": {
+        "ntests": 168
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
@@ -3778,7 +3768,6 @@
         "ntests": 166
     },
     "sage.rings.laurent_series_ring_element": {
-        "failed": true,
         "ntests": 402
     },
     "sage.rings.localization": {
@@ -4468,6 +4457,10 @@
         "failed": true,
         "ntests": 227
     },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "failed": true,
+        "ntests": 37
+    },
     "sage.schemes.elliptic_curves.ec_database": {
         "failed": true,
         "ntests": 9
@@ -4949,7 +4942,6 @@
         "ntests": 160
     },
     "sage.structure.factorization": {
-        "failed": true,
         "ntests": 240
     },
     "sage.structure.factorization_integer": {
@@ -5101,7 +5093,6 @@
         "ntests": 245
     },
     "sage.tests.book_stein_modform": {
-        "failed": true,
         "ntests": 237
     },
     "sage.tests.cmdline": {

--- a/src/sage/all__sagemath_schemes.py
+++ b/src/sage/all__sagemath_schemes.py
@@ -11,7 +11,7 @@ This distribution makes the following features available::
     FeatureTestResult('sage.modular', True)
 """
 
-from .all__sagemath_modules import *
+from .all__sagemath_polyhedra import *
 
 from .all__sagemath_singular import *
 

--- a/src/sage/modular/all__sagemath_flint.py
+++ b/src/sage/modular/all__sagemath_flint.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-flint

--- a/src/sage/modular/hypergeometric_motive.py
+++ b/src/sage/modular/hypergeometric_motive.py
@@ -72,6 +72,7 @@ from sage.geometry.lattice_polytope import LatticePolytope
 from sage.matrix.constructor import matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.functional import cyclotomic_polynomial
+from sage.misc.lazy_import import lazy_import
 from sage.misc.misc_c import prod
 from sage.modular.hypergeometric_misc import hgm_coeffs
 from sage.modules.free_module_element import vector
@@ -85,8 +86,9 @@ from sage.rings.polynomial.polynomial_ring import polygen, polygens
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.power_series_ring import PowerSeriesRing
 from sage.rings.rational_field import QQ
-from sage.rings.universal_cyclotomic_field import UniversalCyclotomicField
 from sage.schemes.generic.spec import Spec
+
+lazy_import('sage.rings.universal_cyclotomic_field', 'UniversalCyclotomicField')
 
 
 def characteristic_polynomial_from_traces(traces, d, q, i, sign, deg=None, use_fe=True):
@@ -1493,6 +1495,7 @@ class HypergeometricData:
 
         With values in the :class:`UniversalCyclotomicField` (slow)::
 
+            sage: # needs sage.libs.gap sage.rings.number_field
             sage: from sage.modular.hypergeometric_motive import HypergeometricData as Hyp
             sage: H = Hyp(alpha_beta=([1/2]*4, [0]*4))
             sage: [H.H_value(3,i,-1) for i in range(1,3)]

--- a/src/sage/modular/modform/all__sagemath_flint.py
+++ b/src/sage/modular/modform/all__sagemath_flint.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-flint

--- a/src/sage/modular/modform/eis_series_cython.pyx
+++ b/src/sage/modular/modform/eis_series_cython.pyx
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 """
 Eisenstein series, optimized
 """

--- a/src/sage/modular/modsym/all__sagemath_flint.py
+++ b/src/sage/modular/modsym/all__sagemath_flint.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-flint

--- a/src/sage/modular/modsym/apply.pxd
+++ b/src/sage/modular/modsym/apply.pxd
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 from sage.libs.flint.types cimport fmpz_poly_t
 
 cdef class Apply:

--- a/src/sage/modular/modsym/apply.pyx
+++ b/src/sage/modular/modsym/apply.pyx
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 # distutils: extra_compile_args = -D_XPG6
 """
 Monomial expansion of `(aX + bY)^i (cX + dY)^{j-i}`

--- a/src/sage/modular/modsym/heilbronn.pyx
+++ b/src/sage/modular/modsym/heilbronn.pyx
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 # distutils: extra_compile_args = -D_XPG6
 """
 Heilbronn matrix computation

--- a/src/sage/modular/pollack_stevens/all__sagemath_flint.py
+++ b/src/sage/modular/pollack_stevens/all__sagemath_flint.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-flint

--- a/src/sage/modular/pollack_stevens/dist.pxd
+++ b/src/sage/modular/pollack_stevens/dist.pxd
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 from sage.structure.sage_object cimport SageObject
 from sage.structure.element cimport ModuleElement
 from sage.categories.action cimport Action

--- a/src/sage/modular/pollack_stevens/dist.pyx
+++ b/src/sage/modular/pollack_stevens/dist.pyx
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 # distutils: libraries = gmp
 # distutils: extra_compile_args = -D_XPG6
 """

--- a/src/sage/schemes/all__sagemath_flint.py
+++ b/src/sage/schemes/all__sagemath_flint.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-flint

--- a/src/sage/schemes/elliptic_curves/all__sagemath_flint.py
+++ b/src/sage/schemes/elliptic_curves/all__sagemath_flint.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-flint

--- a/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
+++ b/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-flint
 r"""
 Descent on elliptic curves over `\QQ` with a 2-isogeny
 """

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -510,7 +510,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, -1, 1, -29372, -1932937])
             sage: E.conductor(algorithm='pari')
             3006
-            sage: E.conductor(algorithm='mwrank')
+            sage: E.conductor(algorithm='mwrank')               # needs eclib
             3006
             sage: E.conductor(algorithm='gp')
             3006
@@ -2883,7 +2883,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve('37a1')
             sage: E.silverman_height_bound()
             4.825400758180918
-            sage: E.silverman_height_bound(algorithm='mwrank')
+            sage: E.silverman_height_bound(algorithm='mwrank')  # needs eclib
             4.825400758180918
             sage: E.CPS_height_bound()
             0.16397076103046915
@@ -3002,7 +3002,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, 1, 1, 508, -2551])
             sage: E.selmer_rank()
             4
-            sage: E.selmer_rank(algorithm='mwrank')
+            sage: E.selmer_rank(algorithm='mwrank')             # needs eclib
             4
 
         The following is the curve 960d1, which has rank 0, but
@@ -3011,7 +3011,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([0, -1, 0, -900, -10098])
             sage: E.selmer_rank()
             3
-            sage: E.selmer_rank(algorithm='mwrank')
+            sage: E.selmer_rank(algorithm='mwrank')             # needs eclib
             3
 
         This curve has rank 1, and 4 elements in Sha[2].
@@ -3071,7 +3071,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([0, -1, 1, -929, -10595])
             sage: E.rank_bound()
             0
-            sage: E.rank_bound(algorithm='mwrank')
+            sage: E.rank_bound(algorithm='mwrank')              # needs eclib
             2
 
         In the following last example, both algorithm only determine a rank bound larger than the actual rank::
@@ -3079,7 +3079,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, 1, 1, -896670, -327184905])
             sage: E.rank_bound()
             2
-            sage: E.rank_bound(algorithm='mwrank')
+            sage: E.rank_bound(algorithm='mwrank')              # needs eclib
             2
             sage: E.rank(only_use_mwrank=False) # uses L-function
             0


### PR DESCRIPTION
- **pkgs/sagemath-flint: Add modules from sage.modular, sage.schemes.elliptic_curves**
- **./sage --fixdoctests --distribution 'sagemath-schemes' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-schemes[pari]' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-schemes[ntl]' --update-known-test-failures**
- **src/sage/all__sagemath_schemes.py: Import from all__sagemath_polyhedra.py**
- **./sage --fixdoctests --distribution 'sagemath-schemes' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-schemes[ntl]' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-schemes[pari]' --update-known-test-failures**
- **src/sage/modular/hypergeometric_motive.py: Use lazy_import**
- **src/sage/schemes/elliptic_curves/ell_rational_field.py: Add # needs**
