### PR TITLE
pkgs/sagemath-polyhedra: Fix extra standard, modularization fixes

### DIFF
--- a/build/pkgs/sagemath_polyhedra/dependencies_check
+++ b/build/pkgs/sagemath_polyhedra/dependencies_check
@@ -1,1 +1,1 @@
-tox sagemath_repl flint fpylll sagemath_linbox sagemath_glpk sagemath_graphs sagemath_groups sagemath_pari sagemath_plot
+tox sagemath_repl flint fpylll sagemath_linbox sagemath_glpk sagemath_graphs sagemath_groups sagemath_pari sagemath_plot sagemath_cddlib

--- a/pkgs/sagemath-polyhedra/known-test-failures--standard.json
+++ b/pkgs/sagemath-polyhedra/known-test-failures--standard.json
@@ -3,7 +3,7 @@
         "ntests": 618
     },
     "sage.algebras.clifford_algebra_element": {
-        "ntests": 148
+        "ntests": 153
     },
     "sage.algebras.commutative_dga": {
         "ntests": 7
@@ -24,8 +24,11 @@
         "ntests": 59
     },
     "sage.algebras.finite_gca": {
+        "ntests": 89
+    },
+    "sage.algebras.group_algebra": {
         "failed": true,
-        "ntests": 91
+        "ntests": 43
     },
     "sage.algebras.octonion_algebra": {
         "failed": true,
@@ -33,16 +36,25 @@
     },
     "sage.algebras.orlik_solomon": {
         "failed": true,
-        "ntests": 88
+        "ntests": 192
     },
     "sage.algebras.orlik_terao": {
-        "ntests": 89
+        "ntests": 183
     },
     "sage.algebras.weyl_algebra": {
         "ntests": 4
     },
     "sage.all__sagemath_flint": {
         "ntests": 5
+    },
+    "sage.all__sagemath_gap": {
+        "ntests": 2
+    },
+    "sage.all__sagemath_graphs": {
+        "ntests": 2
+    },
+    "sage.all__sagemath_groups": {
+        "ntests": 2
     },
     "sage.all__sagemath_modules": {
         "ntests": 4
@@ -91,7 +103,7 @@
         "ntests": 17
     },
     "sage.calculus.transforms.dft": {
-        "ntests": 117
+        "ntests": 120
     },
     "sage.calculus.transforms.dwt": {
         "ntests": 13
@@ -106,7 +118,6 @@
         "ntests": 9
     },
     "sage.categories.additive_magmas": {
-        "failed": true,
         "ntests": 161
     },
     "sage.categories.additive_monoids": {
@@ -119,7 +130,8 @@
         "ntests": 15
     },
     "sage.categories.algebra_functor": {
-        "ntests": 5
+        "failed": true,
+        "ntests": 154
     },
     "sage.categories.algebra_ideals": {
         "ntests": 8
@@ -128,7 +140,7 @@
         "ntests": 9
     },
     "sage.categories.algebras": {
-        "ntests": 23
+        "ntests": 26
     },
     "sage.categories.algebras_with_basis": {
         "ntests": 16
@@ -152,7 +164,8 @@
         "ntests": 42
     },
     "sage.categories.category": {
-        "ntests": 433
+        "failed": true,
+        "ntests": 438
     },
     "sage.categories.category_cy_helper": {
         "ntests": 27
@@ -161,19 +174,19 @@
         "ntests": 59
     },
     "sage.categories.category_types": {
-        "ntests": 80
+        "ntests": 89
     },
     "sage.categories.category_with_axiom": {
         "ntests": 328
     },
     "sage.categories.chain_complexes": {
-        "ntests": 26
+        "ntests": 35
     },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
     "sage.categories.coalgebras_with_basis": {
-        "ntests": 20
+        "ntests": 28
     },
     "sage.categories.coercion_methods": {
         "ntests": 6
@@ -207,14 +220,13 @@
         "ntests": 16
     },
     "sage.categories.complex_reflection_or_generalized_coxeter_groups": {
-        "ntests": 36
+        "ntests": 141
     },
     "sage.categories.covariant_functorial_construction": {
         "ntests": 65
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
-        "ntests": 368
+        "ntests": 390
     },
     "sage.categories.crystals": {
         "ntests": 1
@@ -290,6 +302,9 @@
     "sage.categories.examples.graphs": {
         "ntests": 24
     },
+    "sage.categories.examples.hopf_algebras_with_basis": {
+        "ntests": 23
+    },
     "sage.categories.examples.infinite_enumerated_sets": {
         "ntests": 35
     },
@@ -352,7 +367,7 @@
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "failed": true,
-        "ntests": 128
+        "ntests": 234
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -368,16 +383,18 @@
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
         "failed": true,
-        "ntests": 172
+        "ntests": 178
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
-        "ntests": 158
+        "failed": true,
+        "ntests": 181
     },
     "sage.categories.finite_dimensional_nilpotent_lie_algebras_with_basis": {
         "ntests": 19
     },
     "sage.categories.finite_dimensional_semisimple_algebras_with_basis": {
-        "ntests": 11
+        "failed": true,
+        "ntests": 19
     },
     "sage.categories.finite_enumerated_sets": {
         "ntests": 123
@@ -386,16 +403,17 @@
         "ntests": 14
     },
     "sage.categories.finite_groups": {
-        "ntests": 1
+        "ntests": 39
     },
     "sage.categories.finite_lattice_posets": {
         "ntests": 31
     },
     "sage.categories.finite_monoids": {
-        "ntests": 28
+        "ntests": 48
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "failed": true,
+        "ntests": 30
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -477,10 +495,13 @@
         "ntests": 25
     },
     "sage.categories.group_algebras": {
-        "ntests": 30
+        "ntests": 50
+    },
+    "sage.categories.groupoid": {
+        "ntests": 9
     },
     "sage.categories.groups": {
-        "ntests": 48
+        "ntests": 74
     },
     "sage.categories.h_trivial_semigroups": {
         "ntests": 4
@@ -489,16 +510,16 @@
         "ntests": 16
     },
     "sage.categories.homset": {
-        "ntests": 222
+        "ntests": 272
     },
     "sage.categories.homsets": {
         "ntests": 56
     },
     "sage.categories.hopf_algebras": {
-        "ntests": 15
+        "ntests": 19
     },
     "sage.categories.hopf_algebras_with_basis": {
-        "ntests": 30
+        "ntests": 43
     },
     "sage.categories.infinite_enumerated_sets": {
         "ntests": 13
@@ -532,7 +553,7 @@
     },
     "sage.categories.lie_algebras": {
         "failed": true,
-        "ntests": 120
+        "ntests": 118
     },
     "sage.categories.lie_algebras_with_basis": {
         "failed": true,
@@ -551,7 +572,8 @@
         "ntests": 1
     },
     "sage.categories.magmas": {
-        "ntests": 147
+        "failed": true,
+        "ntests": 159
     },
     "sage.categories.magmas_and_additive_magmas": {
         "ntests": 21
@@ -578,16 +600,18 @@
         "ntests": 145
     },
     "sage.categories.modules_with_basis": {
-        "ntests": 496
+        "failed": true,
+        "ntests": 501
     },
     "sage.categories.monoid_algebras": {
         "ntests": 4
     },
     "sage.categories.monoids": {
-        "ntests": 85
+        "failed": true,
+        "ntests": 98
     },
     "sage.categories.morphism": {
-        "ntests": 146
+        "ntests": 152
     },
     "sage.categories.noetherian_rings": {
         "ntests": 19
@@ -613,15 +637,19 @@
     "sage.categories.poor_man_map": {
         "ntests": 59
     },
+    "sage.categories.posets": {
+        "failed": true,
+        "ntests": 147
+    },
     "sage.categories.primer": {
-        "ntests": 163
+        "ntests": 167
     },
     "sage.categories.principal_ideal_domains": {
         "ntests": 45
     },
     "sage.categories.pushout": {
         "failed": true,
-        "ntests": 857
+        "ntests": 887
     },
     "sage.categories.quantum_group_representations": {
         "ntests": 13
@@ -655,7 +683,7 @@
         "ntests": 39
     },
     "sage.categories.semigroups": {
-        "ntests": 102
+        "ntests": 132
     },
     "sage.categories.semirings": {
         "ntests": 6
@@ -664,7 +692,8 @@
         "ntests": 15
     },
     "sage.categories.sets_cat": {
-        "ntests": 432
+        "failed": true,
+        "ntests": 441
     },
     "sage.categories.sets_with_grading": {
         "ntests": 23
@@ -682,7 +711,7 @@
         "ntests": 17
     },
     "sage.categories.simplicial_sets": {
-        "ntests": 55
+        "ntests": 176
     },
     "sage.categories.subobjects": {
         "ntests": 2
@@ -724,7 +753,8 @@
         "ntests": 39
     },
     "sage.categories.unital_algebras": {
-        "ntests": 36
+        "failed": true,
+        "ntests": 43
     },
     "sage.categories.vector_spaces": {
         "ntests": 44
@@ -740,7 +770,7 @@
         "ntests": 82
     },
     "sage.coding.binary_code": {
-        "ntests": 337
+        "ntests": 367
     },
     "sage.coding.bounds_catalog": {
         "ntests": 1
@@ -756,7 +786,13 @@
     },
     "sage.coding.code_constructions": {
         "failed": true,
-        "ntests": 118
+        "ntests": 144
+    },
+    "sage.coding.codecan.autgroup_can_label": {
+        "ntests": 82
+    },
+    "sage.coding.codecan.codecan": {
+        "ntests": 71
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
@@ -766,7 +802,7 @@
         "ntests": 274
     },
     "sage.coding.databases": {
-        "ntests": 3
+        "ntests": 7
     },
     "sage.coding.decoder": {
         "ntests": 62
@@ -822,10 +858,10 @@
     },
     "sage.coding.linear_code": {
         "failed": true,
-        "ntests": 354
+        "ntests": 404
     },
     "sage.coding.linear_code_no_metric": {
-        "ntests": 232
+        "ntests": 249
     },
     "sage.coding.linear_rank_metric": {
         "ntests": 138
@@ -839,20 +875,53 @@
     "sage.coding.reed_muller_code": {
         "ntests": 168
     },
+    "sage.coding.self_dual_codes": {
+        "ntests": 26
+    },
     "sage.coding.source_coding.huffman": {
         "ntests": 64
     },
     "sage.coding.subfield_subcode": {
         "ntests": 65
     },
+    "sage.coding.two_weight_db": {
+        "failed": true,
+        "ntests": 2
+    },
+    "sage.combinat.abstract_tree": {
+        "ntests": 422
+    },
     "sage.combinat.backtrack": {
         "ntests": 28
+    },
+    "sage.combinat.binary_tree": {
+        "ntests": 706
     },
     "sage.combinat.cartesian_product": {
         "ntests": 68
     },
+    "sage.combinat.cluster_algebra_quiver.cluster_seed": {
+        "failed": true,
+        "ntests": 674
+    },
+    "sage.combinat.cluster_algebra_quiver.interact": {
+        "ntests": 2
+    },
+    "sage.combinat.cluster_algebra_quiver.mutation_class": {
+        "ntests": 66
+    },
+    "sage.combinat.cluster_algebra_quiver.mutation_type": {
+        "ntests": 73
+    },
+    "sage.combinat.cluster_algebra_quiver.quiver": {
+        "failed": true,
+        "ntests": 312
+    },
+    "sage.combinat.cluster_algebra_quiver.quiver_mutation_type": {
+        "ntests": 244
+    },
     "sage.combinat.combinat": {
-        "ntests": 249
+        "ntests": 263
     },
     "sage.combinat.combinat_cython": {
         "ntests": 22
@@ -866,11 +935,89 @@
     "sage.combinat.composition": {
         "ntests": 287
     },
+    "sage.combinat.designs.MOLS_handbook_data": {
+        "ntests": 7
+    },
+    "sage.combinat.designs.bibd": {
+        "ntests": 127
+    },
+    "sage.combinat.designs.block_design": {
+        "failed": true,
+        "ntests": 83
+    },
+    "sage.combinat.designs.covering_array": {
+        "ntests": 31
+    },
+    "sage.combinat.designs.covering_design": {
+        "ntests": 46
+    },
+    "sage.combinat.designs.database": {
+        "failed": true,
+        "ntests": 409
+    },
+    "sage.combinat.designs.design_catalog": {
+        "ntests": 2
+    },
+    "sage.combinat.designs.designs_pyx": {
+        "failed": true,
+        "ntests": 86
+    },
+    "sage.combinat.designs.difference_family": {
+        "failed": true,
+        "ntests": 391
+    },
+    "sage.combinat.designs.difference_matrices": {
+        "ntests": 20
+    },
+    "sage.combinat.designs.evenly_distributed_sets": {
+        "ntests": 50
+    },
+    "sage.combinat.designs.ext_rep": {
+        "failed": true,
+        "ntests": 0
+    },
+    "sage.combinat.designs.gen_quadrangles_with_spread": {
+        "ntests": 51
+    },
+    "sage.combinat.designs.group_divisible_designs": {
+        "ntests": 24
+    },
+    "sage.combinat.designs.incidence_structures": {
+        "failed": true,
+        "ntests": 297
+    },
+    "sage.combinat.designs.latin_squares": {
+        "ntests": 36
+    },
+    "sage.combinat.designs.orthogonal_arrays_build_recursive": {
+        "ntests": 47
+    },
+    "sage.combinat.designs.resolvable_bibd": {
+        "ntests": 22
+    },
+    "sage.combinat.designs.steiner_quadruple_systems": {
+        "ntests": 36
+    },
+    "sage.combinat.designs.subhypergraph_search": {
+        "ntests": 12
+    },
+    "sage.combinat.designs.twographs": {
+        "ntests": 33
+    },
     "sage.combinat.dlx": {
         "ntests": 65
     },
+    "sage.combinat.finite_state_machine": {
+        "ntests": 2033
+    },
+    "sage.combinat.finite_state_machine_generators": {
+        "ntests": 172
+    },
     "sage.combinat.free_module": {
         "ntests": 401
+    },
+    "sage.combinat.graph_path": {
+        "ntests": 95
     },
     "sage.combinat.integer_lists.base": {
         "ntests": 116
@@ -888,8 +1035,10 @@
         "ntests": 254
     },
     "sage.combinat.integer_vector_weighted": {
-        "failed": true,
-        "ntests": 52
+        "ntests": 45
+    },
+    "sage.combinat.interval_posets": {
+        "ntests": 539
     },
     "sage.combinat.matrices.dancing_links": {
         "ntests": 250
@@ -897,59 +1046,130 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 13
     },
+    "sage.combinat.ordered_tree": {
+        "ntests": 240
+    },
     "sage.combinat.permutation": {
-        "ntests": 1195
+        "failed": true,
+        "ntests": 1235
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.posets.cartesian_product": {
+        "ntests": 75
+    },
+    "sage.combinat.posets.elements": {
+        "ntests": 67
+    },
+    "sage.combinat.posets.hasse_cython": {
+        "ntests": 27
+    },
+    "sage.combinat.posets.hasse_cython_flint": {
+        "ntests": 21
+    },
+    "sage.combinat.posets.hasse_diagram": {
+        "ntests": 581
+    },
+    "sage.combinat.posets.incidence_algebras": {
+        "ntests": 165
+    },
+    "sage.combinat.posets.lattices": {
+        "failed": true,
+        "ntests": 612
+    },
+    "sage.combinat.posets.linear_extension_iterator": {
+        "ntests": 13
+    },
+    "sage.combinat.posets.linear_extensions": {
+        "ntests": 174
+    },
+    "sage.combinat.posets.mobile": {
+        "failed": true,
+        "ntests": 36
+    },
+    "sage.combinat.posets.moebius_algebra": {
+        "ntests": 118
+    },
+    "sage.combinat.posets.poset_examples": {
+        "ntests": 1
+    },
+    "sage.combinat.posets.posets": {
+        "failed": true,
+        "ntests": 1469
     },
     "sage.combinat.ranker": {
         "ntests": 48
     },
     "sage.combinat.root_system.ambient_space": {
-        "ntests": 82
+        "ntests": 84
     },
     "sage.combinat.root_system.associahedron": {
         "ntests": 4
     },
+    "sage.combinat.root_system.braid_move_calculator": {
+        "ntests": 17
+    },
     "sage.combinat.root_system.braid_orbit": {
         "ntests": 11
     },
+    "sage.combinat.root_system.branching_rules": {
+        "ntests": 255
+    },
     "sage.combinat.root_system.cartan_matrix": {
-        "ntests": 64
+        "ntests": 176
     },
     "sage.combinat.root_system.cartan_type": {
-        "failed": true,
-        "ntests": 394
+        "ntests": 460
     },
     "sage.combinat.root_system.coxeter_group": {
+        "failed": true,
         "ntests": 13
     },
+    "sage.combinat.root_system.coxeter_matrix": {
+        "ntests": 181
+    },
     "sage.combinat.root_system.coxeter_type": {
-        "ntests": 81
+        "ntests": 85
+    },
+    "sage.combinat.root_system.extended_affine_weyl_group": {
+        "ntests": 408
+    },
+    "sage.combinat.root_system.fundamental_group": {
+        "ntests": 155
     },
     "sage.combinat.root_system.hecke_algebra_representation": {
-        "ntests": 1
+        "failed": true,
+        "ntests": 292
     },
     "sage.combinat.root_system.integrable_representations": {
-        "ntests": 4
+        "ntests": 156
     },
     "sage.combinat.root_system.non_symmetric_macdonald_polynomials": {
-        "ntests": 27
+        "failed": true,
+        "ntests": 506
+    },
+    "sage.combinat.root_system.pieri_factors": {
+        "ntests": 225
+    },
+    "sage.combinat.root_system.reflection_group_c": {
+        "ntests": 51
+    },
+    "sage.combinat.root_system.reflection_group_element": {
+        "ntests": 101
     },
     "sage.combinat.root_system.root_lattice_realization_algebras": {
         "failed": true,
-        "ntests": 284
+        "ntests": 311
     },
     "sage.combinat.root_system.root_lattice_realizations": {
-        "failed": true,
-        "ntests": 488
+        "ntests": 623
     },
     "sage.combinat.root_system.root_space": {
-        "ntests": 78
+        "ntests": 88
     },
     "sage.combinat.root_system.root_system": {
-        "ntests": 123
+        "ntests": 136
     },
     "sage.combinat.root_system.type_A": {
         "ntests": 48
@@ -967,7 +1187,7 @@
         "ntests": 41
     },
     "sage.combinat.root_system.type_B_affine": {
-        "ntests": 20
+        "ntests": 26
     },
     "sage.combinat.root_system.type_C": {
         "ntests": 40
@@ -982,10 +1202,10 @@
         "ntests": 22
     },
     "sage.combinat.root_system.type_E": {
-        "ntests": 46
+        "ntests": 52
     },
     "sage.combinat.root_system.type_E_affine": {
-        "ntests": 19
+        "ntests": 23
     },
     "sage.combinat.root_system.type_F": {
         "ntests": 39
@@ -1009,13 +1229,13 @@
         "ntests": 25
     },
     "sage.combinat.root_system.type_affine": {
-        "ntests": 67
+        "ntests": 72
     },
     "sage.combinat.root_system.type_dual": {
         "ntests": 126
     },
     "sage.combinat.root_system.type_folded": {
-        "ntests": 31
+        "ntests": 38
     },
     "sage.combinat.root_system.type_marked": {
         "ntests": 119
@@ -1030,25 +1250,44 @@
         "ntests": 127
     },
     "sage.combinat.root_system.weight_lattice_realizations": {
-        "ntests": 135
+        "ntests": 221
     },
     "sage.combinat.root_system.weight_space": {
         "ntests": 109
+    },
+    "sage.combinat.root_system.weyl_characters": {
+        "failed": true,
+        "ntests": 273
+    },
+    "sage.combinat.root_system.weyl_group": {
+        "ntests": 254
+    },
+    "sage.combinat.rooted_tree": {
+        "ntests": 162
+    },
+    "sage.combinat.shard_order": {
+        "ntests": 40
     },
     "sage.combinat.subset": {
         "ntests": 281
     },
     "sage.combinat.subsets_hereditary": {
-        "ntests": 7
+        "ntests": 16
     },
     "sage.combinat.subsets_pairwise": {
         "ntests": 32
+    },
+    "sage.combinat.tamari_lattices": {
+        "ntests": 36
     },
     "sage.combinat.tools": {
         "ntests": 2
     },
     "sage.combinat.tuple": {
         "ntests": 33
+    },
+    "sage.combinat.yang_baxter_graph": {
+        "ntests": 181
     },
     "sage.cpython.atexit": {
         "ntests": 19
@@ -1086,15 +1325,6 @@
     "sage.crypto.boolean_function": {
         "ntests": 206
     },
-    "sage.crypto.classical": {
-        "ntests": 13
-    },
-    "sage.crypto.classical_cipher": {
-        "ntests": 2
-    },
-    "sage.crypto.cryptosystem": {
-        "ntests": 14
-    },
     "sage.crypto.key_exchange.catalog": {
         "ntests": 1
     },
@@ -1115,7 +1345,7 @@
     },
     "sage.crypto.mq.rijndael_gf": {
         "failed": true,
-        "ntests": 342
+        "ntests": 362
     },
     "sage.crypto.mq.sr": {
         "ntests": 355
@@ -1146,14 +1376,17 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
+    "sage.databases.knotinfo_db": {
+        "ntests": 100
+    },
     "sage.databases.sql_db": {
-        "ntests": 230
+        "ntests": 248
     },
     "sage.doctest.check_tolerance": {
         "ntests": 19
     },
     "sage.doctest.control": {
-        "ntests": 3
+        "ntests": 1
     },
     "sage.doctest.external": {
         "ntests": 42
@@ -1163,14 +1396,13 @@
     },
     "sage.doctest.forker": {
         "failed": true,
-        "ntests": 389
+        "ntests": 269
     },
     "sage.doctest.marked_output": {
         "ntests": 21
     },
     "sage.doctest.parsing": {
-        "failed": true,
-        "ntests": 277
+        "ntests": 275
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -1240,6 +1472,9 @@
     "sage.features.fricas": {
         "ntests": 6
     },
+    "sage.features.frobby": {
+        "ntests": 4
+    },
     "sage.features.gap": {
         "ntests": 6
     },
@@ -1268,7 +1503,6 @@
         "ntests": 5
     },
     "sage.features.jmol": {
-        "failed": true,
         "ntests": 4
     },
     "sage.features.join_feature": {
@@ -1285,6 +1519,9 @@
     },
     "sage.features.lrs": {
         "ntests": 16
+    },
+    "sage.features.macaulay2": {
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1325,12 +1562,14 @@
     "sage.features.poppler": {
         "ntests": 4
     },
+    "sage.features.qepcad": {
+        "ntests": 4
+    },
     "sage.features.rubiks": {
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "failed": true,
-        "ntests": 188
+        "ntests": 193
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1345,6 +1584,9 @@
         "ntests": 8
     },
     "sage.features.symengine_py": {
+        "ntests": 4
+    },
+    "sage.features.sympow": {
         "ntests": 4
     },
     "sage.features.tdlib": {
@@ -1431,6 +1673,9 @@
     "sage.game_theory.cooperative_game": {
         "ntests": 101
     },
+    "sage.game_theory.matching_game": {
+        "ntests": 304
+    },
     "sage.game_theory.normal_form_game": {
         "ntests": 602
     },
@@ -1441,8 +1686,7 @@
         "ntests": 15
     },
     "sage.geometry.cone": {
-        "failed": true,
-        "ntests": 1130
+        "ntests": 1206
     },
     "sage.geometry.cone_catalog": {
         "ntests": 101
@@ -1455,7 +1699,7 @@
         "ntests": 148
     },
     "sage.geometry.fan": {
-        "ntests": 4
+        "ntests": 2
     },
     "sage.geometry.fan_isomorphism": {
         "ntests": 65
@@ -1468,19 +1712,17 @@
     },
     "sage.geometry.hyperplane_arrangement.arrangement": {
         "failed": true,
-        "ntests": 460
+        "ntests": 540
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
         "failed": true,
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
-        "failed": true,
-        "ntests": 24
+        "ntests": 47
     },
     "sage.geometry.hyperplane_arrangement.ordered_arrangement": {
-        "failed": true,
-        "ntests": 38
+        "ntests": 57
     },
     "sage.geometry.hyperplane_arrangement.plot": {
         "failed": true,
@@ -1491,7 +1733,7 @@
     },
     "sage.geometry.lattice_polytope": {
         "failed": true,
-        "ntests": 618
+        "ntests": 659
     },
     "sage.geometry.linear_expression": {
         "ntests": 165
@@ -1499,20 +1741,26 @@
     "sage.geometry.newton_polygon": {
         "ntests": 110
     },
+    "sage.geometry.palp_normal_form": {
+        "ntests": 15
+    },
     "sage.geometry.point_collection": {
         "ntests": 111
+    },
+    "sage.geometry.polyhedral_complex": {
+        "ntests": 457
     },
     "sage.geometry.polyhedron.backend_cdd": {
         "ntests": 33
     },
     "sage.geometry.polyhedron.backend_cdd_rdf": {
-        "ntests": 34
+        "ntests": 39
     },
     "sage.geometry.polyhedron.backend_field": {
         "ntests": 64
     },
     "sage.geometry.polyhedron.backend_normaliz": {
-        "ntests": 21
+        "ntests": 15
     },
     "sage.geometry.polyhedron.backend_number_field": {
         "ntests": 27
@@ -1524,7 +1772,7 @@
         "ntests": 90
     },
     "sage.geometry.polyhedron.base": {
-        "ntests": 150
+        "ntests": 174
     },
     "sage.geometry.polyhedron.base0": {
         "ntests": 212
@@ -1537,10 +1785,10 @@
         "ntests": 96
     },
     "sage.geometry.polyhedron.base3": {
-        "ntests": 320
+        "ntests": 326
     },
     "sage.geometry.polyhedron.base4": {
-        "ntests": 10
+        "ntests": 191
     },
     "sage.geometry.polyhedron.base5": {
         "ntests": 382
@@ -1550,7 +1798,7 @@
         "ntests": 247
     },
     "sage.geometry.polyhedron.base7": {
-        "ntests": 128
+        "ntests": 138
     },
     "sage.geometry.polyhedron.base_QQ": {
         "ntests": 112
@@ -1559,7 +1807,6 @@
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
-        "failed": true,
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
@@ -1572,7 +1819,7 @@
         "ntests": 10
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.base": {
-        "ntests": 581
+        "ntests": 596
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.combinatorial_face": {
         "ntests": 180
@@ -1581,7 +1828,7 @@
         "ntests": 58
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.face_iterator": {
-        "ntests": 364
+        "ntests": 391
     },
     "sage.geometry.polyhedron.combinatorial_polyhedron.list_of_faces": {
         "ntests": 67
@@ -1605,8 +1852,7 @@
         "ntests": 27
     },
     "sage.geometry.polyhedron.library": {
-        "failed": true,
-        "ntests": 314
+        "ntests": 320
     },
     "sage.geometry.polyhedron.misc": {
         "ntests": 12
@@ -1622,13 +1868,13 @@
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
-        "ntests": 225
+        "ntests": 247
     },
     "sage.geometry.polyhedron.ppl_lattice_polygon": {
         "ntests": 81
     },
     "sage.geometry.polyhedron.ppl_lattice_polytope": {
-        "ntests": 166
+        "ntests": 176
     },
     "sage.geometry.polyhedron.representation": {
         "ntests": 343
@@ -1639,6 +1885,9 @@
     "sage.geometry.relative_interior": {
         "ntests": 88
     },
+    "sage.geometry.ribbon_graph": {
+        "ntests": 224
+    },
     "sage.geometry.toric_lattice": {
         "ntests": 302
     },
@@ -1647,7 +1896,7 @@
     },
     "sage.geometry.toric_plotter": {
         "failed": true,
-        "ntests": 89
+        "ntests": 100
     },
     "sage.geometry.triangulation.base": {
         "ntests": 173
@@ -1656,19 +1905,269 @@
         "ntests": 116
     },
     "sage.geometry.triangulation.point_configuration": {
-        "ntests": 214
+        "ntests": 250
     },
     "sage.geometry.voronoi_diagram": {
         "ntests": 32
     },
-    "sage.graphs.matchpoly": {
+    "sage.graphs.all": {
         "ntests": 3
     },
+    "sage.graphs.asteroidal_triples": {
+        "ntests": 13
+    },
+    "sage.graphs.base.boost_graph": {
+        "ntests": 205
+    },
+    "sage.graphs.base.c_graph": {
+        "ntests": 773
+    },
+    "sage.graphs.base.dense_graph": {
+        "ntests": 86
+    },
+    "sage.graphs.base.graph_backends": {
+        "ntests": 85
+    },
+    "sage.graphs.base.overview": {
+        "ntests": 1
+    },
+    "sage.graphs.base.sparse_graph": {
+        "ntests": 133
+    },
+    "sage.graphs.base.static_dense_graph": {
+        "ntests": 110
+    },
+    "sage.graphs.base.static_sparse_backend": {
+        "ntests": 181
+    },
+    "sage.graphs.base.static_sparse_graph": {
+        "ntests": 91
+    },
+    "sage.graphs.bipartite_graph": {
+        "ntests": 431
+    },
+    "sage.graphs.centrality": {
+        "ntests": 31
+    },
+    "sage.graphs.chrompoly": {
+        "ntests": 41
+    },
+    "sage.graphs.cliquer": {
+        "ntests": 34
+    },
+    "sage.graphs.comparability": {
+        "ntests": 52
+    },
+    "sage.graphs.connectivity": {
+        "ntests": 580
+    },
+    "sage.graphs.convexity_properties": {
+        "ntests": 67
+    },
+    "sage.graphs.digraph": {
+        "failed": true,
+        "ntests": 569
+    },
+    "sage.graphs.digraph_generators": {
+        "ntests": 137
+    },
+    "sage.graphs.distances_all_pairs": {
+        "ntests": 165
+    },
+    "sage.graphs.domination": {
+        "ntests": 165
+    },
+    "sage.graphs.dot2tex_utils": {
+        "ntests": 6
+    },
+    "sage.graphs.edge_connectivity": {
+        "ntests": 101
+    },
+    "sage.graphs.generators.basic": {
+        "ntests": 128
+    },
+    "sage.graphs.generators.chessboard": {
+        "ntests": 42
+    },
+    "sage.graphs.generators.classical_geometries": {
+        "ntests": 111
+    },
+    "sage.graphs.generators.degree_sequence": {
+        "ntests": 13
+    },
+    "sage.graphs.generators.distance_regular": {
+        "failed": true,
+        "ntests": 166
+    },
+    "sage.graphs.generators.families": {
+        "failed": true,
+        "ntests": 415
+    },
+    "sage.graphs.generators.intersection": {
+        "ntests": 72
+    },
+    "sage.graphs.generators.platonic_solids": {
+        "ntests": 26
+    },
+    "sage.graphs.generators.random": {
+        "failed": true,
+        "ntests": 195
+    },
+    "sage.graphs.generators.smallgraphs": {
+        "failed": true,
+        "ntests": 448
+    },
+    "sage.graphs.generators.world_map": {
+        "ntests": 20
+    },
+    "sage.graphs.generic_graph": {
+        "failed": true,
+        "ntests": 3862
+    },
+    "sage.graphs.generic_graph_pyx": {
+        "ntests": 139
+    },
+    "sage.graphs.genus": {
+        "ntests": 42
+    },
+    "sage.graphs.graph": {
+        "failed": true,
+        "ntests": 1185
+    },
+    "sage.graphs.graph_coloring": {
+        "ntests": 160
+    },
+    "sage.graphs.graph_database": {
+        "ntests": 3
+    },
+    "sage.graphs.graph_decompositions.bandwidth": {
+        "ntests": 14
+    },
+    "sage.graphs.graph_decompositions.clique_separators": {
+        "ntests": 68
+    },
+    "sage.graphs.graph_decompositions.cutwidth": {
+        "ntests": 63
+    },
+    "sage.graphs.graph_decompositions.fast_digraph": {
+        "ntests": 11
+    },
+    "sage.graphs.graph_decompositions.graph_products": {
+        "ntests": 48
+    },
+    "sage.graphs.graph_decompositions.modular_decomposition": {
+        "ntests": 151
+    },
+    "sage.graphs.graph_decompositions.slice_decomposition": {
+        "ntests": 131
+    },
+    "sage.graphs.graph_decompositions.tree_decomposition": {
+        "ntests": 273
+    },
+    "sage.graphs.graph_decompositions.vertex_separation": {
+        "ntests": 173
+    },
+    "sage.graphs.graph_editor": {
+        "ntests": 8
+    },
+    "sage.graphs.graph_generators": {
+        "ntests": 174
+    },
+    "sage.graphs.graph_generators_pyx": {
+        "ntests": 7
+    },
+    "sage.graphs.graph_input": {
+        "ntests": 61
+    },
+    "sage.graphs.graph_latex": {
+        "failed": true,
+        "ntests": 198
+    },
+    "sage.graphs.graph_list": {
+        "ntests": 54
+    },
+    "sage.graphs.graph_plot": {
+        "ntests": 161
+    },
+    "sage.graphs.graph_plot_js": {
+        "ntests": 9
+    },
+    "sage.graphs.hyperbolicity": {
+        "ntests": 68
+    },
+    "sage.graphs.hypergraph_generators": {
+        "ntests": 29
+    },
+    "sage.graphs.independent_sets": {
+        "ntests": 56
+    },
+    "sage.graphs.isoperimetric_inequalities": {
+        "ntests": 25
+    },
+    "sage.graphs.line_graph": {
+        "ntests": 40
+    },
+    "sage.graphs.lovasz_theta": {
+        "ntests": 5
+    },
+    "sage.graphs.matching": {
+        "failed": true,
+        "ntests": 197
+    },
+    "sage.graphs.matchpoly": {
+        "ntests": 57
+    },
+    "sage.graphs.orientations": {
+        "ntests": 163
+    },
+    "sage.graphs.partial_cube": {
+        "ntests": 14
+    },
+    "sage.graphs.path_enumeration": {
+        "ntests": 267
+    },
+    "sage.graphs.pq_trees": {
+        "ntests": 90
+    },
+    "sage.graphs.print_graphs": {
+        "ntests": 12
+    },
+    "sage.graphs.spanning_tree": {
+        "ntests": 169
+    },
+    "sage.graphs.strongly_regular_db": {
+        "failed": true,
+        "ntests": 305
+    },
+    "sage.graphs.traversals": {
+        "ntests": 222
+    },
+    "sage.graphs.trees": {
+        "ntests": 25
+    },
+    "sage.graphs.tutte_polynomial": {
+        "ntests": 109
+    },
+    "sage.graphs.views": {
+        "ntests": 206
+    },
+    "sage.graphs.weakly_chordal": {
+        "ntests": 33
+    },
+    "sage.groups.abelian_gps.abelian_aut": {
+        "ntests": 123
+    },
     "sage.groups.abelian_gps.abelian_group": {
-        "ntests": 238
+        "ntests": 341
     },
     "sage.groups.abelian_gps.abelian_group_element": {
-        "ntests": 26
+        "ntests": 32
+    },
+    "sage.groups.abelian_gps.abelian_group_gap": {
+        "ntests": 261
+    },
+    "sage.groups.abelian_gps.abelian_group_morphism": {
+        "ntests": 44
     },
     "sage.groups.abelian_gps.dual_abelian_group": {
         "ntests": 97
@@ -1686,7 +2185,7 @@
         "ntests": 78
     },
     "sage.groups.additive_abelian.additive_abelian_wrapper": {
-        "ntests": 96
+        "ntests": 95
     },
     "sage.groups.additive_abelian.qmodnz": {
         "ntests": 37
@@ -1695,66 +2194,190 @@
         "ntests": 73
     },
     "sage.groups.affine_gps.affine_group": {
-        "ntests": 57
+        "ntests": 65
     },
     "sage.groups.affine_gps.euclidean_group": {
-        "ntests": 33
+        "ntests": 34
     },
     "sage.groups.affine_gps.group_element": {
-        "ntests": 92
+        "ntests": 101
+    },
+    "sage.groups.artin": {
+        "failed": true,
+        "ntests": 137
+    },
+    "sage.groups.braid": {
+        "failed": true,
+        "ntests": 517
+    },
+    "sage.groups.cactus_group": {
+        "ntests": 174
+    },
+    "sage.groups.class_function": {
+        "ntests": 314
+    },
+    "sage.groups.conjugacy_classes": {
+        "ntests": 135
+    },
+    "sage.groups.cubic_braid": {
+        "failed": true,
+        "ntests": 192
+    },
+    "sage.groups.finitely_presented": {
+        "failed": true,
+        "ntests": 380
+    },
+    "sage.groups.finitely_presented_named": {
+        "ntests": 79
+    },
+    "sage.groups.fqf_orthogonal": {
+        "ntests": 116
+    },
+    "sage.groups.free_group": {
+        "ntests": 190
     },
     "sage.groups.galois_group": {
-        "failed": true,
         "ntests": 90
+    },
+    "sage.groups.galois_group_perm": {
+        "ntests": 31
     },
     "sage.groups.generic": {
         "failed": true,
-        "ntests": 196
+        "ntests": 201
     },
     "sage.groups.group": {
-        "ntests": 45
+        "ntests": 55
+    },
+    "sage.groups.group_exp": {
+        "ntests": 73
+    },
+    "sage.groups.group_semidirect_product": {
+        "ntests": 82
+    },
+    "sage.groups.kernel_subgroup": {
+        "ntests": 55
+    },
+    "sage.groups.libgap_group": {
+        "ntests": 13
+    },
+    "sage.groups.libgap_mixin": {
+        "ntests": 180
+    },
+    "sage.groups.libgap_morphism": {
+        "ntests": 202
+    },
+    "sage.groups.libgap_wrapper": {
+        "ntests": 173
+    },
+    "sage.groups.lie_gps.nilpotent_lie_group": {
+        "failed": true,
+        "ntests": 186
+    },
+    "sage.groups.matrix_gps.binary_dihedral": {
+        "ntests": 8
     },
     "sage.groups.matrix_gps.coxeter_group": {
-        "ntests": 10
+        "failed": true,
+        "ntests": 119
     },
     "sage.groups.matrix_gps.finitely_generated": {
-        "ntests": 47
+        "ntests": 72
+    },
+    "sage.groups.matrix_gps.finitely_generated_gap": {
+        "failed": true,
+        "ntests": 188
     },
     "sage.groups.matrix_gps.group_element": {
-        "ntests": 33
+        "ntests": 38
+    },
+    "sage.groups.matrix_gps.group_element_gap": {
+        "ntests": 80
+    },
+    "sage.groups.matrix_gps.heisenberg": {
+        "failed": true,
+        "ntests": 36
+    },
+    "sage.groups.matrix_gps.isometries": {
+        "ntests": 103
     },
     "sage.groups.matrix_gps.linear": {
-        "ntests": 47
+        "ntests": 71
+    },
+    "sage.groups.matrix_gps.linear_gap": {
+        "ntests": 3
     },
     "sage.groups.matrix_gps.matrix_group": {
         "failed": true,
-        "ntests": 63
+        "ntests": 96
     },
-    "sage.groups.matrix_gps.named_group": {
-        "ntests": 21
-    },
-    "sage.groups.matrix_gps.orthogonal": {
+    "sage.groups.matrix_gps.matrix_group_gap": {
         "failed": true,
         "ntests": 57
     },
+    "sage.groups.matrix_gps.named_group": {
+        "ntests": 31
+    },
+    "sage.groups.matrix_gps.named_group_gap": {
+        "ntests": 3
+    },
+    "sage.groups.matrix_gps.orthogonal": {
+        "failed": true,
+        "ntests": 71
+    },
+    "sage.groups.matrix_gps.orthogonal_gap": {
+        "ntests": 19
+    },
     "sage.groups.matrix_gps.symplectic": {
-        "ntests": 24
+        "ntests": 30
+    },
+    "sage.groups.matrix_gps.symplectic_gap": {
+        "ntests": 6
     },
     "sage.groups.matrix_gps.unitary": {
         "failed": true,
-        "ntests": 50
+        "ntests": 58
+    },
+    "sage.groups.matrix_gps.unitary_gap": {
+        "ntests": 5
+    },
+    "sage.groups.misc_gps.argument_groups": {
+        "failed": true,
+        "ntests": 332
+    },
+    "sage.groups.misc_gps.imaginary_groups": {
+        "failed": true,
+        "ntests": 74
     },
     "sage.groups.old": {
-        "ntests": 31
+        "ntests": 35
+    },
+    "sage.groups.pari_group": {
+        "ntests": 45
+    },
+    "sage.groups.perm_gps.constructor": {
+        "ntests": 46
+    },
+    "sage.groups.perm_gps.cubegroup": {
+        "ntests": 137
+    },
+    "sage.groups.perm_gps.partn_ref.automorphism_group_canonical_label": {
+        "ntests": 32
     },
     "sage.groups.perm_gps.partn_ref.canonical_augmentation": {
         "ntests": 1
     },
     "sage.groups.perm_gps.partn_ref.data_structures": {
-        "ntests": 4
+        "ntests": 38
+    },
+    "sage.groups.perm_gps.partn_ref.double_coset": {
+        "ntests": 15
     },
     "sage.groups.perm_gps.partn_ref.refinement_binary": {
         "ntests": 75
+    },
+    "sage.groups.perm_gps.partn_ref.refinement_graphs": {
+        "ntests": 117
     },
     "sage.groups.perm_gps.partn_ref.refinement_lists": {
         "ntests": 3
@@ -1768,14 +2391,56 @@
     "sage.groups.perm_gps.partn_ref.refinement_sets": {
         "ntests": 156
     },
+    "sage.groups.perm_gps.partn_ref2.refinement_generic": {
+        "ntests": 39
+    },
+    "sage.groups.perm_gps.permgroup": {
+        "failed": true,
+        "ntests": 1008
+    },
+    "sage.groups.perm_gps.permgroup_element": {
+        "ntests": 402
+    },
+    "sage.groups.perm_gps.permgroup_morphism": {
+        "ntests": 90
+    },
+    "sage.groups.perm_gps.permgroup_named": {
+        "failed": true,
+        "ntests": 553
+    },
+    "sage.groups.perm_gps.symgp_conjugacy_class": {
+        "ntests": 47
+    },
+    "sage.groups.raag": {
+        "ntests": 181
+    },
+    "sage.groups.semimonomial_transformations.semimonomial_transformation": {
+        "failed": true,
+        "ntests": 57
+    },
+    "sage.groups.semimonomial_transformations.semimonomial_transformation_group": {
+        "failed": true,
+        "ntests": 62
+    },
+    "sage.homology.algebraic_topological_model": {
+        "ntests": 44
+    },
     "sage.homology.chain_complex": {
-        "ntests": 250
+        "ntests": 264
+    },
+    "sage.homology.chain_complex_homspace": {
+        "failed": true,
+        "ntests": 40
     },
     "sage.homology.chain_complex_morphism": {
-        "ntests": 37
+        "failed": true,
+        "ntests": 135
     },
     "sage.homology.chain_homotopy": {
-        "ntests": 87
+        "ntests": 96
+    },
+    "sage.homology.chains": {
+        "ntests": 136
     },
     "sage.homology.free_resolution": {
         "ntests": 2
@@ -1786,8 +2451,13 @@
     "sage.homology.homology_group": {
         "ntests": 23
     },
+    "sage.homology.homology_morphism": {
+        "failed": true,
+        "ntests": 100
+    },
     "sage.homology.homology_vector_space_with_basis": {
-        "ntests": 6
+        "failed": true,
+        "ntests": 290
     },
     "sage.homology.koszul_complex": {
         "ntests": 23
@@ -1798,11 +2468,16 @@
     "sage.interfaces.abc": {
         "ntests": 8
     },
-    "sage.interfaces.four_ti_2": {
-        "ntests": 54
+    "sage.interfaces.gap": {
+        "failed": true,
+        "ntests": 204
     },
-    "sage.interfaces.gfan": {
-        "ntests": 2
+    "sage.interfaces.gap3": {
+        "ntests": 35
+    },
+    "sage.interfaces.gap_workspace": {
+        "failed": true,
+        "ntests": 15
     },
     "sage.interfaces.gnuplot": {
         "ntests": 1
@@ -1814,11 +2489,7 @@
         "ntests": 4
     },
     "sage.interfaces.jmoldata": {
-        "failed": true,
         "ntests": 26
-    },
-    "sage.interfaces.latte": {
-        "ntests": 65
     },
     "sage.interfaces.polymake": {
         "ntests": 188
@@ -1841,6 +2512,25 @@
     "sage.interfaces.tachyon": {
         "failed": true,
         "ntests": 23
+    },
+    "sage.knots.free_knotinfo_monoid": {
+        "failed": true,
+        "ntests": 66
+    },
+    "sage.knots.gauss_code": {
+        "ntests": 18
+    },
+    "sage.knots.knot": {
+        "failed": true,
+        "ntests": 95
+    },
+    "sage.knots.knotinfo": {
+        "failed": true,
+        "ntests": 342
+    },
+    "sage.knots.link": {
+        "failed": true,
+        "ntests": 582
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -1874,6 +2564,32 @@
     },
     "sage.libs.flint.ulong_extras_sage": {
         "ntests": 3
+    },
+    "sage.libs.gap.context_managers": {
+        "ntests": 14
+    },
+    "sage.libs.gap.element": {
+        "failed": true,
+        "ntests": 519
+    },
+    "sage.libs.gap.libgap": {
+        "failed": true,
+        "ntests": 98
+    },
+    "sage.libs.gap.operations": {
+        "ntests": 15
+    },
+    "sage.libs.gap.saved_workspace": {
+        "ntests": 7
+    },
+    "sage.libs.gap.test": {
+        "ntests": 2
+    },
+    "sage.libs.gap.test_long": {
+        "ntests": 3
+    },
+    "sage.libs.gap.util": {
+        "ntests": 19
     },
     "sage.libs.gsl.array": {
         "ntests": 22
@@ -1982,7 +2698,7 @@
         "ntests": 109
     },
     "sage.matrix.args": {
-        "ntests": 180
+        "ntests": 187
     },
     "sage.matrix.berlekamp_massey": {
         "ntests": 7
@@ -2004,15 +2720,15 @@
     },
     "sage.matrix.matrix0": {
         "failed": true,
-        "ntests": 846
+        "ntests": 873
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 441
+        "ntests": 457
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2614
+        "ntests": 2641
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -2031,10 +2747,13 @@
         "ntests": 35
     },
     "sage.matrix.matrix_double_dense": {
-        "ntests": 460
+        "ntests": 486
     },
     "sage.matrix.matrix_double_sparse": {
         "ntests": 24
+    },
+    "sage.matrix.matrix_gap": {
+        "ntests": 120
     },
     "sage.matrix.matrix_generic_dense": {
         "ntests": 57
@@ -2047,7 +2766,7 @@
     },
     "sage.matrix.matrix_integer_dense": {
         "failed": true,
-        "ntests": 676
+        "ntests": 675
     },
     "sage.matrix.matrix_integer_dense_hnf": {
         "ntests": 125
@@ -2100,7 +2819,7 @@
     },
     "sage.matrix.matrix_space": {
         "failed": true,
-        "ntests": 459
+        "ntests": 469
     },
     "sage.matrix.matrix_sparse": {
         "ntests": 164
@@ -2115,10 +2834,10 @@
         "ntests": 7
     },
     "sage.matrix.operation_table": {
-        "ntests": 90
+        "ntests": 185
     },
     "sage.matrix.special": {
-        "ntests": 481
+        "ntests": 485
     },
     "sage.matrix.strassen": {
         "ntests": 69
@@ -2142,34 +2861,37 @@
         "ntests": 86
     },
     "sage.matroids.circuits_matroid": {
-        "ntests": 119
-    },
-    "sage.matroids.constructor": {
         "ntests": 141
     },
+    "sage.matroids.constructor": {
+        "ntests": 166
+    },
     "sage.matroids.database_collections": {
-        "ntests": 10
+        "ntests": 14
     },
     "sage.matroids.database_matroids": {
-        "ntests": 589
+        "ntests": 632
     },
     "sage.matroids.dual_matroid": {
-        "ntests": 77
+        "ntests": 92
     },
     "sage.matroids.extension": {
         "ntests": 48
     },
     "sage.matroids.flats_matroid": {
-        "ntests": 1
+        "ntests": 107
+    },
+    "sage.matroids.graphic_matroid": {
+        "ntests": 362
     },
     "sage.matroids.lean_matrix": {
-        "ntests": 282
+        "ntests": 286
     },
     "sage.matroids.linear_matroid": {
-        "ntests": 654
+        "ntests": 677
     },
     "sage.matroids.matroid": {
-        "ntests": 943
+        "ntests": 1003
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2187,10 +2909,10 @@
         "ntests": 40
     },
     "sage.matroids.unpickling": {
-        "ntests": 66
+        "ntests": 69
     },
     "sage.matroids.utilities": {
-        "ntests": 55
+        "ntests": 72
     },
     "sage.misc.abstract_method": {
         "ntests": 33
@@ -2208,7 +2930,7 @@
         "ntests": 40
     },
     "sage.misc.c3_controlled": {
-        "ntests": 150
+        "ntests": 204
     },
     "sage.misc.cachefunc": {
         "ntests": 688
@@ -2225,6 +2947,9 @@
     },
     "sage.misc.classcall_metaclass": {
         "ntests": 78
+    },
+    "sage.misc.classgraph": {
+        "ntests": 8
     },
     "sage.misc.compat": {
         "ntests": 2
@@ -2246,7 +2971,7 @@
     },
     "sage.misc.dev_tools": {
         "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.misc.edit_module": {
         "ntests": 16
@@ -2272,7 +2997,7 @@
     },
     "sage.misc.functional": {
         "failed": true,
-        "ntests": 315
+        "ntests": 319
     },
     "sage.misc.gperftools": {
         "ntests": 17
@@ -2290,13 +3015,13 @@
         "ntests": 67
     },
     "sage.misc.latex": {
-        "ntests": 235
+        "ntests": 236
     },
     "sage.misc.latex_macros": {
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
-        "ntests": 210
+        "ntests": 237
     },
     "sage.misc.lazy_attribute": {
         "ntests": 100
@@ -2368,6 +3093,10 @@
     "sage.misc.random_testing": {
         "ntests": 18
     },
+    "sage.misc.randstate": {
+        "failed": true,
+        "ntests": 146
+    },
     "sage.misc.remote_file": {
         "ntests": 1
     },
@@ -2382,10 +3111,10 @@
         "ntests": 29
     },
     "sage.misc.rest_index_of_methods": {
-        "ntests": 22
+        "ntests": 27
     },
     "sage.misc.sage_eval": {
-        "ntests": 35
+        "ntests": 43
     },
     "sage.misc.sage_input": {
         "ntests": 732
@@ -2406,7 +3135,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 329
+        "ntests": 330
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2454,6 +3183,16 @@
     "sage.misc.weak_dict": {
         "ntests": 281
     },
+    "sage.modular.modform.eis_series_cython": {
+        "ntests": 6
+    },
+    "sage.modular.modsym.apply": {
+        "ntests": 6
+    },
+    "sage.modular.pollack_stevens.dist": {
+        "failed": true,
+        "ntests": 168
+    },
     "sage.modules.complex_double_vector": {
         "ntests": 2
     },
@@ -2470,7 +3209,7 @@
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "ntests": 169
+        "ntests": 174
     },
     "sage.modules.finite_submodule_iter": {
         "failed": true,
@@ -2497,8 +3236,7 @@
         "ntests": 306
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
-        "failed": true,
-        "ntests": 158
+        "ntests": 249
     },
     "sage.modules.matrix_morphism": {
         "ntests": 393
@@ -2539,7 +3277,7 @@
         "ntests": 13
     },
     "sage.modules.vector_double_dense": {
-        "ntests": 96
+        "ntests": 52
     },
     "sage.modules.vector_integer_dense": {
         "ntests": 46
@@ -2567,14 +3305,22 @@
     },
     "sage.modules.vector_space_morphism": {
         "failed": true,
-        "ntests": 168
+        "ntests": 184
     },
     "sage.modules.with_basis.indexed_element": {
         "failed": true,
-        "ntests": 166
+        "ntests": 174
+    },
+    "sage.modules.with_basis.invariant": {
+        "failed": true,
+        "ntests": 298
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353
+    },
+    "sage.modules.with_basis.representation": {
+        "failed": true,
+        "ntests": 665
     },
     "sage.modules.with_basis.subquotient": {
         "failed": true,
@@ -2584,13 +3330,12 @@
         "ntests": 10
     },
     "sage.numerical.backends.generic_backend": {
-        "ntests": 60
+        "ntests": 65
     },
     "sage.numerical.backends.generic_sdp_backend": {
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
-        "failed": true,
         "ntests": 266
     },
     "sage.numerical.backends.logging_backend": {
@@ -2601,9 +3346,6 @@
     },
     "sage.numerical.backends.ppl_backend": {
         "ntests": 221
-    },
-    "sage.numerical.backends.scip_backend": {
-        "ntests": 1
     },
     "sage.numerical.gauss_legendre": {
         "ntests": 60
@@ -2628,14 +3370,14 @@
         "ntests": 80
     },
     "sage.numerical.mip": {
-        "ntests": 700
+        "ntests": 734
     },
     "sage.numerical.optimize": {
         "failed": true,
         "ntests": 74
     },
     "sage.numerical.sdp": {
-        "ntests": 239
+        "ntests": 245
     },
     "sage.parallel.decorate": {
         "ntests": 89
@@ -2705,7 +3447,7 @@
         "ntests": 2
     },
     "sage.plot.plot3d.base": {
-        "ntests": 398
+        "ntests": 404
     },
     "sage.plot.plot3d.index_face_set": {
         "ntests": 162
@@ -2774,6 +3516,9 @@
         "failed": true,
         "ntests": 529
     },
+    "sage.quadratic_forms.genera.spinor_genus": {
+        "ntests": 30
+    },
     "sage.quadratic_forms.qfsolve": {
         "ntests": 38
     },
@@ -2821,7 +3566,7 @@
         "ntests": 14
     },
     "sage.quadratic_forms.quadratic_form__neighbors": {
-        "ntests": 36
+        "ntests": 34
     },
     "sage.quadratic_forms.quadratic_form__reduction_theory": {
         "ntests": 21
@@ -2853,6 +3598,35 @@
     "sage.quadratic_forms.ternary_qf": {
         "ntests": 309
     },
+    "sage.quivers.algebra": {
+        "ntests": 122
+    },
+    "sage.quivers.algebra_elements": {
+        "failed": true,
+        "ntests": 211
+    },
+    "sage.quivers.algebra_elements.pxi": {
+        "failed": true,
+        "ntests": 5
+    },
+    "sage.quivers.ar_quiver": {
+        "ntests": 188
+    },
+    "sage.quivers.homspace": {
+        "ntests": 97
+    },
+    "sage.quivers.morphism": {
+        "ntests": 346
+    },
+    "sage.quivers.path_semigroup": {
+        "ntests": 195
+    },
+    "sage.quivers.paths": {
+        "ntests": 154
+    },
+    "sage.quivers.representation": {
+        "ntests": 495
+    },
     "sage.repl.attach": {
         "ntests": 135
     },
@@ -2882,11 +3656,11 @@
         "ntests": 7
     },
     "sage.repl.interface_magic": {
-        "ntests": 20
+        "ntests": 30
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 111
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -2990,7 +3764,7 @@
         "ntests": 4
     },
     "sage.rings.complex_double": {
-        "ntests": 339
+        "ntests": 333
     },
     "sage.rings.complex_interval": {
         "ntests": 265
@@ -2999,7 +3773,6 @@
         "ntests": 131
     },
     "sage.rings.complex_mpc": {
-        "failed": true,
         "ntests": 406
     },
     "sage.rings.complex_mpfr": {
@@ -3032,7 +3805,7 @@
     },
     "sage.rings.finite_rings.element_base": {
         "failed": true,
-        "ntests": 243
+        "ntests": 248
     },
     "sage.rings.finite_rings.element_givaro": {
         "failed": true,
@@ -3044,11 +3817,11 @@
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
         "failed": true,
-        "ntests": 283
+        "ntests": 300
     },
     "sage.rings.finite_rings.finite_field_base": {
         "failed": true,
-        "ntests": 340
+        "ntests": 344
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "failed": true,
@@ -3087,10 +3860,10 @@
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
-        "ntests": 583
+        "ntests": 588
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 367
+        "ntests": 420
     },
     "sage.rings.finite_rings.maps_finite_field": {
         "ntests": 31
@@ -3177,7 +3950,7 @@
     },
     "sage.rings.function_field.valuation": {
         "failed": true,
-        "ntests": 284
+        "ntests": 276
     },
     "sage.rings.generic": {
         "ntests": 78
@@ -3246,7 +4019,7 @@
         "ntests": 238
     },
     "sage.rings.number_field.galois_group": {
-        "ntests": 2
+        "ntests": 280
     },
     "sage.rings.number_field.homset": {
         "ntests": 131
@@ -3259,7 +4032,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2250
+        "ntests": 2353
     },
     "sage.rings.number_field.number_field_base": {
         "failed": true,
@@ -3267,7 +4040,7 @@
     },
     "sage.rings.number_field.number_field_element": {
         "failed": true,
-        "ntests": 1241
+        "ntests": 1259
     },
     "sage.rings.number_field.number_field_element_base": {
         "ntests": 4
@@ -3285,15 +4058,14 @@
         "ntests": 167
     },
     "sage.rings.number_field.number_field_rel": {
-        "ntests": 591
+        "ntests": 600
     },
     "sage.rings.number_field.order": {
         "failed": true,
-        "ntests": 661
+        "ntests": 662
     },
     "sage.rings.number_field.order_ideal": {
-        "failed": true,
-        "ntests": 199
+        "ntests": 200
     },
     "sage.rings.number_field.selmer_group": {
         "ntests": 93
@@ -3470,10 +4242,6 @@
         "failed": true,
         "ntests": 150
     },
-    "sage.rings.polynomial.groebner_fan": {
-        "failed": true,
-        "ntests": 357
-    },
     "sage.rings.polynomial.hilbert": {
         "ntests": 8
     },
@@ -3504,7 +4272,7 @@
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 561
+        "ntests": 583
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
@@ -3519,7 +4287,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "failed": true,
-        "ntests": 249
+        "ntests": 253
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
@@ -3557,7 +4325,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2603
+        "ntests": 2619
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 219
@@ -3587,8 +4355,7 @@
         "ntests": 151
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
-        "failed": true,
-        "ntests": 393
+        "ntests": 407
     },
     "sage.rings.polynomial.polynomial_real_mpfr_dense": {
         "ntests": 136
@@ -3655,8 +4422,7 @@
         "ntests": 241
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
-        "ntests": 491
+        "ntests": 483
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 72
@@ -3707,7 +4473,7 @@
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 924
+        "ntests": 907
     },
     "sage.rings.real_mpfr": {
         "failed": true,
@@ -3759,9 +4525,12 @@
     "sage.rings.tests": {
         "ntests": 52
     },
+    "sage.rings.universal_cyclotomic_field": {
+        "ntests": 327
+    },
     "sage.rings.valuation.augmented_valuation": {
         "failed": true,
-        "ntests": 462
+        "ntests": 457
     },
     "sage.rings.valuation.developing_valuation": {
         "ntests": 62
@@ -3771,13 +4540,10 @@
     },
     "sage.rings.valuation.inductive_valuation": {
         "failed": true,
-        "ntests": 271
+        "ntests": 284
     },
     "sage.rings.valuation.limit_valuation": {
         "ntests": 155
-    },
-    "sage.rings.valuation.mapped_valuation": {
-        "ntests": 76
     },
     "sage.rings.valuation.scaled_valuation": {
         "ntests": 41
@@ -3795,6 +4561,12 @@
     "sage.rings.valuation.value_group": {
         "ntests": 102
     },
+    "sage.sandpiles.examples": {
+        "ntests": 24
+    },
+    "sage.sandpiles.sandpile": {
+        "ntests": 912
+    },
     "sage.schemes.affine.affine_homset": {
         "ntests": 52
     },
@@ -3807,18 +4579,21 @@
         "ntests": 69
     },
     "sage.schemes.affine.affine_rational_point": {
-        "ntests": 38
+        "ntests": 36
     },
     "sage.schemes.affine.affine_space": {
         "failed": true,
         "ntests": 175
     },
     "sage.schemes.affine.affine_subscheme": {
-        "ntests": 92
+        "ntests": 90
+    },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "ntests": 17
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
-        "ntests": 381
+        "ntests": 391
     },
     "sage.schemes.generic.ambient_space": {
         "ntests": 60
@@ -3827,12 +4602,11 @@
         "ntests": 40
     },
     "sage.schemes.generic.homset": {
-        "failed": true,
         "ntests": 139
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 459
+        "ntests": 453
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -3869,7 +4643,7 @@
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 627
+        "ntests": 600
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
@@ -3886,25 +4660,59 @@
         "ntests": 260
     },
     "sage.schemes.toric.chow_group": {
-        "ntests": 2
+        "ntests": 199
     },
     "sage.schemes.toric.divisor": {
-        "ntests": 7
+        "failed": true,
+        "ntests": 366
+    },
+    "sage.schemes.toric.divisor_class": {
+        "failed": true,
+        "ntests": 62
     },
     "sage.schemes.toric.fano_variety": {
-        "ntests": 1
+        "failed": true,
+        "ntests": 175
+    },
+    "sage.schemes.toric.homset": {
+        "failed": true,
+        "ntests": 94
+    },
+    "sage.schemes.toric.library": {
+        "ntests": 100
+    },
+    "sage.schemes.toric.morphism": {
+        "ntests": 340
+    },
+    "sage.schemes.toric.points": {
+        "failed": true,
+        "ntests": 195
+    },
+    "sage.schemes.toric.sheaf.constructor": {
+        "ntests": 41
+    },
+    "sage.schemes.toric.sheaf.klyachko": {
+        "failed": true,
+        "ntests": 146
     },
     "sage.schemes.toric.toric_subscheme": {
-        "ntests": 3
+        "failed": true,
+        "ntests": 89
     },
     "sage.schemes.toric.variety": {
-        "ntests": 27
+        "failed": true,
+        "ntests": 418
+    },
+    "sage.schemes.toric.weierstrass": {
+        "failed": true,
+        "ntests": 146
     },
     "sage.schemes.toric.weierstrass_covering": {
-        "ntests": 5
+        "failed": true,
+        "ntests": 86
     },
     "sage.schemes.toric.weierstrass_higher": {
-        "ntests": 1
+        "ntests": 53
     },
     "sage.sets.cartesian_product": {
         "ntests": 54
@@ -3958,7 +4766,7 @@
         "ntests": 397
     },
     "sage.sets.set_from_iterator": {
-        "ntests": 155
+        "ntests": 204
     },
     "sage.sets.totally_ordered_finite_set": {
         "ntests": 69
@@ -3984,7 +4792,6 @@
         "ntests": 70
     },
     "sage.stats.hmm.hmm": {
-        "failed": true,
         "ntests": 125
     },
     "sage.stats.hmm.util": {
@@ -4006,7 +4813,7 @@
         "ntests": 360
     },
     "sage.structure.coerce_actions": {
-        "ntests": 133
+        "ntests": 143
     },
     "sage.structure.coerce_dict": {
         "ntests": 289
@@ -4068,7 +4875,7 @@
         "ntests": 11
     },
     "sage.structure.parent": {
-        "ntests": 354
+        "ntests": 369
     },
     "sage.structure.parent_gens": {
         "failed": true,
@@ -4091,7 +4898,8 @@
         "ntests": 24
     },
     "sage.structure.sage_object": {
-        "ntests": 84
+        "failed": true,
+        "ntests": 88
     },
     "sage.structure.sequence": {
         "ntests": 183
@@ -4109,7 +4917,7 @@
         "ntests": 6
     },
     "sage.structure.unique_representation": {
-        "ntests": 237
+        "ntests": 242
     },
     "sage.symbolic.function": {
         "failed": true,
@@ -4169,8 +4977,11 @@
     "sage.tensor.modules.tensor_free_submodule_basis": {
         "ntests": 31
     },
+    "sage.tensor.modules.tensor_with_indices": {
+        "ntests": 233
+    },
     "sage.tests.article_heuberger_krenn_kropf_fsm-in-sage": {
-        "ntests": 22
+        "ntests": 103
     },
     "sage.tests.book_schilling_zabrocki_kschur_primer": {
         "ntests": 2
@@ -4183,7 +4994,7 @@
         "ntests": 141
     },
     "sage.tests.finite_poset": {
-        "ntests": 1
+        "ntests": 8
     },
     "sage.tests.functools_partial_src": {
         "ntests": 3
@@ -4199,6 +5010,59 @@
     },
     "sage.tests.test_deprecation": {
         "ntests": 4
+    },
+    "sage.topology.cell_complex": {
+        "failed": true,
+        "ntests": 161
+    },
+    "sage.topology.cubical_complex": {
+        "ntests": 253
+    },
+    "sage.topology.delta_complex": {
+        "ntests": 166
+    },
+    "sage.topology.filtered_simplicial_complex": {
+        "ntests": 110
+    },
+    "sage.topology.moment_angle_complex": {
+        "ntests": 107
+    },
+    "sage.topology.simplicial_complex": {
+        "failed": true,
+        "ntests": 667
+    },
+    "sage.topology.simplicial_complex_catalog": {
+        "ntests": 6
+    },
+    "sage.topology.simplicial_complex_examples": {
+        "failed": true,
+        "ntests": 137
+    },
+    "sage.topology.simplicial_complex_homset": {
+        "ntests": 47
+    },
+    "sage.topology.simplicial_complex_morphism": {
+        "failed": true,
+        "ntests": 224
+    },
+    "sage.topology.simplicial_set": {
+        "failed": true,
+        "ntests": 854
+    },
+    "sage.topology.simplicial_set_catalog": {
+        "ntests": 6
+    },
+    "sage.topology.simplicial_set_constructions": {
+        "failed": true,
+        "ntests": 488
+    },
+    "sage.topology.simplicial_set_examples": {
+        "failed": true,
+        "ntests": 100
+    },
+    "sage.topology.simplicial_set_morphism": {
+        "failed": true,
+        "ntests": 308
     },
     "sage.typeset.ascii_art": {
         "ntests": 24

--- a/pkgs/sagemath-polyhedra/known-test-failures.json
+++ b/pkgs/sagemath-polyhedra/known-test-failures.json
@@ -22,8 +22,7 @@
         "ntests": 59
     },
     "sage.algebras.finite_gca": {
-        "failed": true,
-        "ntests": 91
+        "ntests": 89
     },
     "sage.algebras.octonion_algebra": {
         "failed": true,
@@ -741,7 +740,7 @@
         "ntests": 44
     },
     "sage.coding.code_constructions": {
-        "ntests": 6
+        "ntests": 7
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
@@ -831,8 +830,7 @@
         "ntests": 254
     },
     "sage.combinat.integer_vector_weighted": {
-        "failed": true,
-        "ntests": 52
+        "ntests": 45
     },
     "sage.combinat.matrices.dancing_links": {
         "ntests": 250
@@ -885,7 +883,7 @@
         "ntests": 284
     },
     "sage.combinat.root_system.root_lattice_realizations": {
-        "ntests": 489
+        "ntests": 484
     },
     "sage.combinat.root_system.root_space": {
         "ntests": 78
@@ -1081,8 +1079,7 @@
         "ntests": 230
     },
     "sage.doctest.check_tolerance": {
-        "failed": true,
-        "ntests": 19
+        "ntests": 9
     },
     "sage.doctest.control": {
         "ntests": 3
@@ -1095,14 +1092,14 @@
     },
     "sage.doctest.forker": {
         "failed": true,
-        "ntests": 389
+        "ntests": 269
     },
     "sage.doctest.marked_output": {
         "ntests": 21
     },
     "sage.doctest.parsing": {
         "failed": true,
-        "ntests": 270
+        "ntests": 233
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -1120,7 +1117,6 @@
         "ntests": 166
     },
     "sage.env": {
-        "failed": true,
         "ntests": 40
     },
     "sage.ext.fast_callable": {
@@ -1169,6 +1165,9 @@
     "sage.features.fricas": {
         "ntests": 6
     },
+    "sage.features.frobby": {
+        "ntests": 4
+    },
     "sage.features.gap": {
         "ntests": 6
     },
@@ -1197,7 +1196,6 @@
         "ntests": 5
     },
     "sage.features.jmol": {
-        "failed": true,
         "ntests": 4
     },
     "sage.features.join_feature": {
@@ -1214,6 +1212,9 @@
     },
     "sage.features.lrs": {
         "ntests": 16
+    },
+    "sage.features.macaulay2": {
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1254,11 +1255,15 @@
     "sage.features.poppler": {
         "ntests": 4
     },
+    "sage.features.qepcad": {
+        "ntests": 4
+    },
     "sage.features.rubiks": {
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "ntests": 181
+        "failed": true,
+        "ntests": 0
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1273,6 +1278,9 @@
         "ntests": 8
     },
     "sage.features.symengine_py": {
+        "ntests": 4
+    },
+    "sage.features.sympow": {
         "ntests": 4
     },
     "sage.features.tdlib": {
@@ -1307,7 +1315,6 @@
         "ntests": 69
     },
     "sage.functions.hyperbolic": {
-        "failed": true,
         "ntests": 81
     },
     "sage.functions.hypergeometric": {
@@ -1330,7 +1337,6 @@
         "ntests": 236
     },
     "sage.functions.other": {
-        "failed": true,
         "ntests": 245
     },
     "sage.functions.piecewise": {
@@ -1379,7 +1385,7 @@
     },
     "sage.geometry.cone": {
         "failed": true,
-        "ntests": 1130
+        "ntests": 1113
     },
     "sage.geometry.cone_catalog": {
         "failed": true,
@@ -1413,11 +1419,9 @@
         "ntests": 130
     },
     "sage.geometry.hyperplane_arrangement.library": {
-        "failed": true,
         "ntests": 24
     },
     "sage.geometry.hyperplane_arrangement.ordered_arrangement": {
-        "failed": true,
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
@@ -1488,8 +1492,7 @@
         "ntests": 162
     },
     "sage.geometry.polyhedron.base7": {
-        "failed": true,
-        "ntests": 124
+        "ntests": 122
     },
     "sage.geometry.polyhedron.base_QQ": {
         "ntests": 112
@@ -1600,7 +1603,7 @@
     },
     "sage.geometry.triangulation.point_configuration": {
         "failed": true,
-        "ntests": 215
+        "ntests": 250
     },
     "sage.geometry.voronoi_diagram": {
         "ntests": 24
@@ -1644,10 +1647,10 @@
         "ntests": 92
     },
     "sage.groups.galois_group": {
-        "ntests": 54
+        "ntests": 40
     },
     "sage.groups.generic": {
-        "ntests": 120
+        "ntests": 110
     },
     "sage.groups.group": {
         "ntests": 45
@@ -1662,11 +1665,10 @@
         "ntests": 33
     },
     "sage.groups.matrix_gps.linear": {
-        "failed": true,
-        "ntests": 47
+        "ntests": 37
     },
     "sage.groups.matrix_gps.matrix_group": {
-        "ntests": 53
+        "ntests": 54
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -1733,21 +1735,11 @@
     "sage.interfaces.abc": {
         "ntests": 8
     },
-    "sage.interfaces.four_ti_2": {
-        "ntests": 54
-    },
-    "sage.interfaces.gfan": {
-        "ntests": 2
-    },
     "sage.interfaces.interface": {
         "ntests": 4
     },
-    "sage.interfaces.latte": {
-        "ntests": 65
-    },
     "sage.interfaces.polymake": {
-        "failed": true,
-        "ntests": 188
+        "ntests": 187
     },
     "sage.interfaces.process": {
         "ntests": 39
@@ -1799,7 +1791,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2094
+        "ntests": 2092
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -1811,7 +1803,7 @@
         "ntests": 35
     },
     "sage.matrix.matrix_double_dense": {
-        "ntests": 23
+        "ntests": 27
     },
     "sage.matrix.matrix_double_sparse": {
         "ntests": 25
@@ -1981,7 +1973,7 @@
     },
     "sage.misc.dev_tools": {
         "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.misc.edit_module": {
         "ntests": 16
@@ -2025,7 +2017,7 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 235
+        "ntests": 236
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -2142,7 +2134,7 @@
     },
     "sage.misc.sageinspect": {
         "failed": true,
-        "ntests": 329
+        "ntests": 330
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2213,7 +2205,7 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1459
+        "ntests": 1453
     },
     "sage.modules.free_module_element": {
         "failed": true,
@@ -2223,8 +2215,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "failed": true,
-        "ntests": 96
+        "ntests": 8
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -2236,7 +2227,7 @@
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
         "failed": true,
-        "ntests": 156
+        "ntests": 133
     },
     "sage.modules.matrix_morphism": {
         "failed": true,
@@ -2400,7 +2391,7 @@
     },
     "sage.quadratic_forms.binary_qf": {
         "failed": true,
-        "ntests": 303
+        "ntests": 299
     },
     "sage.quadratic_forms.constructions": {
         "ntests": 5
@@ -2582,7 +2573,7 @@
     },
     "sage.rings.complex_double": {
         "failed": true,
-        "ntests": 327
+        "ntests": 325
     },
     "sage.rings.complex_mpc": {
         "failed": true,
@@ -2590,7 +2581,7 @@
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
-        "ntests": 501
+        "ntests": 497
     },
     "sage.rings.continued_fraction": {
         "failed": true,
@@ -2631,7 +2622,7 @@
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "failed": true,
-        "ntests": 365
+        "ntests": 354
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 39
@@ -2786,10 +2777,6 @@
         "failed": true,
         "ntests": 133
     },
-    "sage.rings.polynomial.groebner_fan": {
-        "failed": true,
-        "ntests": 357
-    },
     "sage.rings.polynomial.ideal": {
         "ntests": 13
     },
@@ -2817,7 +2804,7 @@
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
         "failed": true,
-        "ntests": 123
+        "ntests": 117
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
@@ -2926,8 +2913,7 @@
         "ntests": 241
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
-        "ntests": 478
+        "ntests": 470
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 72
@@ -2944,7 +2930,7 @@
     },
     "sage.rings.rational": {
         "failed": true,
-        "ntests": 545
+        "ntests": 546
     },
     "sage.rings.rational_field": {
         "failed": true,
@@ -3014,13 +3000,13 @@
         "ntests": 69
     },
     "sage.schemes.affine.affine_rational_point": {
-        "ntests": 26
+        "ntests": 24
     },
     "sage.schemes.affine.affine_space": {
         "ntests": 167
     },
     "sage.schemes.affine.affine_subscheme": {
-        "ntests": 81
+        "ntests": 79
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
@@ -3033,12 +3019,11 @@
         "ntests": 40
     },
     "sage.schemes.generic.homset": {
-        "failed": true,
-        "ntests": 124
+        "ntests": 121
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 395
+        "ntests": 391
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -3075,7 +3060,7 @@
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 499
+        "ntests": 487
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
@@ -3107,7 +3092,7 @@
         "ntests": 7
     },
     "sage.schemes.toric.toric_subscheme": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.schemes.toric.variety": {
         "ntests": 28
@@ -3202,7 +3187,7 @@
         "ntests": 2
     },
     "sage.stats.time_series": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.structure.category_object": {
         "failed": true,

--- a/pkgs/sagemath-polyhedra/pyproject.toml.m4
+++ b/pkgs/sagemath-polyhedra/pyproject.toml.m4
@@ -77,6 +77,8 @@ RDF         = ["passagemath-polyhedra[cddlib]"]
 NumberField = ["passagemath-polyhedra[flint]"]
 
 # features
+graphs      = ["passagemath-graphs"]
+groups      = ["passagemath-groups"]
 plot        = ["passagemath-plot"]
 
 # the whole package

--- a/src/sage/arith/functions.pyx
+++ b/src/sage/arith/functions.pyx
@@ -90,8 +90,8 @@ def lcm(a, b=None):
     Verify that objects without lcm methods but which can't be
     coerced to `\ZZ` or `\QQ` raise an error::
 
-        sage: F.<x,y> = FreeMonoid(2)                                                   # needs sage.groups
-        sage: lcm(x,y)                                                                  # needs sage.groups
+        sage: F.<x,y> = FreeMonoid(2)                                                   # needs sage.combinat
+        sage: lcm(x,y)                                                                  # needs sage.combinat
         Traceback (most recent call last):
         ...
         TypeError: unable to find lcm of x and y

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -1810,8 +1810,8 @@ def gcd(a, b=None, **kwargs):
     Verify that objects without gcd methods but which cannot be
     coerced to ZZ or QQ raise an error::
 
-        sage: F.<a,b> = FreeMonoid(2)                                                   # needs sage.groups
-        sage: gcd(a, b)                                                                 # needs sage.groups
+        sage: F.<a,b> = FreeMonoid(2)                                                   # needs sage.combinat
+        sage: gcd(a, b)                                                                 # needs sage.combinat
         Traceback (most recent call last):
         ...
         TypeError: unable to call gcd with a

--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -837,7 +837,7 @@ class SimplicialSets(Category_singleton):
 
                 EXAMPLES::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.graphs sage.libs.singular
                     sage: X = simplicial_sets.Sphere(1).wedge(simplicial_sets.Sphere(2))
                     sage: X.twisted_homology(1)
                     Quotient module by Submodule of Ambient free module of rank 0 over the integral domain Multivariate Polynomial Ring in f1, f1inv over Integer Ring
@@ -850,7 +850,7 @@ class SimplicialSets(Category_singleton):
 
                 ::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.graphs sage.libs.singular
                     sage: Y = simplicial_sets.Torus()
                     sage: Y.twisted_homology(1)
                     Quotient module by Submodule of Ambient free module of rank 5 over the integral domain Multivariate Polynomial Ring in f1, f1inv, f2, f2inv over Integer Ring
@@ -885,7 +885,7 @@ class SimplicialSets(Category_singleton):
 
                 TESTS::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.graphs sage.libs.singular
                     sage: X = simplicial_sets.PresentationComplex(groups.presentation.FGAbelian((3,2)))
                     sage: TW2 = X.twisted_homology(2, reduced=True)
                     sage: M = TW2.relations_matrix()

--- a/src/sage/combinat/designs/orthogonal_arrays_build_recursive.py
+++ b/src/sage/combinat/designs/orthogonal_arrays_build_recursive.py
@@ -1385,7 +1385,7 @@ def brouwer_separable_design(k,t,q,x,check=False,verbose=False,explain_construct
         sage: k,q,t=5,4,8; _=brouwer_separable_design(k,t,q,q**2,verbose=True,check=True)
         Case vi) with k=5,q=4,t=8,x=16,e3=0,e4=1
 
-        sage: print(designs.orthogonal_arrays.explain_construction(10,189))
+        sage: print(designs.orthogonal_arrays.explain_construction(10, 189))            # needs sage.schemes
         Brouwer's separable design construction with t=9,q=4,x=0 from:
            Andries E. Brouwer,
            A series of separable designs with application to pairwise orthogonal Latin squares

--- a/src/sage/combinat/finite_state_machine.py
+++ b/src/sage/combinat/finite_state_machine.py
@@ -532,12 +532,14 @@ Sage's :doc:`words <words/words>`.
 
 ::
 
+    sage: # needs sage.combinat
     sage: W = Words([0, 1]); W
     Finite and infinite words over {0, 1}
 
 Let us take the inverter from the previous section and feed some
 finite word into it::
 
+    sage: # needs sage.combinat
     sage: w = W([1, 1, 0, 1]); w
     word: 1101
     sage: inverter(w)
@@ -548,6 +550,7 @@ calling :meth:`~Transducer.process` with ``automatic_output_type``).
 
 We can even input something infinite like an infinite word::
 
+    sage: # needs sage.combinat
     sage: tm = words.ThueMorseWord(); tm
     word: 0110100110010110100101100110100110010110...
     sage: inverter(tm)

--- a/src/sage/combinat/posets/lattices.py
+++ b/src/sage/combinat/posets/lattices.py
@@ -2513,6 +2513,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         The Boolean lattice of `2^3` elements is not upward planar, even if
         its covering relations graph is planar::
 
+            sage: # needs planarity
             sage: B3 = posets.BooleanLattice(3)
             sage: B3.is_planar()
             False
@@ -2523,6 +2524,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         Ordinal product of planar lattices is obviously planar. Same does
         not apply to Cartesian products::
 
+            sage: # needs planarity
             sage: P = posets.PentagonPoset()
             sage: Pc = P.product(P)
             sage: Po = P.ordinal_product(P)
@@ -2537,6 +2539,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
 
         TESTS::
 
+            sage: # needs planarity
             sage: posets.ChainPoset(0).is_planar()
             True
             sage: posets.ChainPoset(1).is_planar()
@@ -3735,7 +3738,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
             ....:                         [7, 8]]) )
             sage: L.is_dismantlable()
             True
-            sage: L.is_planar()
+            sage: L.is_planar()                                                         # needs planarity
             False
 
         .. SEEALSO::
@@ -4253,7 +4256,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
             sage: L = LatticePoset(DiGraph('OQC?a?@CO?G_C@?GA?O??_??@?BO?A_?G??C??_?@???'))
             sage: L.is_constructible_by_doublings('convex')                             # needs sage.combinat
             False
-            sage: L.is_constructible_by_doublings('any')
+            sage: L.is_constructible_by_doublings('any')                                # needs sage.combinat
             True
 
         .. SEEALSO::

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -955,6 +955,7 @@ class sage__rings__number_field(JoinFeature):
     Doctests that construct algebraic number fields should be marked ``# needs sage.rings.number_field``::
 
         sage: # needs sage.rings.number_field
+        sage: x = polygen(ZZ, 'x')
         sage: K.<cuberoot2> = NumberField(x^3 - 2)
         sage: L.<cuberoot3> = K.extension(x^3 - 3)
         sage: S.<sqrt2> = L.extension(x^2 - 2); S

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6196,13 +6196,13 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The maximal angle in a single ray is zero::
 
             sage: K = random_cone(min_rays=1, max_rays=1, max_ambient_dim=5)
-            sage: K.max_angle()[0]
+            sage: K.max_angle()[0]                                                      # needs sage.rings.number_field sage.symbolic
             0
 
         The maximal angle in the nonnegative octant is `\pi/2`::
 
             sage: K = cones.nonnegative_orthant(3)
-            sage: K.max_angle()[0]
+            sage: K.max_angle()[0]                                                      # needs sage.rings.number_field sage.symbolic
             1/2*pi
 
         The maximal angle between the nonnegative quintant and the
@@ -6210,7 +6210,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         result can be obtained faster using inexact arithmetic, but
         only confidently so because we already know the answer::
 
-            sage: # long time
+            sage: # long time, needs sage.rings.number_field sage.symbolic
             sage: P = cones.nonnegative_orthant(5)
             sage: Q = cones.schur(5)
             sage: actual = P.max_angle(Q)[0]
@@ -6226,13 +6226,14 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
             sage: n = 3
             sage: K = cones.schur(n)
-            sage: bool(K.max_angle()[0] == ((n-1)/n)*pi)
+            sage: bool(K.max_angle()[0] == ((n-1)/n)*pi)                                # needs sage.rings.number_field sage.symbolic
             True
 
         Sage can't prove that the actual and expected results are
         equal in the next two cases without a little nudge in the
         right direction, and, moreover, it's crashy about it::
 
+            sage: # needs sage.rings.number_field sage.symbolic
             sage: n = 4
             sage: K = cones.schur(n)
             sage: actual = K.max_angle()[0].simplify()._sympy_()._sage_()
@@ -6251,7 +6252,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
             sage: P = Cone([(5,1), (1,-1)])
             sage: Q = Cone([(-1,0), (-1,0)])
-            sage: P.max_angle(Q)[0]
+            sage: P.max_angle(Q)[0]                                                     # needs sage.rings.number_field sage.symbolic
             pi
 
         TESTS:
@@ -6259,7 +6260,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         When ``self`` and ``-other`` have nontrivial intersection, we
         expect the maximal angle to be `\pi`::
 
-            sage: # long time
+            sage: # long time, needs sage.rings.number_field sage.symbolic
             sage: from sage.geometry.cone_critical_angles import (
             ....:   _random_admissible_cone )
             sage: n = ZZ.random_element(1,3)
@@ -6273,6 +6274,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         In particular, this should happen when either cone is the full
         space::
 
+            sage: # needs sage.rings.number_field sage.symbolic
             sage: from sage.geometry.cone_critical_angles import (
             ....:   _random_admissible_cone )
             sage: n = ZZ.random_element(1,5)

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -996,8 +996,8 @@ class HyperplaneArrangementElement(Element):
             sage: A = hyperplane_arrangements.coordinate(2)
             sage: A.cocharacteristic_polynomial()                                       # needs sage.graphs
             z^2 + 2*z + 1
-            sage: B = hyperplane_arrangements.braid(3)
-            sage: B.cocharacteristic_polynomial()                                       # needs sage.graphs
+            sage: B = hyperplane_arrangements.braid(3)                                  # needs sage.groups
+            sage: B.cocharacteristic_polynomial()                                       # needs sage.graphs sage.groups
             2*z^3 + 3*z^2 + z
 
         TESTS::
@@ -1044,8 +1044,8 @@ class HyperplaneArrangementElement(Element):
             sage: A = hyperplane_arrangements.coordinate(2)
             sage: A.primitive_eulerian_polynomial()                                     # needs sage.graphs
             z^2
-            sage: B = hyperplane_arrangements.braid(3)
-            sage: B.primitive_eulerian_polynomial()                                     # needs sage.graphs
+            sage: B = hyperplane_arrangements.braid(3)                                  # needs sage.groups
+            sage: B.primitive_eulerian_polynomial()                                     # needs sage.graphs sage.groups
             z^2 + z
 
             sage: H = hyperplane_arrangements.Shi(['B',2]).cone()
@@ -1255,7 +1255,7 @@ class HyperplaneArrangementElement(Element):
             sage: x,y,z = H.gens()
             sage: h1,h2 = [1*x+2*y+3*z, 3*x+2*y+1*z]
             sage: A = H(h1, h2, backend='normaliz')
-            sage: A.restriction(h2).backend()
+            sage: A.restriction(h2).backend()                                           # needs sage.combinat
             'normaliz'
         """
         parent = self.parent()

--- a/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
@@ -90,12 +90,14 @@ from sage.geometry.hyperplane_arrangement.arrangement import HyperplaneArrangeme
 from sage.geometry.hyperplane_arrangement.arrangement import HyperplaneArrangements
 from sage.geometry.hyperplane_arrangement.hyperplane import Hyperplane
 from sage.matrix.constructor import matrix, vector
+from sage.misc.lazy_import import lazy_import
 from sage.misc.misc_c import prod
-from sage.groups.free_group import FreeGroup
 from sage.rings.integer_ring import ZZ
-from sage.rings.qqbar import QQbar
-from sage.schemes.curves.plane_curve_arrangement import AffinePlaneCurveArrangements
-from sage.schemes.curves.plane_curve_arrangement import ProjectivePlaneCurveArrangements
+
+lazy_import('sage.groups.free_group', 'FreeGroup')
+lazy_import('sage.rings.qqbar', 'QQbar')
+lazy_import('sage.schemes.curves.plane_curve_arrangement', 'AffinePlaneCurveArrangements')
+lazy_import('sage.schemes.curves.plane_curve_arrangement', 'ProjectivePlaneCurveArrangements')
 
 
 class OrderedHyperplaneArrangementElement(HyperplaneArrangementElement):

--- a/src/sage/geometry/palp_normal_form.pyx
+++ b/src/sage/geometry/palp_normal_form.pyx
@@ -61,6 +61,8 @@ def _palp_PM_max(Matrix_integer_dense PM, check=False):
         sage: PM_max = PM.permutation_normal_form()
         sage: PM_max == o._palp_PM_max()
         True
+
+        sage: # needs polytopes_db
         sage: P2 = ReflexivePolytope(2, 0)
         sage: PM_max, permutations = P2._palp_PM_max(check=True)
         sage: PM_max

--- a/src/sage/geometry/polyhedron/base7.py
+++ b/src/sage/geometry/polyhedron/base7.py
@@ -663,7 +663,7 @@ class Polyhedron_base7(Polyhedron_base6):
         Induced volumes work with lrs (:issue:`33410`)::
 
             sage: P = Polyhedron([[0, 0], [1, 1]])
-            sage: P.volume(measure='induced', engine='lrs')             # optional - lrslib
+            sage: P.volume(measure='induced', engine='lrs')             # optional - lrslib sage.rings.number_field
             1.414213562373095?
         """
         from sage.features import FeatureNotPresentError
@@ -805,6 +805,7 @@ class Polyhedron_base7(Polyhedron_base6):
         If the polyhedron has floating point coordinates, an inexact result can
         be obtained if we transform to rational coordinates::
 
+            sage: # needs sage.rings.real_interval_field
             sage: P = 1.4142*polytopes.cube()
             sage: P_QQ = Polyhedron(vertices=[[QQ(vi) for vi in v] for v in P.vertex_generator()])
             sage: RDF(P_QQ.integrate(x^2*y^2*z^2))                      # optional - latte_int

--- a/src/sage/geometry/polyhedron/base_ZZ.py
+++ b/src/sage/geometry/polyhedron/base_ZZ.py
@@ -883,7 +883,7 @@ class Polyhedron_ZZ(Polyhedron_QQ):
         span the space::
 
             sage: p = Polyhedron([(1,0,0), (0,1,0), (-1,0,0), (0,-1,0)])
-            sage: p.normal_form()
+            sage: p.normal_form()                                                       # needs sage.groups
             Traceback (most recent call last):
             ...
             ValueError: normal form is not defined for lower-dimensional polyhedra, got
@@ -892,7 +892,7 @@ class Polyhedron_ZZ(Polyhedron_QQ):
         The normal form is also not defined for unbounded polyhedra::
 
             sage: p = Polyhedron(vertices=[[1, 1]], rays=[[1, 0], [0, 1]], base_ring=ZZ)
-            sage: p.normal_form()
+            sage: p.normal_form()                                                       # needs sage.groups
             Traceback (most recent call last):
             ...
             ValueError: normal form is not defined for unbounded polyhedra, got

--- a/src/sage/graphs/generators/basic.py
+++ b/src/sage/graphs/generators/basic.py
@@ -111,7 +111,7 @@ def ButterflyGraph():
         sage: G = graphs.ButterflyGraph(); G
         Butterfly graph: Graph on 5 vertices
         sage: G.show()                          # long time                             # needs sage.plot
-        sage: G.is_planar()
+        sage: G.is_planar()                                     # needs planarity
         True
         sage: G.order()
         5

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1520,7 +1520,7 @@ def FriendshipGraph(n):
         3
         sage: G.chromatic_number()
         3
-        sage: G.is_planar()
+        sage: G.is_planar()                                                             # needs planarity
         True
         sage: G.is_eulerian()
         True
@@ -4579,7 +4579,7 @@ def BiwheelGraph(n):
 
         sage: g = graphs.BiwheelGraph(5)
         sage: g.show()                          # long time                             # needs sage.plot
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
         sage: g.is_bipartite()
         True

--- a/src/sage/graphs/generators/random.py
+++ b/src/sage/graphs/generators/random.py
@@ -2271,7 +2271,7 @@ def RandomTriangulation(n, set_position=False, k=3, seed=None):
 
         sage: G = graphs.RandomTriangulation(6, True); G
         Graph on 6 vertices
-        sage: G.is_planar()
+        sage: G.is_planar()                                                             # needs planarity
         True
         sage: G.girth()
         3

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -1087,7 +1087,7 @@ def BidiakisCube():
     `(x - 3) (x - 2) (x^4) (x + 1) (x + 2) (x^2 + x - 4)^2` and
     chromatic number 3::
 
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
         sage: char_poly = g.characteristic_polynomial()                                 # needs sage.modules
         sage: x = char_poly.parent()('x')                                               # needs sage.modules
@@ -1417,7 +1417,7 @@ def BuckyBall():
     The Bucky Ball is planar::
 
         sage: g = graphs.BuckyBall()
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
 
     The Bucky Ball can also be created by extracting the 1-skeleton of the Bucky
@@ -1965,7 +1965,7 @@ def CubeplexGraph(embedding='LM'):
         3
         sage: g.is_hamiltonian()                                                        # needs sage.numerical.mip
         True
-        sage: g.crossing_number()
+        sage: g.crossing_number()                               # needs planarity
         1
         sage: g.show()                          # long time                             # needs sage.plot
 
@@ -2123,7 +2123,7 @@ def DurerGraph():
 
         sage: G = graphs.DurerGraph(); G
         Durer graph: Graph on 12 vertices
-        sage: G.is_planar()
+        sage: G.is_planar()                                     # needs planarity
         True
         sage: G.order()
         12
@@ -2178,7 +2178,7 @@ def DyckGraph():
     It is non-planar and Hamiltonian, as well as bipartite (making it a bicubic
     graph)::
 
-        sage: G.is_planar()
+        sage: G.is_planar()                                     # needs planarity
         False
         sage: G.is_hamiltonian()                                                        # needs sage.numerical.mip
         True
@@ -2480,7 +2480,7 @@ def ErreraGraph():
 
         sage: G = graphs.ErreraGraph(); G
         Errera graph: Graph on 17 vertices
-        sage: G.is_planar()
+        sage: G.is_planar()                                     # needs planarity
         True
         sage: G.order()
         17
@@ -2773,7 +2773,7 @@ def GoldnerHararyGraph():
 
         sage: G = graphs.GoldnerHararyGraph(); G
         Goldner-Harary graph: Graph on 11 vertices
-        sage: G.is_planar()
+        sage: G.is_planar()                                     # needs planarity
         True
         sage: G.order()
         11
@@ -3035,7 +3035,7 @@ def HerschelGraph():
 
         sage: G = graphs.HerschelGraph(); G
         Herschel graph: Graph on 11 vertices
-        sage: G.is_planar()
+        sage: G.is_planar()                                     # needs planarity
         True
         sage: G.is_bipartite()
         True
@@ -3731,7 +3731,7 @@ def MarkstroemGraph():
         24
         sage: g.size()
         36
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
         sage: g.is_regular(3)
         True
@@ -4145,7 +4145,7 @@ def PoussinGraph():
         sage: g = graphs.PoussinGraph()
         sage: g.order()
         15
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
     """
     g = Graph({2: [7, 8, 3, 4], 1: [7, 6], 0: [6, 5, 4], 3: [5]},
@@ -4869,7 +4869,7 @@ def TutteGraph():
         46
         sage: g.size()
         69
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
         sage: g.vertex_connectivity()           # long time                             # needs sage.numerical.mip
         3
@@ -4986,7 +4986,7 @@ def TwinplexGraph(embedding='LM'):
         3
         sage: g.is_hamiltonian()                                                        # needs sage.numerical.mip
         True
-        sage: g.crossing_number()
+        sage: g.crossing_number()                               # needs planarity
         2
         sage: g.show()                          # long time                             # needs sage.plot
 
@@ -5193,7 +5193,7 @@ def WienerArayaGraph():
         67
         sage: g.girth()
         4
-        sage: g.is_planar()
+        sage: g.is_planar()                                     # needs planarity
         True
         sage: g.is_hamiltonian()                # not tested (30s)                      # needs sage.numerical.mip
         False

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -3237,9 +3237,9 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: G = graphs.PetersenGraph()
-            sage: G.genus()
+            sage: G.genus()                                                             # needs planarity
             1
-            sage: G.get_embedding()
+            sage: G.get_embedding()                                                     # needs planarity
             {0: [1, 4, 5], 1: [0, 2, 6], 2: [1, 3, 7], 3: [2, 4, 8],
              4: [0, 3, 9], 5: [0, 7, 8], 6: [1, 9, 8], 7: [2, 5, 9],
              8: [3, 6, 5], 9: [4, 6, 7]}
@@ -3248,7 +3248,7 @@ class GenericGraph(GenericGraph_pyx):
 
             sage: G.delete_edge(0, 1)
             sage: G.delete_vertex(3)
-            sage: G.get_embedding()
+            sage: G.get_embedding()                                                     # needs planarity
             {0: [4, 5],
              1: [2, 6],
              2: [1, 7],
@@ -5680,15 +5680,15 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: g = graphs.CubeGraph(4)
-            sage: g.is_planar()
+            sage: g.is_planar()                                                         # needs planarity
             False
 
         ::
 
             sage: g = graphs.CircularLadderGraph(4)
-            sage: g.is_planar(set_embedding=True)
+            sage: g.is_planar(set_embedding=True)                                       # needs planarity
             True
-            sage: g.get_embedding()
+            sage: g.get_embedding()                                                     # needs planarity
             {0: [1, 4, 3],
              1: [2, 5, 0],
              2: [3, 6, 1],
@@ -5701,7 +5701,7 @@ class GenericGraph(GenericGraph_pyx):
         ::
 
             sage: g = graphs.PetersenGraph()
-            sage: (g.is_planar(kuratowski=True))[1].adjacency_matrix()                  # needs sage.modules
+            sage: (g.is_planar(kuratowski=True))[1].adjacency_matrix()                  # needs planarity sage.modules
             [0 1 0 0 0 1 0 0 0]
             [1 0 1 0 0 0 1 0 0]
             [0 1 0 1 0 0 0 1 0]
@@ -5952,7 +5952,7 @@ class GenericGraph(GenericGraph_pyx):
 
             sage: g439 = Graph({1: [5, 7], 2: [5, 6], 3: [6, 7], 4: [5, 6, 7]})
             sage: g439.show()                                                           # needs sage.plot
-            sage: g439.is_circular_planar(boundary=[1, 2, 3, 4])
+            sage: g439.is_circular_planar(boundary=[1, 2, 3, 4])                        # needs planarity
             False
             sage: g439.is_circular_planar(kuratowski=True, boundary=[1, 2, 3, 4])
             (False, Kuratowski subgraph of (): Graph on 8 vertices)
@@ -5970,7 +5970,7 @@ class GenericGraph(GenericGraph_pyx):
         Order matters::
 
             sage: K23 = graphs.CompleteBipartiteGraph(2, 3)
-            sage: K23.is_circular_planar(boundary=[0, 1, 2, 3])
+            sage: K23.is_circular_planar(boundary=[0, 1, 2, 3])                         # needs planarity
             True
             sage: K23.is_circular_planar(ordered=True, boundary=[0, 1, 2, 3])
             False
@@ -6115,6 +6115,7 @@ class GenericGraph(GenericGraph_pyx):
 
         EXAMPLES::
 
+            sage: # needs planarity
             sage: g = graphs.PathGraph(10)
             sage: g.layout(layout='planar', save_pos=True, test=True)
             {0: [0, 8],
@@ -6145,9 +6146,9 @@ class GenericGraph(GenericGraph_pyx):
         Choose the external face of the drawing::
 
             sage: g = graphs.CompleteGraph(4)
-            sage: g.layout(layout='planar', external_face=(0,1))
+            sage: g.layout(layout='planar', external_face=(0,1))                        # needs planarity
             {0: [0, 2], 1: [2, 1], 2: [1, 0], 3: [1, 1]}
-            sage: g.layout(layout='planar', external_face=(3,1))
+            sage: g.layout(layout='planar', external_face=(3,1))                        # needs planarity
             {0: [2, 1], 1: [0, 2], 2: [1, 1], 3: [1, 0]}
 
         Choose the embedding::
@@ -6155,8 +6156,8 @@ class GenericGraph(GenericGraph_pyx):
             sage: H = graphs.LadderGraph(4)
             sage: em = {0:[1,4], 4:[0,5], 1:[5,2,0], 5:[4,6,1],
             ....:       2:[1,3,6], 6:[7,5,2], 3:[7,2], 7:[3,6]}
-            sage: p = H.layout_planar(on_embedding=em)
-            sage: p  # random
+            sage: p = H.layout_planar(on_embedding=em)                                  # needs planarity
+            sage: p  # random                                                           # needs planarity
             {2: [8.121320343559642, 1],
              3: [2.1213203435596424, 6],
              7: [3.1213203435596424, 0],
@@ -20530,7 +20531,9 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS::
 
-            sage: for style in ('spring', 'planar', 'circular', 'forest'):
+            sage: styles = ['spring', 'circular', 'forest']
+            sage: styles += ['planar']                                                  # needs planarity
+            sage: for style in styles:
             ....:     for G in [Graph([(1, 2)]), Graph([(1, 2), (2, 3), (3, 4)])]:
             ....:         pos = G.layout(style, save_pos=True)
             ....:         assert G._pos is not None
@@ -23791,7 +23794,7 @@ class GenericGraph(GenericGraph_pyx):
 
         Graphs::
 
-            sage: # needs sage.groups
+            sage: # needs database_graphs sage.groups
             sage: graphs_query = GraphQuery(display_cols=['graph6'],num_vertices=4)
             sage: L = graphs_query.get_graphs_list()
             sage: graphs_list.show_graphs(L)                                            # needs sage.plot

--- a/src/sage/graphs/genus.pyx
+++ b/src/sage/graphs/genus.pyx
@@ -569,6 +569,7 @@ def simple_connected_graph_genus(G, set_embedding=False, check=True, minimal=Tru
 
     EXAMPLES::
 
+        sage: # needs planarity
         sage: import sage.graphs.genus
         sage: from sage.graphs.genus import simple_connected_graph_genus as genus
         sage: [genus(g) for g in graphs(6) if g.is_connected()].count(1)

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -280,6 +280,7 @@ see how people usually visualize these graphs.
 
 ::
 
+    sage: # needs database_graphs
     sage: G = GraphQuery(display_cols=['graph6'], num_vertices=7, diameter=5)
     sage: L = G.get_graphs_list()
     sage: graphs_list.show_graphs(L)                                                    # needs sage.plot
@@ -1695,31 +1696,31 @@ class Graph(GenericGraph):
         EXAMPLES::
 
             sage: g = Graph({1: [2], 2: [3, 4], 3: [4, 5, 6, 7], 8: [3, 5], 9: [6, 7]})
-            sage: g.is_cactus()
+            sage: g.is_cactus()                                                         # needs planarity
             True
 
             sage: c6 = graphs.CycleGraph(6)
             sage: naphthalene = c6 + c6
-            sage: naphthalene.is_cactus()  # Not connected
+            sage: naphthalene.is_cactus()  # Not connected                              # needs planarity
             False
             sage: naphthalene.merge_vertices([0, 6])
-            sage: naphthalene.is_cactus()
+            sage: naphthalene.is_cactus()                                               # needs planarity
             True
             sage: naphthalene.merge_vertices([1, 7])
-            sage: naphthalene.is_cactus()
+            sage: naphthalene.is_cactus()                                               # needs planarity
             False
 
         TESTS::
 
-            sage: all(graphs.PathGraph(i).is_cactus() for i in range(5))
+            sage: all(graphs.PathGraph(i).is_cactus() for i in range(5))                # needs planarity
             True
 
-            sage: Graph('Fli@?').is_cactus()
+            sage: Graph('Fli@?').is_cactus()                                            # needs planarity
             False
 
         Test a graph that is not outerplanar, see :issue:`24480`::
 
-            sage: graphs.Balaban10Cage().is_cactus()                                    # needs networkx
+            sage: graphs.Balaban10Cage().is_cactus()                                    # needs networkx planarity
             False
         """
         self._scream_if_not_simple()
@@ -1905,7 +1906,7 @@ class Graph(GenericGraph):
         The Petersen graph is not apex::
 
             sage: G = graphs.PetersenGraph()
-            sage: G.is_apex()
+            sage: G.is_apex()                                   # needs planarity
             False
 
         A graph is apex if all its connected components are apex, but at most
@@ -1913,9 +1914,9 @@ class Graph(GenericGraph):
 
             sage: M = graphs.Grid2dGraph(3,3)
             sage: K5 = graphs.CompleteGraph(5)
-            sage: (M+K5).is_apex()
+            sage: (M + K5).is_apex()                            # needs planarity
             True
-            sage: (M+K5+K5).is_apex()
+            sage: (M + K5 + K5).is_apex()                       # needs planarity
             False
 
         TESTS:
@@ -1928,8 +1929,8 @@ class Graph(GenericGraph):
 
         The graph might be mutable or immutable::
 
-            sage: G = Graph(M+K5, immutable=True)
-            sage: G.is_apex()
+            sage: G = Graph(M + K5, immutable=True)
+            sage: G.is_apex()                                   # needs planarity
             True
         """
         # Easy cases: null graph, subgraphs of K_5 and K_3,3
@@ -1993,16 +1994,16 @@ class Graph(GenericGraph):
         vertex is the unique apex vertex ::
 
             sage: G = graphs.Grid2dGraph(4,4)
-            sage: set(G.apex_vertices()) == set(G.vertices(sort=False))
+            sage: set(G.apex_vertices()) == set(G.vertices(sort=False))     # needs planarity
             True
             sage: G.add_edges([('universal',v) for v in G])
-            sage: G.apex_vertices()
+            sage: G.apex_vertices()                                         # needs planarity
             ['universal']
 
         The Petersen graph is not apex::
 
             sage: G = graphs.PetersenGraph()
-            sage: G.apex_vertices()
+            sage: G.apex_vertices()                                         # needs planarity
             []
 
         A graph is apex if all its connected components are apex, but at most
@@ -2010,9 +2011,9 @@ class Graph(GenericGraph):
 
             sage: M = graphs.Grid2dGraph(3,3)
             sage: K5 = graphs.CompleteGraph(5)
-            sage: (M+K5).apex_vertices()
+            sage: (M + K5).apex_vertices()                                  # needs planarity
             [9, 10, 11, 12, 13]
-            sage: (M+K5+K5).apex_vertices()
+            sage: (M + K5 + K5).apex_vertices()                             # needs planarity
             []
 
         Neighbors of an apex of degree 2 are apex::
@@ -2020,11 +2021,11 @@ class Graph(GenericGraph):
             sage: G = graphs.Grid2dGraph(5,5)
             sage: v = (666, 666)
             sage: G.add_path([(1, 1), v, (3, 3)])
-            sage: G.is_planar()
+            sage: G.is_planar()                                             # needs planarity
             False
             sage: G.degree(v)
             2
-            sage: sorted(G.apex_vertices())
+            sage: sorted(G.apex_vertices())                                 # needs planarity
             [(1, 1), (2, 2), (3, 3), (666, 666)]
 
 
@@ -2045,8 +2046,8 @@ class Graph(GenericGraph):
 
         The graph might be mutable or immutable::
 
-            sage: G = Graph(M+K5, immutable=True)
-            sage: G.apex_vertices()
+            sage: G = Graph(M + K5, immutable=True)
+            sage: G.apex_vertices()                                         # needs planarity
             [9, 10, 11, 12, 13]
         """
         if k is None:
@@ -7409,10 +7410,11 @@ class Graph(GenericGraph):
 
         EXAMPLES::
 
+            sage: # needs planarity
             sage: C = graphs.CubeGraph(3)
             sage: C.is_polyhedral()
             True
-            sage: K33=graphs.CompleteBipartiteGraph(3, 3)
+            sage: K33 = graphs.CompleteBipartiteGraph(3, 3)
             sage: K33.is_polyhedral()
             False
             sage: graphs.CycleGraph(17).is_polyhedral()
@@ -7471,22 +7473,22 @@ class Graph(GenericGraph):
         EXAMPLES::
 
             sage: C = graphs.CubeGraph(3)
-            sage: C.is_circumscribable()                                                # needs sage.numerical.mip
+            sage: C.is_circumscribable()                                                # needs planarity sage.numerical.mip
             True
 
             sage: O = graphs.OctahedralGraph()
-            sage: O.is_circumscribable()                                                # needs sage.numerical.mip
+            sage: O.is_circumscribable()                                                # needs planarity sage.numerical.mip
             True
 
             sage: TT = polytopes.truncated_tetrahedron().graph()                        # needs sage.geometry.polyhedron
-            sage: TT.is_circumscribable()                                               # needs sage.geometry.polyhedron sage.numerical.mip
+            sage: TT.is_circumscribable()                                               # needs planarity sage.geometry.polyhedron sage.numerical.mip
             False
 
         Stellating in a face of the octahedral graph is not circumscribable::
 
             sage: f = set(flatten(choice(O.faces())))
             sage: O.add_edges([[6, i] for i in f])
-            sage: O.is_circumscribable()                                                # needs sage.numerical.mip
+            sage: O.is_circumscribable()                                                # needs planarity sage.numerical.mip
             False
 
         .. SEEALSO::
@@ -7497,7 +7499,7 @@ class Graph(GenericGraph):
         TESTS::
 
             sage: G = graphs.CompleteGraph(5)
-            sage: G.is_circumscribable()
+            sage: G.is_circumscribable()                                                # needs planarity
             Traceback (most recent call last):
             ...
             NotImplementedError: this method only works for polyhedral graphs

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -287,7 +287,7 @@ def is_bicritical(G, matching=None, algorithm='Edmonds', coNP_certificate=False,
         sage: G.add_edges([(5, 6), (5, 7), (6, 7)])
         sage: G.is_cut_vertex(5)
         True
-        sage: G.has_perfect_matching()
+        sage: G.has_perfect_matching()                                              # needs networkx
         True
         sage: G.is_bicritical()                                                     # needs networkx
         False
@@ -305,7 +305,7 @@ def is_bicritical(G, matching=None, algorithm='Edmonds', coNP_certificate=False,
     A bipartite graph of order three or more is not bicritical::
 
         sage: G = graphs.CompleteBipartiteGraph(3, 3)
-        sage: G.has_perfect_matching()
+        sage: G.has_perfect_matching()                                              # needs networkx
         True
         sage: G.is_bicritical()                                                     # needs networkx
         False
@@ -824,8 +824,8 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
         sage: P = graphs.PathGraph(10)
         sage: P.is_bipartite()
         True
-        sage: M = Graph(P.matching())
-        sage: set(P) == set(M)
+        sage: M = Graph(P.matching())                                                   # needs networkx
+        sage: set(P) == set(M)                                                          # needs networkx
         True
         sage: P.is_matching_covered()                                                   # needs networkx
         False
@@ -844,8 +844,8 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
         sage: a = random.choice(list(A))
         sage: b = random.choice(list(B))
         sage: G.delete_vertices([a, b])
-        sage: M = Graph(G.matching())
-        sage: set(M) == set(G)
+        sage: M = Graph(G.matching())                                                   # needs networkx
+        sage: set(M) == set(G)                                                          # needs networkx
         True
         sage: cycle1 = graphs.CycleGraph(4)
         sage: cycle2 = graphs.CycleGraph(6)
@@ -858,12 +858,13 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
         sage: H.is_matching_covered()                                                   # needs networkx
         False
         sage: H.delete_vertices([3, 4])
-        sage: N = Graph(H.matching())
-        sage: set(N) == set(H)
+        sage: N = Graph(H.matching())                                                   # needs networkx
+        sage: set(N) == set(H)                                                          # needs networkx
         False
 
     One may specify a matching::
 
+        sage: # needs networkx
         sage: G = graphs.WheelGraph(20)
         sage: M = Graph(G.matching())
         sage: G.is_matching_covered(matching=M)
@@ -876,6 +877,7 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
 
     One may ask for a co-`\mathcal{NP}` certificate::
 
+        sage: # needs networkx
         sage: G = graphs.CompleteGraph(14)
         sage: G.is_matching_covered(coNP_certificate=True)
         (True, None)

--- a/src/sage/graphs/schnyder.py
+++ b/src/sage/graphs/schnyder.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-graphs
+# sage.doctest: needs planarity
 """
 Schnyder's algorithm for straight-line planar embeddings
 

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -773,7 +773,7 @@ def basis_from_generators(gens, ords=None):
 
     EXAMPLES::
 
-        sage: # needs sage.groups sage.rings.finite_rings
+        sage: # needs sage.groups sage.rings.finite_rings sage.schemes
         sage: from sage.groups.additive_abelian.additive_abelian_wrapper import basis_from_generators
         sage: E = EllipticCurve(GF(31337^6,'a'), j=37)
         sage: E.order()

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -1765,7 +1765,7 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
 
             sage: L = [2*(i, j) + 2* (-i, -j) for i, j in ((1, 2), (2, 3), (3, 1))]
             sage: G = FreeGroup(3) / L
-            sage: G.characteristic_varieties(groebner=True)
+            sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular
             {0: [(0,)],
              1: [(f1 - 1, f2 - 1, f3 - 1), (f1*f3 + 1, f2 - 1), (f1*f2 + 1, f3 - 1), (f2*f3 + 1, f1 - 1),
                  (f2*f3 + 1, f1 - f2), (f2*f3 + 1, f1 - f3), (f1*f3 + 1, f2 - f3)],
@@ -1789,10 +1789,10 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             {0: Ideal (0) of Univariate Laurent Polynomial Ring in f1 over Rational Field,
              1: Ideal (-1 + 2*f1 - 2*f1^2 + f1^3) of Univariate Laurent Polynomial Ring in f1 over Rational Field,
              2: Ideal (1) of Univariate Laurent Polynomial Ring in f1 over Rational Field}
-            sage: G.characteristic_varieties(groebner=True)
+            sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular
             {0: [0], 1: [-1 + f1, 1 - f1 + f1^2], 2: []}
             sage: G = FreeGroup(2)/[3 * (1, ), 2 * (2, )]
-            sage: G.characteristic_varieties(groebner=True)
+            sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular
             {0: [-1 + F1, 1 + F1, 1 - F1 + F1^2, 1 + F1 + F1^2], 1: [1 - F1 + F1^2],  2: []}
             sage: G = FreeGroup(2)/[2 * (2, )]
             sage: G.characteristic_varieties(groebner=True)
@@ -1801,7 +1801,7 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             sage: G.characteristic_varieties()
             {0: Principal ideal (0) of Rational Field,
              1: Principal ideal (1) of Rational Field}
-            sage: G.characteristic_varieties(groebner=True)
+            sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular
             {0: [(0,)], 1: [(1,)]}
         """
         if self.ngens() == 0:

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -360,10 +360,11 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
 
         Check if :issue:`35490` is fixed::
 
+            sage: # needs sage.libs.pari
             sage: q = 7
             sage: FqT.<T> = GF(q)[]
-            sage: N = T^2+1
-            sage: FqTN = QuotientRing(FqT, N*FqT)
+            sage: N = T^2 + 1
+            sage: FqTN = QuotientRing(FqT, N * FqT)
             sage: S = SL(2, FqTN)
             sage: S.is_finite()
             True

--- a/src/sage/groups/matrix_gps/matrix_group.py
+++ b/src/sage/groups/matrix_gps/matrix_group.py
@@ -606,7 +606,7 @@ class MatrixGroup_generic(MatrixGroup_base):
             sage: # needs sage.libs.gap
             sage: CoxeterGroup(['A',0], implementation='matrix').is_trivial()
             True
-            sage: MatrixGroup([matrix(SR, [[1,x], [0,1]])]).is_trivial()
+            sage: MatrixGroup([matrix(SR, [[1,x], [0,1]])]).is_trivial()                # needs sage.symbolic
             False
             sage: G = MatrixGroup([identity_matrix(3), identity_matrix(3)])
             sage: G.ngens()

--- a/src/sage/groups/misc_gps/misc_groups_catalog.py
+++ b/src/sage/groups/misc_gps/misc_groups_catalog.py
@@ -13,17 +13,21 @@ of various groups not listed elsewhere.
 # entry to the list in the module-level
 # docstring of groups/groups_catalog.py
 
-from sage.groups.additive_abelian.additive_abelian_group import AdditiveAbelianGroup as AdditiveAbelian
-from sage.groups.abelian_gps.abelian_group import AbelianGroup as MultiplicativeAbelian
-from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as AdditiveCyclic
-from sage.groups.free_group import FreeGroup as Free
-from sage.groups.artin import ArtinGroup as Artin
-from sage.groups.braid import BraidGroup as Braid
-from sage.groups.semimonomial_transformations.semimonomial_transformation_group import SemimonomialTransformationGroup as SemimonomialTransformation
-from sage.combinat.root_system.coxeter_group import CoxeterGroup
-from sage.combinat.root_system.weyl_group import WeylGroup
-from sage.combinat.colored_permutations import ShephardToddFamilyGroup as ShephardToddFamily
-from sage.groups.raag import RightAngledArtinGroup as RightAngledArtin
-from sage.combinat.root_system.reflection_group_real import ReflectionGroup
-from sage.groups.cactus_group import CactusGroup as Cactus
-from sage.groups.cactus_group import PureCactusGroup as PureCactus
+from sage.misc.lazy_import import lazy_import
+
+lazy_import('sage.groups.additive_abelian.additive_abelian_group', 'AdditiveAbelianGroup', as_='AdditiveAbelian')
+lazy_import('sage.groups.abelian_gps.abelian_group', 'AbelianGroup', as_='MultiplicativeAbelian')
+lazy_import('sage.rings.finite_rings.integer_mod_ring', 'IntegerModRing', as_='AdditiveCyclic')
+lazy_import('sage.groups.free_group', 'FreeGroup', as_='Free')
+lazy_import('sage.groups.artin', 'ArtinGroup', as_='Artin')
+lazy_import('sage.groups.braid', 'BraidGroup', as_='Braid')
+lazy_import('sage.groups.semimonomial_transformations.semimonomial_transformation_group', 'SemimonomialTransformationGroup', as_='SemimonomialTransformation')
+lazy_import('sage.combinat.root_system.coxeter_group', 'CoxeterGroup')
+lazy_import('sage.combinat.root_system.weyl_group', 'WeylGroup')
+lazy_import('sage.combinat.colored_permutations', 'ShephardToddFamilyGroup', as_='ShephardToddFamily')
+lazy_import('sage.groups.raag', 'RightAngledArtinGroup', as_='RightAngledArtin')
+lazy_import('sage.combinat.root_system.reflection_group_real', 'ReflectionGroup')
+lazy_import('sage.groups.cactus_group', 'CactusGroup', as_='Cactus')
+lazy_import('sage.groups.cactus_group', 'PureCactusGroup', as_='PureCactus')
+
+del lazy_import

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -48,6 +48,7 @@ polynomial.
 
 ::
 
+    sage: # needs sage.libs.singular
     sage: singular(389)
     389
     sage: R1 = singular.ring(0, '(x,y)', 'dp')

--- a/src/sage/interfaces/polymake.py
+++ b/src/sage/interfaces/polymake.py
@@ -1456,6 +1456,7 @@ class PolymakeElement(ExtraTabCompletion, InterfaceElement):
 
         Quadratic extensions::
 
+            sage: # needs sage.rings.number_field
             sage: K.<sqrt5> = QuadraticField(5)
             sage: polymake(K(0)).sage()   # optional - jupymake
             0
@@ -1490,7 +1491,7 @@ class PolymakeElement(ExtraTabCompletion, InterfaceElement):
 
             sage: polymake.cube(3).sage() # optional - jupymake
             A 3-dimensional polyhedron in QQ^3 defined as the convex hull of 8 vertices
-            sage: polymake.icosahedron().sage() # optional - jupymake
+            sage: polymake.icosahedron().sage() # optional - jupymake, needs sage.rings.number_field
             A 3-dimensional polyhedron in
              (Number Field in a with defining polynomial x^2 - 5 with a = 2.236067977499790?)^3
              defined as the convex hull of 12 vertices

--- a/src/sage/knots/free_knotinfo_monoid.py
+++ b/src/sage/knots/free_knotinfo_monoid.py
@@ -227,7 +227,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()
-            sage: FKIM(K)                                                               # needs sage.modules
+            sage: FKIM(K)                                                               # needs libhomfly sage.modules
             KnotInfo['K5_1m']
         """
         if isinstance(x, tuple):
@@ -311,8 +311,8 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
             Defining K3_1m
             sage: KI = K3_1 * K3_1m
             sage: K = KI.as_knot()
-            sage: h = K3_1.to_knotinfo()[0][0].homfly_polynomial()                      # needs sage.modules
-            sage: FKIM._search_composition(3, K, h)                                     # needs sage.modules
+            sage: h = K3_1.to_knotinfo()[0][0].homfly_polynomial()                      # needs libhomfly sage.modules
+            sage: FKIM._search_composition(3, K, h)                                     # needs libhomfly sage.modules
             (KnotInfo['K3_1'],)
         """
         from sage.knots.knotinfo import KnotInfo
@@ -403,7 +403,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()
-            sage: FKIM.from_knot(K)                                                     # needs sage.modules
+            sage: FKIM.from_knot(K)                                                     # needs libhomfly sage.modules
             KnotInfo['K5_1m']
 
             sage: # optional - database_knotinfo

--- a/src/sage/knots/knot.py
+++ b/src/sage/knots/knot.py
@@ -441,7 +441,7 @@ class Knot(Link, Element, metaclass=InheritComparisonClasscallMetaclass):
             [(4, 1), (2, 5), (6, 3), (10, 7), (8, 11), (12, 9)]
             sage: K2.dowker_notation()
             [(4, 1), (2, 5), (6, 3), (7, 10), (11, 8), (9, 12)]
-            sage: K.homfly_polynomial() == K2.homfly_polynomial()
+            sage: K.homfly_polynomial() == K2.homfly_polynomial()                       # needs libhomfly
             False
 
         TESTS::

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -2700,7 +2700,7 @@ class Link(SageObject):
 
             sage: B = BraidGroup(9)
             sage: b = B([1, 2, 3, 4, 5, 6, 7, 8])
-            sage: Link(b).jones_polynomial()
+            sage: Link(b).jones_polynomial()                                            # needs sage.symbolic
             1
 
         The "monster" unknot::
@@ -4182,7 +4182,7 @@ class Link(SageObject):
             sage: b, = BraidGroup(2).gens()
             sage: Link(b**13).get_knotinfo()    # optional - database_knotinfo
             KnotInfo['K13a_4878']
-            sage: Link(b**14).get_knotinfo()
+            sage: Link(b**14).get_knotinfo()                    # needs libhomfly
             Traceback (most recent call last):
             ...
             NotImplementedError: this link having more than 11 crossings cannot be determined

--- a/src/sage/modular/modsym/heilbronn.pyx
+++ b/src/sage/modular/modsym/heilbronn.pyx
@@ -1,5 +1,6 @@
 # sage_setup: distribution = sagemath-flint
 # distutils: extra_compile_args = -D_XPG6
+# sage.doctest: needs sage.schemes
 """
 Heilbronn matrix computation
 """

--- a/src/sage/rings/function_field/khuri_makdisi.pyx
+++ b/src/sage/rings/function_field/khuri_makdisi.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-modules
+# sage.doctest: needs sage.schemes
 r"""
 Khuri-Makdisi algorithms for arithmetic in Jacobians
 

--- a/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
+++ b/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
@@ -1145,6 +1145,7 @@ def two_descent_by_two_isogeny(E,
 
     EXAMPLES::
 
+        sage: # needs sage.schemes
         sage: from sage.schemes.elliptic_curves.descent_two_isogeny import two_descent_by_two_isogeny
         sage: E = EllipticCurve('14a')
         sage: n1, n2, n1_prime, n2_prime = two_descent_by_two_isogeny(E)
@@ -1155,7 +1156,7 @@ def two_descent_by_two_isogeny(E,
         sage: log(n1,2) + log(n1_prime,2) - 2 # the rank
         1
 
-        sage: # needs sage.symbolic
+        sage: # needs sage.schemes sage.symbolic
         sage: x,y = var('x,y')
         sage: E = EllipticCurve(y^2 == x^3 + x^2 - 25*x + 39)
         sage: n1, n2, n1_prime, n2_prime = two_descent_by_two_isogeny(E)
@@ -1168,6 +1169,7 @@ def two_descent_by_two_isogeny(E,
 
     Using the verbosity option::
 
+        sage: # needs sage.schemes
         sage: E = EllipticCurve('14a')
         sage: two_descent_by_two_isogeny(E, verbosity=1)
         2-isogeny
@@ -1184,6 +1186,7 @@ def two_descent_by_two_isogeny(E,
 
     Handling curves whose discriminants involve larger than wordsize primes::
 
+        sage: # needs sage.schemes
         sage: E = EllipticCurve('14a')
         sage: E = E.quadratic_twist(next_prime(10^20))
         sage: E
@@ -1204,6 +1207,7 @@ def two_descent_by_two_isogeny(E,
     for rational points which do not exist, and by setting global_limit_large
     to a very high bound, it will still be working when we simulate a ``CTRL-C``::
 
+        sage: # needs sage.schemes
         sage: from sage.schemes.elliptic_curves.descent_two_isogeny import two_descent_by_two_isogeny
         sage: E = EllipticCurve('960d'); E
         Elliptic Curve defined by y^2 = x^3 - x^2 - 900*x - 10098 over Rational Field

--- a/src/sage/schemes/generic/homset.py
+++ b/src/sage/schemes/generic/homset.py
@@ -702,7 +702,7 @@ class SchemeHomset_points(SchemeHomset_generic):
 
         ::
 
-            sage: # needs sage.geometry.polyhedron
+            sage: # needs sage.geometry.polyhedron sage.graphs
             sage: P1 = toric_varieties.P1(base_ring=GF(3))
             sage: list(P1.point_homset())
             [[0 : 1], [1 : 0], [1 : 1], [1 : 2]]

--- a/src/sage/schemes/toric/toric_subscheme.py
+++ b/src/sage/schemes/toric/toric_subscheme.py
@@ -299,7 +299,7 @@ class AlgebraicScheme_subscheme_toric(AlgebraicScheme_subscheme):
             sage: X.<x,y,u,v,t> = CPRFanoToricVariety(Delta_polar=lp)
             sage: Y = X.subscheme(x*v + y*u + t)
             sage: cone = Cone([(1,0,0), (1,1,0), (1,1,1), (1,0,1)])
-            sage: Y.affine_algebraic_patch(cone)
+            sage: Y.affine_algebraic_patch(cone)                                        # needs sage.libs.singular
             Closed subscheme of Affine Space of dimension 4 over Rational Field defined by:
               z0*z2 - z1*z3,
               z1 + z3 + 1


### PR DESCRIPTION
- **build/pkgs/sagemath_polyhedra/dependencies_check: Add sagemath_cddlib**
- **pkgs/sagemath-polyhedra/pyproject.toml.m4: Define extras 'graphs', 'groups'**
- **src/sage/features/sagemath.py: Add # needs**
- **src/sage/arith: Update # needs**
- **src/sage/categories/simplicial_sets.py: Add # needs**
- **src/sage/combinat: Add # needs**
- **src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py: Use lazy_import**
- **src/sage/geometry: Add # needs**
- **src/sage/groups/misc_gps/misc_groups_catalog.py: Use lazy_import**
- **src/sage/groups: Add # needs**
- **src/sage/interfaces: Add # needs**
- **src/sage/knots: Add # needs**
- **src/sage/modular/modsym/heilbronn.pyx: Add file-level # needs**
- **src/sage/rings/function_field/khuri_makdisi.pyx: Add file-level # needs**
- **src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx: Add # needs**
- **src/sage/schemes: Add # needs**
- **src/sage/graphs: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-polyhedra[standard]' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-polyhedra' --update-known-test-failures**
