### PR TITLE
Modularization fix for sage.rings.complex_mpc

### DIFF
--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -2330,7 +2330,7 @@
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "failed": true,
-        "ntests": 356
+        "ntests": 348
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 39
@@ -2513,8 +2513,7 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "failed": true,
-        "ntests": 117
+        "ntests": 119
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
@@ -2661,7 +2660,7 @@
     },
     "sage.rings.real_mpfr": {
         "failed": true,
-        "ntests": 1017
+        "ntests": 956
     },
     "sage.rings.ring": {
         "ntests": 173

--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -736,7 +736,7 @@
         "ntests": 44
     },
     "sage.coding.code_constructions": {
-        "ntests": 6
+        "ntests": 7
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
@@ -1081,7 +1081,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 42
+        "ntests": 43
     },
     "sage.doctest.fixtures": {
         "ntests": 59
@@ -1210,7 +1210,7 @@
         "ntests": 16
     },
     "sage.features.macaulay2": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1273,6 +1273,9 @@
         "ntests": 8
     },
     "sage.features.symengine_py": {
+        "ntests": 4
+    },
+    "sage.features.sympow": {
         "ntests": 4
     },
     "sage.features.tdlib": {
@@ -1360,7 +1363,7 @@
     },
     "sage.geometry.toric_lattice": {
         "failed": true,
-        "ntests": 302
+        "ntests": 298
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 80
@@ -1404,7 +1407,7 @@
         "ntests": 92
     },
     "sage.groups.galois_group": {
-        "ntests": 54
+        "ntests": 40
     },
     "sage.groups.generic": {
         "ntests": 110
@@ -1422,11 +1425,10 @@
         "ntests": 33
     },
     "sage.groups.matrix_gps.linear": {
-        "failed": true,
-        "ntests": 44
+        "ntests": 37
     },
     "sage.groups.matrix_gps.matrix_group": {
-        "ntests": 53
+        "ntests": 54
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -1542,11 +1544,11 @@
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 425
+        "ntests": 431
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2054
+        "ntests": 2052
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -1958,18 +1960,17 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1459
+        "ntests": 1454
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 897
+        "ntests": 902
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "failed": true,
-        "ntests": 96
+        "ntests": 8
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -2097,6 +2098,7 @@
         "ntests": 19
     },
     "sage.quadratic_forms.binary_qf": {
+        "failed": true,
         "ntests": 299
     },
     "sage.quadratic_forms.constructions": {
@@ -2187,7 +2189,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 116
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -2287,7 +2289,7 @@
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
-        "ntests": 501
+        "ntests": 497
     },
     "sage.rings.continued_fraction": {
         "failed": true,
@@ -2328,7 +2330,7 @@
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "failed": true,
-        "ntests": 354
+        "ntests": 356
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 39
@@ -2401,7 +2403,8 @@
         "ntests": 37
     },
     "sage.rings.ideal": {
-        "ntests": 340
+        "failed": true,
+        "ntests": 349
     },
     "sage.rings.ideal_monoid": {
         "failed": true,
@@ -2419,7 +2422,8 @@
         "ntests": 1
     },
     "sage.rings.integer_ring": {
-        "ntests": 202
+        "failed": true,
+        "ntests": 203
     },
     "sage.rings.invariants.invariant_theory": {
         "failed": true,
@@ -2517,14 +2521,15 @@
         "ntests": 516
     },
     "sage.rings.polynomial.multi_polynomial_element": {
-        "ntests": 275
+        "failed": true,
+        "ntests": 277
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "ntests": 99
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 149
+        "ntests": 155
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "failed": true,
@@ -2532,7 +2537,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 135
+        "ntests": 138
     },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 56
@@ -2568,7 +2573,8 @@
         "ntests": 128
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "ntests": 409
+        "failed": true,
+        "ntests": 411
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -2593,7 +2599,8 @@
         "ntests": 9
     },
     "sage.rings.polynomial.term_order": {
-        "ntests": 327
+        "failed": true,
+        "ntests": 328
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 32
@@ -2625,18 +2632,18 @@
     },
     "sage.rings.quotient_ring": {
         "failed": true,
-        "ntests": 189
+        "ntests": 193
     },
     "sage.rings.quotient_ring_element": {
         "ntests": 100
     },
     "sage.rings.rational": {
         "failed": true,
-        "ntests": 545
+        "ntests": 546
     },
     "sage.rings.rational_field": {
         "failed": true,
-        "ntests": 193
+        "ntests": 194
     },
     "sage.rings.real_double": {
         "failed": true,
@@ -2695,7 +2702,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 296
+        "ntests": 304
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
@@ -2708,7 +2715,7 @@
         "ntests": 167
     },
     "sage.schemes.affine.affine_subscheme": {
-        "ntests": 81
+        "ntests": 79
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
@@ -2725,7 +2732,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 395
+        "ntests": 391
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -2762,7 +2769,7 @@
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 499
+        "ntests": 487
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
@@ -2773,7 +2780,7 @@
     },
     "sage.schemes.projective.projective_space": {
         "failed": true,
-        "ntests": 376
+        "ntests": 377
     },
     "sage.schemes.projective.projective_subscheme": {
         "ntests": 240
@@ -2862,7 +2869,7 @@
         "ntests": 2
     },
     "sage.stats.time_series": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.structure.category_object": {
         "failed": true,
@@ -3044,7 +3051,6 @@
         "ntests": 8
     },
     "sage.tests.cmdline": {
-        "failed": true,
         "ntests": 133
     },
     "sage.tests.finite_poset": {

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3720,7 +3720,7 @@ def binomial(x, m, **kwds):
         -6
         sage: binomial(-5, -2)
         0
-        sage: binomial(RealField()('2.5'), 2)                                           # needs sage.rings.real_mpfr
+        sage: binomial(RealField()('2.5'), 2)                                           # needs sage.libs.pari sage.rings.real_mpfr
         1.87500000000000
         sage: binomial(Zp(5)(99),50)
         3 + 4*5^3 + 2*5^4 + 4*5^5 + 4*5^6 + 4*5^7 + 4*5^8 + 5^9 + 2*5^10 + 3*5^11 +

--- a/src/sage/functions/gamma.py
+++ b/src/sage/functions/gamma.py
@@ -320,7 +320,7 @@ class Function_gamma_inc(BuiltinFunction):
 
             sage: gamma_inc(CDF(0,1), 3)                                                # needs sage.libs.pari sage.rings.complex_double
             0.0032085749933691158 + 0.012406185811871568*I
-            sage: gamma_inc(RDF(1), 3)                                                  # needs sage.rings.complex_double
+            sage: gamma_inc(RDF(1), 3)                                                  # needs sage.libs.pari sage.rings.complex_double
             0.049787068367863944
 
             sage: # needs sage.symbolic
@@ -333,9 +333,9 @@ class Function_gamma_inc(BuiltinFunction):
             sage: loads(dumps((gamma_inc(3, 2))))
             gamma(3, 2)
 
-            sage: i = ComplexField(30).0; gamma_inc(2, 1 + i)                           # needs sage.rings.real_mpfr
+            sage: i = ComplexField(30).0; gamma_inc(2, 1 + i)                           # needs sage.libs.pari sage.rings.real_mpfr
             0.70709210 - 0.42035364*I
-            sage: gamma_inc(2., 5)                                                      # needs sage.rings.complex_double
+            sage: gamma_inc(2., 5)                                                      # needs sage.libs.pari sage.rings.complex_double
             0.0404276819945128
 
             sage: x, y = var('x,y')                                                     # needs sage.symbolic
@@ -393,9 +393,9 @@ class Function_gamma_inc(BuiltinFunction):
         """
         EXAMPLES::
 
-            sage: gamma_inc(2., 0)                                                      # needs sage.rings.complex_double
+            sage: gamma_inc(2., 0)                                                      # needs sage.libs.pari sage.rings.complex_double
             1.00000000000000
-            sage: gamma_inc(2, 0)                                                       # needs sage.rings.real_mpfr
+            sage: gamma_inc(2, 0)                                                       # needs sage.libs.pari sage.rings.real_mpfr
             1
 
             sage: # needs sage.symbolic

--- a/src/sage/functions/special.py
+++ b/src/sage/functions/special.py
@@ -417,7 +417,7 @@ def elliptic_j(z, prec=53):
 
     EXAMPLES::
 
-        sage: elliptic_j(CC(i))                                                         # needs sage.rings.real_mpfr
+        sage: elliptic_j(CC(i))                                                         # needs sage.rings.real_mpfr sage.symbolic
         1728.00000000000
         sage: elliptic_j(sqrt(-2.0))                                                    # needs sage.rings.complex_double
         8000.00000000000

--- a/src/sage/rings/complex_double.pyx
+++ b/src/sage/rings/complex_double.pyx
@@ -661,6 +661,7 @@ cdef class ComplexDoubleField_class(sage.rings.abc.ComplexDoubleField):
 
         TESTS::
 
+            sage: # needs numpy
             sage: R.<x> = CDF[]
             sage: CDF._factor_univariate_polynomial(x)
             x

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -414,9 +414,9 @@ cdef class MPComplexField_class(Field):
 
         Complex number can be coerced into MPComplexNumber::
 
-            sage: C20(14.7+0.35*I)
+            sage: C20(14.7 + 0.35*I)                                                    # needs sage.symbolic
             14.700 + 0.35000*I
-            sage: C20(i*4, 7)
+            sage: C20(i*4, 7)                                                           # needs sage.symbolic
             Traceback (most recent call last):
             ...
             TypeError: unable to coerce to a ComplexNumber: <class 'sage.rings.number_field.number_field_element_quadratic.NumberFieldElement_gaussian'>
@@ -788,11 +788,11 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
             sage: c = ComplexField(53)(1, r)
             sage: MPC(c)
             1.0000000000000000000000000000 + 3.1415926535897931159979634685*I
-            sage: MPC(I)
+            sage: MPC(I)                                                                # needs sage.symbolic
             1.0000000000000000000000000000*I
             sage: MPC('-0 +i')
             1.0000000000000000000000000000*I
-            sage: MPC(1+i)
+            sage: MPC(1+i)                                                              # needs sage.symbolic
             1.0000000000000000000000000000 + 1.0000000000000000000000000000*I
             sage: MPC(1/3)
             0.33333333333333333333333333333
@@ -1306,8 +1306,8 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
         EXAMPLES::
 
             sage: MPC = MPComplexField()
-            sage: z = 1 + MPC(I)
-            sage: z.is_zero()
+            sage: z = 1 + MPC(I)                                                        # needs sage.symbolic
+            sage: z.is_zero()                                                           # needs sage.symbolic
             False
         """
         return not (mpfr_zero_p(self.value.re) and mpfr_zero_p(self.value.im))
@@ -1340,7 +1340,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
             sage: C200 = MPComplexField(200)
             sage: C200(1.23).is_real()
             True
-            sage: C200(1+i).is_real()
+            sage: C200(1 + i).is_real()                                                 # needs sage.symbolic
             False
         """
         return (mpfr_zero_p(self.value.im) != 0)
@@ -1352,9 +1352,9 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
         EXAMPLES::
 
             sage: C200 = MPComplexField(200)
-            sage: C200(1.23*i).is_imaginary()
+            sage: C200(1.23*i).is_imaginary()                                           # needs sage.symbolic
             True
-            sage: C200(1+i).is_imaginary()
+            sage: C200(1 + i).is_imaginary()                                            # needs sage.symbolic
             False
         """
         return (mpfr_zero_p(self.value.re) != 0)
@@ -1371,6 +1371,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: MPC = MPComplexField()
             sage: z = (1/2)*(1 + sqrt(3.0) * MPC.0); z
             0.500000000000000 + 0.866025403784439*I
@@ -1948,7 +1949,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
         EXAMPLES::
 
             sage: MPC = MPComplexField(53)
-            sage: (1+MPC(I)).cot()
+            sage: (1+MPC(I)).cot()                                                      # needs sage.symbolic
             0.217621561854403 - 0.868014142895925*I
             sage: i = MPComplexField(200).0
             sage: (1+i).cot()
@@ -2198,7 +2199,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
             sage: MPC = MPComplexField()
             sage: a = MPC(1,0)
-            sage: a.dilog()
+            sage: a.dilog()                                                             # needs sage.libs.pari
             1.64493406684823
             sage: float(pi^2/6)                                                         # needs sage.symbolic
             1.6449340668482262
@@ -2206,13 +2207,13 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
         ::
 
             sage: b = MPC(0,1)
-            sage: b.dilog()
+            sage: b.dilog()                                                             # needs sage.libs.pari
             -0.205616758356028 + 0.915965594177219*I
 
         ::
 
             sage: c = MPC(0,0)
-            sage: c.dilog()
+            sage: c.dilog()                                                             # needs sage.libs.pari
             0
         """
         return self._parent(self.__pari__().dilog())
@@ -2244,7 +2245,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
             sage: MPC = MPComplexField()
             sage: i = MPC.0
-            sage: z = 1+i; z.eta()
+            sage: z = 1+i; z.eta()                                                      # needs sage.libs.pari
             0.742048775836565 + 0.198831370229911*I
         """
         try:
@@ -2260,17 +2261,17 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
             sage: MPC = MPComplexField(30)
             sage: i = MPC.0
-            sage: (1+i).gamma()
+            sage: (1+i).gamma()                                                         # needs sage.libs.pari
             0.49801567 - 0.15494983*I
 
         TESTS::
 
-            sage: MPC(0).gamma()
+            sage: MPC(0).gamma()                                                        # needs sage.libs.pari
             Infinity
 
         ::
 
-            sage: MPC(-1).gamma()
+            sage: MPC(-1).gamma()                                                       # needs sage.libs.pari
             Infinity
         """
         try:
@@ -2285,6 +2286,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: C, i = MPComplexField(30).objgen()
             sage: (1+i).gamma_inc(2 + 3*i)  # abs tol 2e-10
             0.0020969149 - 0.059981914*I
@@ -2303,7 +2305,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
             sage: i = MPComplexField(30).gen()
             sage: z = 1 + i
-            sage: z.zeta()
+            sage: z.zeta()                                                              # needs sage.libs.pari
             0.58215806 - 0.92684856*I
         """
         return self._parent(self.__pari__().zeta())
@@ -2317,7 +2319,7 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
             sage: MPC = MPComplexField()
             sage: u = MPC(1, 4)
             sage: v = MPC(-2,5)
-            sage: u.agm(v, algorithm='pari')
+            sage: u.agm(v, algorithm='pari')                                            # needs sage.libs.pari
             -0.410522769709397 + 4.60061063922097*I
             sage: u.agm(v, algorithm='principal')
             1.24010691168158 - 0.472193567796433*I
@@ -2438,7 +2440,7 @@ def __create__MPComplexNumber_version0 (parent, s, base=10):
     EXAMPLES::
 
         sage: C = MPComplexField(prec=20, rnd='RNDUU')
-        sage: sage.rings.complex_mpc.__create__MPComplexNumber_version0(C, 3.2+2*i)
+        sage: sage.rings.complex_mpc.__create__MPComplexNumber_version0(C, 3.2+2*i)     # needs sage.symbolic
         3.2001 + 2.0000*I
         sage: C = MPComplexField(prec=20, rnd='RNDUU')
         sage: sage.rings.complex_mpc.__create__MPComplexNumber_version0(C,"33.",10)

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -108,10 +108,11 @@ def late_import():
     """
     global AA, QQbar
     global CLF, RLF, CDF
-    if AA is None:
-        import sage.rings.qqbar
-        AA = sage.rings.qqbar.AA
-        QQbar = sage.rings.qqbar.QQbar
+    if CDF is None:
+        try:
+            from sage.rings.qqbar import AA, QQbar
+        except ImportError:
+            pass
         from sage.rings.real_lazy import CLF, RLF
         from sage.rings.complex_double import CDF
 

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -1638,6 +1638,7 @@ In the latter case, please inform the developers.""".format(self.order()))
             sage: R._lift_residue_field_root(2, 16, f, f.derivative(), Zmod(2)(1))
             (65535,)
 
+            sage: # needs sage.libs.pari
             sage: R = Zmod(7**4)
             sage: S.<x> = R[]
             sage: f = x^4 - 2
@@ -1788,6 +1789,7 @@ In the latter case, please inform the developers.""".format(self.order()))
         We can find roots without multiplicities over a ring whose modulus is
         a prime power, even a big power:
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = Zmod(7^3)[]
             sage: (x^2 + x + 1).roots(multiplicities=False)
             [18, 324]

--- a/src/sage/rings/polynomial/laurent_polynomial_ring_base.py
+++ b/src/sage/rings/polynomial/laurent_polynomial_ring_base.py
@@ -577,7 +577,8 @@ class LaurentPolynomialRing_generic(CommutativeRing, Parent):
 
         Test for constructions which use multivariate polynomial rings::
 
-            sage: rings = [RR, QQ, ZZ, GF(13), GF(7^3)]
+            sage: rings = [RR, QQ, ZZ, GF(13)]
+            sage: rings += [GF(7^3)]                                                    # needs sage.rings.finite_rings
             sage: for ring in rings:
             ....:     d = randint(1, 6)
             ....:     t = randint(5, 20)
@@ -594,7 +595,8 @@ class LaurentPolynomialRing_generic(CommutativeRing, Parent):
 
         Test for constructions which use univariate polynomial rings::
 
-            sage: rings = [RR, QQ, ZZ, GF(13), GF(7^3)]
+            sage: rings = [RR, QQ, ZZ, GF(13)]
+            sage: rings += [GF(7^3)]                                                    # needs sage.rings.finite_rings
             sage: for ring in rings:
             ....:     L.<x> = LaurentPolynomialRing(ring)
             ....:     for _ in range(100):

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -1669,7 +1669,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
             ....:     for rnd_dir in ('RNDN', 'RNDD', 'RNDU', 'RNDZ'):
             ....:         fld = RealField(prec, rnd=rnd_dir)
             ....:         var = polygen(fld)
-            ....:         for v in [NaN, -infinity, -20, -e, 0, 1, 2^500, -2^4000, -2^-500, 2^-4000] + [fld.random_element() for _ in range(5)]:
+            ....:         for v in values + [fld.random_element() for _ in range(5)]:
             ....:             for preparse in (True, False, None):
             ....:                 _ = sage_input(fld(v), verify=True, preparse=preparse)
             ....:                 _ = sage_input(fld(v) * var, verify=True, preparse=preparse)
@@ -2361,7 +2361,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         r"""
         TESTS::
 
-            sage: RR(1) + RIF(1)
+            sage: RR(1) + RIF(1)                                                        # needs sage.rings.real_interval_field
             doctest:...:
             DeprecationWarning: automatic conversions from floating-point numbers to intervals are deprecated
             See https://github.com/sagemath/sage/issues/15114 for details.
@@ -2385,7 +2385,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         r"""
         TESTS::
 
-            sage: RR(2) - RIF(1)
+            sage: RR(2) - RIF(1)                                                        # needs sage.rings.real_interval_field
             doctest:...:
             DeprecationWarning: automatic conversions from floating-point numbers to intervals are deprecated
             See https://github.com/sagemath/sage/issues/15114 for details.
@@ -2409,7 +2409,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         r"""
         TESTS::
 
-            sage: RR(1) * RIF(1)
+            sage: RR(1) * RIF(1)                                                        # needs sage.rings.real_interval_field
             doctest:...:
             DeprecationWarning: automatic conversions from floating-point numbers to intervals are deprecated
             See https://github.com/sagemath/sage/issues/15114 for details.
@@ -2433,7 +2433,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         r"""
         TESTS::
 
-            sage: RR(1) / RIF(1/2)
+            sage: RR(1) / RIF(1/2)                                                      # needs sage.rings.real_interval_field
             doctest:...:
             DeprecationWarning: automatic conversions from floating-point numbers to intervals are deprecated
             See https://github.com/sagemath/sage/issues/15114 for details.
@@ -3531,6 +3531,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.real_interval_field
             sage: RRd = RealField(53, rnd='RNDD')
             sage: RRz = RealField(53, rnd='RNDZ')
             sage: RRu = RealField(53, rnd='RNDU')
@@ -3708,6 +3709,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.real_interval_field
             sage: (0.333).nearby_rational(max_error=0.001)
             1/3
             sage: (0.333).nearby_rational(max_error=1)
@@ -3717,6 +3719,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
         ::
 
+            sage: # needs sage.rings.real_interval_field
             sage: (0.333).nearby_rational(max_denominator=100)
             1/3
             sage: RR(1/3 + 1/1000000).nearby_rational(max_denominator=2999999)
@@ -3728,7 +3731,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
             sage: RR(3/4).nearby_rational(max_denominator=2)
             1
 
-            sage: # needs sage.symbolic
+            sage: # needs sage.rings.real_interval_field sage.symbolic
             sage: RR(pi).nearby_rational(max_denominator=120)
             355/113
             sage: RR(pi).nearby_rational(max_denominator=10000)
@@ -3738,7 +3741,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
             sage: RR(pi).nearby_rational(max_denominator=1)
             3
 
-            sage: RR(-3.5).nearby_rational(max_denominator=1)
+            sage: RR(-3.5).nearby_rational(max_denominator=1)                           # needs sage.rings.real_interval_field
             -3
 
         TESTS::

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -919,7 +919,7 @@ cdef class Element(SageObject):
             sage: mp.dps = 30
             sage: 25._mpmath_(53)
             mpf('25.0')
-            sage: mpmathify(3 + 4*I)
+            sage: mpmathify(3 + 4*I)                                                    # needs sage.symbolic
             mpc(real='3.0', imag='4.0')
             sage: mpmathify(1 + pi)                                                     # needs sage.symbolic
             mpf('4.14159265358979323846264338327933')
@@ -2864,7 +2864,7 @@ cdef class RingElement(ModuleElement):
             sage: a.is_nilpotent()
             True
             sage: m = matrix(QQ, 3, [[3,2,3], [9,0,3], [-9,0,-3]])                      # needs sage.modules
-            sage: m.is_nilpotent()                                                      # needs sage.modules
+            sage: m.is_nilpotent()                                                      # needs sage.libs.pari sage.modules
             True
         """
         if self.is_unit():


### PR DESCRIPTION
- **src/sage/rings/complex_mpc.pyx (late_import): Do not fail when sage.rings.qqbar cannot be imported**
- **src/sage/arith/misc.py: Add # needs**
- **src/sage/functions: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/structure/element.pyx: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-modules' --update-known-test-failures**
