### PR TITLE
pkgs/sagemath-polyhedra: Doctest modularization fixes

### DIFF
--- a/pkgs/sagemath-polyhedra/known-test-failures--standard.json
+++ b/pkgs/sagemath-polyhedra/known-test-failures--standard.json
@@ -210,7 +210,6 @@
         "ntests": 7
     },
     "sage.categories.commutative_rings": {
-        "failed": true,
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
@@ -440,7 +439,6 @@
         "ntests": 11
     },
     "sage.categories.functor": {
-        "failed": true,
         "ntests": 137
     },
     "sage.categories.g_sets": {
@@ -785,7 +783,6 @@
         "ntests": 45
     },
     "sage.coding.code_constructions": {
-        "failed": true,
         "ntests": 144
     },
     "sage.coding.codecan.autgroup_can_label": {
@@ -798,7 +795,6 @@
         "ntests": 1
     },
     "sage.coding.cyclic_code": {
-        "failed": true,
         "ntests": 274
     },
     "sage.coding.databases": {
@@ -833,7 +829,6 @@
         "ntests": 115
     },
     "sage.coding.grs_code": {
-        "failed": true,
         "ntests": 530
     },
     "sage.coding.guava": {
@@ -853,11 +848,9 @@
         "ntests": 172
     },
     "sage.coding.kasami_codes": {
-        "failed": true,
         "ntests": 45
     },
     "sage.coding.linear_code": {
-        "failed": true,
         "ntests": 404
     },
     "sage.coding.linear_code_no_metric": {
@@ -885,7 +878,6 @@
         "ntests": 65
     },
     "sage.coding.two_weight_db": {
-        "failed": true,
         "ntests": 2
     },
     "sage.combinat.abstract_tree": {
@@ -959,11 +951,9 @@
         "ntests": 2
     },
     "sage.combinat.designs.designs_pyx": {
-        "failed": true,
         "ntests": 86
     },
     "sage.combinat.designs.difference_family": {
-        "failed": true,
         "ntests": 391
     },
     "sage.combinat.designs.difference_matrices": {
@@ -990,7 +980,8 @@
         "ntests": 36
     },
     "sage.combinat.designs.orthogonal_arrays_build_recursive": {
-        "ntests": 47
+        "failed": true,
+        "ntests": 61
     },
     "sage.combinat.designs.resolvable_bibd": {
         "ntests": 22
@@ -1358,7 +1349,6 @@
         "ntests": 283
     },
     "sage.crypto.sboxes": {
-        "failed": true,
         "ntests": 27
     },
     "sage.data_structures.bitset": {
@@ -1375,6 +1365,9 @@
     },
     "sage.data_structures.mutable_poset": {
         "ntests": 441
+    },
+    "sage.databases.conway": {
+        "ntests": 42
     },
     "sage.databases.knotinfo_db": {
         "ntests": 100
@@ -2243,7 +2236,6 @@
         "ntests": 31
     },
     "sage.groups.generic": {
-        "failed": true,
         "ntests": 201
     },
     "sage.groups.group": {
@@ -2295,7 +2287,6 @@
         "ntests": 80
     },
     "sage.groups.matrix_gps.heisenberg": {
-        "failed": true,
         "ntests": 36
     },
     "sage.groups.matrix_gps.isometries": {
@@ -2415,11 +2406,9 @@
         "ntests": 181
     },
     "sage.groups.semimonomial_transformations.semimonomial_transformation": {
-        "failed": true,
         "ntests": 57
     },
     "sage.groups.semimonomial_transformations.semimonomial_transformation_group": {
-        "failed": true,
         "ntests": 62
     },
     "sage.homology.algebraic_topological_model": {
@@ -2569,7 +2558,6 @@
         "ntests": 14
     },
     "sage.libs.gap.element": {
-        "failed": true,
         "ntests": 519
     },
     "sage.libs.gap.libgap": {
@@ -2608,14 +2596,12 @@
         "ntests": 70
     },
     "sage.libs.ntl.ntl_GF2EContext": {
-        "failed": true,
         "ntests": 20
     },
     "sage.libs.ntl.ntl_GF2EX": {
         "ntests": 31
     },
     "sage.libs.ntl.ntl_GF2X": {
-        "failed": true,
         "ntests": 112
     },
     "sage.libs.ntl.ntl_GF2X_linkage.pxi": {
@@ -3254,7 +3240,6 @@
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "failed": true,
         "ntests": 133
     },
     "sage.modules.real_double_vector": {
@@ -3304,7 +3289,6 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "failed": true,
         "ntests": 184
     },
     "sage.modules.with_basis.indexed_element": {
@@ -3744,7 +3728,6 @@
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
-        "failed": true,
         "ntests": 213
     },
     "sage.rings.bernmm": {
@@ -3804,19 +3787,15 @@
         "ntests": 57
     },
     "sage.rings.finite_rings.element_base": {
-        "failed": true,
         "ntests": 248
     },
     "sage.rings.finite_rings.element_givaro": {
-        "failed": true,
         "ntests": 244
     },
     "sage.rings.finite_rings.element_ntl_gf2e": {
-        "failed": true,
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
-        "failed": true,
         "ntests": 300
     },
     "sage.rings.finite_rings.finite_field_base": {
@@ -3828,15 +3807,12 @@
         "ntests": 126
     },
     "sage.rings.finite_rings.finite_field_givaro": {
-        "failed": true,
         "ntests": 122
     },
     "sage.rings.finite_rings.finite_field_ntl_gf2e": {
-        "failed": true,
         "ntests": 61
     },
     "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "failed": true,
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
@@ -3846,7 +3822,6 @@
         "ntests": 20
     },
     "sage.rings.finite_rings.hom_finite_field": {
-        "failed": true,
         "ntests": 201
     },
     "sage.rings.finite_rings.hom_finite_field_givaro": {
@@ -3856,7 +3831,6 @@
         "ntests": 21
     },
     "sage.rings.finite_rings.homset": {
-        "failed": true,
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
@@ -4095,26 +4069,21 @@
         "ntests": 180
     },
     "sage.rings.padics.CA_template.pxi": {
-        "failed": true,
         "ntests": 311
     },
     "sage.rings.padics.CR_template.pxi": {
-        "failed": true,
         "ntests": 431
     },
     "sage.rings.padics.FM_template.pxi": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.padics.FP_template.pxi": {
-        "failed": true,
         "ntests": 342
     },
     "sage.rings.padics.eisenstein_extension_generic": {
         "ntests": 41
     },
     "sage.rings.padics.factory": {
-        "failed": true,
         "ntests": 559
     },
     "sage.rings.padics.generic_nodes": {
@@ -4139,11 +4108,9 @@
         "ntests": 223
     },
     "sage.rings.padics.padic_extension_generic": {
-        "failed": true,
         "ntests": 208
     },
     "sage.rings.padics.padic_extension_leaves": {
-        "failed": true,
         "ntests": 72
     },
     "sage.rings.padics.padic_generic_element": {
@@ -4154,7 +4121,6 @@
         "ntests": 269
     },
     "sage.rings.padics.padic_printing": {
-        "failed": true,
         "ntests": 108
     },
     "sage.rings.padics.padic_relaxed_errors": {
@@ -4173,43 +4139,33 @@
         "ntests": 76
     },
     "sage.rings.padics.pow_computer_relative": {
-        "failed": true,
         "ntests": 97
     },
     "sage.rings.padics.qadic_flint_CA": {
-        "failed": true,
         "ntests": 19
     },
     "sage.rings.padics.qadic_flint_CR": {
-        "failed": true,
         "ntests": 23
     },
     "sage.rings.padics.qadic_flint_FM": {
-        "failed": true,
         "ntests": 17
     },
     "sage.rings.padics.qadic_flint_FP": {
-        "failed": true,
         "ntests": 22
     },
     "sage.rings.padics.relative_extension_leaves": {
-        "failed": true,
         "ntests": 87
     },
     "sage.rings.padics.relative_ramified_CA": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_CR": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FM": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FP": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relaxed_template.pxi": {
@@ -4219,11 +4175,9 @@
         "ntests": 12
     },
     "sage.rings.padics.tutorial": {
-        "failed": true,
         "ntests": 45
     },
     "sage.rings.padics.unramified_extension_generic": {
-        "failed": true,
         "ntests": 33
     },
     "sage.rings.pari_ring": {
@@ -4268,7 +4222,7 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 127
+        "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
@@ -4291,7 +4245,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 141
+        "ntests": 142
     },
     "sage.rings.polynomial.omega": {
         "failed": true,
@@ -4348,10 +4302,9 @@
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
         "failed": true,
-        "ntests": 508
+        "ntests": 503
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "failed": true,
         "ntests": 151
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
@@ -4361,7 +4314,6 @@
         "ntests": 136
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "failed": true,
         "ntests": 525
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
@@ -4381,7 +4333,6 @@
         "ntests": 183
     },
     "sage.rings.polynomial.polynomial_zz_pex": {
-        "failed": true,
         "ntests": 155
     },
     "sage.rings.polynomial.real_roots": {
@@ -4488,7 +4439,6 @@
         "ntests": 442
     },
     "sage.rings.ring_extension_conversion": {
-        "failed": true,
         "ntests": 75
     },
     "sage.rings.ring_extension_element": {
@@ -4496,11 +4446,9 @@
         "ntests": 279
     },
     "sage.rings.ring_extension_homset": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.ring_extension_morphism": {
-        "failed": true,
         "ntests": 148
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
@@ -4582,7 +4530,6 @@
         "ntests": 36
     },
     "sage.schemes.affine.affine_space": {
-        "failed": true,
         "ntests": 175
     },
     "sage.schemes.affine.affine_subscheme": {
@@ -4844,7 +4791,6 @@
         "ntests": 6
     },
     "sage.structure.factory": {
-        "failed": true,
         "ntests": 118
     },
     "sage.structure.formal_sum": {
@@ -4878,7 +4824,6 @@
         "ntests": 369
     },
     "sage.structure.parent_gens": {
-        "failed": true,
         "ntests": 41
     },
     "sage.structure.parent_old": {

--- a/pkgs/sagemath-polyhedra/known-test-failures.json
+++ b/pkgs/sagemath-polyhedra/known-test-failures.json
@@ -1262,8 +1262,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "failed": true,
-        "ntests": 0
+        "ntests": 181
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1729,7 +1728,6 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
-        "failed": true,
         "ntests": 5
     },
     "sage.interfaces.abc": {
@@ -2390,7 +2388,6 @@
         "ntests": 19
     },
     "sage.quadratic_forms.binary_qf": {
-        "failed": true,
         "ntests": 299
     },
     "sage.quadratic_forms.constructions": {
@@ -2573,11 +2570,10 @@
     },
     "sage.rings.complex_double": {
         "failed": true,
-        "ntests": 325
+        "ntests": 315
     },
     "sage.rings.complex_mpc": {
-        "failed": true,
-        "ntests": 406
+        "ntests": 397
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
@@ -2622,7 +2618,7 @@
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "failed": true,
-        "ntests": 354
+        "ntests": 346
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 39
@@ -2803,8 +2799,7 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "failed": true,
-        "ntests": 117
+        "ntests": 119
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
@@ -2826,7 +2821,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 135
+        "ntests": 138
     },
     "sage.rings.polynomial.omega": {
         "failed": true,
@@ -2952,7 +2947,7 @@
     },
     "sage.rings.real_mpfr": {
         "failed": true,
-        "ntests": 1017
+        "ntests": 956
     },
     "sage.rings.ring": {
         "ntests": 173
@@ -2993,7 +2988,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 296
+        "ntests": 304
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -5715,10 +5715,10 @@ class GenericGraph(GenericGraph_pyx):
         ::
 
             sage: k43 = graphs.CompleteBipartiteGraph(4, 3)
-            sage: result = k43.is_planar(kuratowski=True); result
+            sage: result = k43.is_planar(kuratowski=True); result                       # needs planarity
             (False,
              Kuratowski subgraph of (Complete bipartite graph of order 4+3): Graph on 6 vertices)
-            sage: result[1].is_isomorphic(graphs.CompleteBipartiteGraph(3, 3))
+            sage: result[1].is_isomorphic(graphs.CompleteBipartiteGraph(3, 3))          # needs planarity
             True
 
         Multi-edged and looped graphs are partially supported::
@@ -5954,11 +5954,11 @@ class GenericGraph(GenericGraph_pyx):
             sage: g439.show()                                                           # needs sage.plot
             sage: g439.is_circular_planar(boundary=[1, 2, 3, 4])                        # needs planarity
             False
-            sage: g439.is_circular_planar(kuratowski=True, boundary=[1, 2, 3, 4])
+            sage: g439.is_circular_planar(kuratowski=True, boundary=[1, 2, 3, 4])       # needs planarity
             (False, Kuratowski subgraph of (): Graph on 8 vertices)
-            sage: g439.is_circular_planar(kuratowski=True, boundary=[1, 2, 3])
+            sage: g439.is_circular_planar(kuratowski=True, boundary=[1, 2, 3])          # needs planarity
             (True, None)
-            sage: g439.get_embedding()
+            sage: g439.get_embedding()                                                  # needs planarity
             {1: [5, 7],
              2: [6, 5],
              3: [7, 6],
@@ -5972,12 +5972,12 @@ class GenericGraph(GenericGraph_pyx):
             sage: K23 = graphs.CompleteBipartiteGraph(2, 3)
             sage: K23.is_circular_planar(boundary=[0, 1, 2, 3])                         # needs planarity
             True
-            sage: K23.is_circular_planar(ordered=True, boundary=[0, 1, 2, 3])
+            sage: K23.is_circular_planar(ordered=True, boundary=[0, 1, 2, 3])           # needs planarity
             False
 
         With a different order::
 
-            sage: K23.is_circular_planar(set_embedding=True, boundary=[0, 2, 1, 3])
+            sage: K23.is_circular_planar(set_embedding=True, boundary=[0, 2, 1, 3])     # needs planarity
             True
 
         TESTS:
@@ -5992,7 +5992,7 @@ class GenericGraph(GenericGraph_pyx):
         Argument saving::
 
             sage: G = Graph([(1, 2)])
-            sage: for set_embedding, set_pos in ((True,True), (True,False), (False, True), (False, False)):
+            sage: for set_embedding, set_pos in ((True,True), (True,False), (False, True), (False, False)):     # needs planarity
             ....:     G = Graph([(1, 2)])
             ....:     assert G.is_circular_planar(set_embedding=set_embedding, set_pos=set_pos)
             ....:     assert (hasattr(G, '_embedding') and G._embedding is not None) == set_embedding, (set_embedding, set_pos)
@@ -6173,7 +6173,7 @@ class GenericGraph(GenericGraph_pyx):
         TESTS::
 
             sage: G = Graph([[0, 1, 2, 3], [[0, 1], [0, 2], [0, 3]]])
-            sage: G.layout(layout='planar', external_face=(1, 2))
+            sage: G.layout(layout='planar', external_face=(1, 2))                       # needs planarity
             Traceback (most recent call last):
             ...
             ValueError: (1, 2) is not an edge of Graph on 4 vertices
@@ -6182,6 +6182,7 @@ class GenericGraph(GenericGraph_pyx):
         Check the dependence of the computed position on the given combinatorial
         embedding (:issue:`28152`)::
 
+            sage: # needs planarity
             sage: G = Graph([[0, 1, 2, 3], [[0, 1], [0, 2], [0, 3]]])
             sage: G.set_embedding({0: [1, 2, 3], 1: [0], 2: [0], 3: [0]})
             sage: pos1 = G.layout('planar', save_pos=True)
@@ -6195,6 +6196,7 @@ class GenericGraph(GenericGraph_pyx):
         Check that the function handles disconnected graphs and small
         graphs (:issue:`29522`)::
 
+            sage: # needs planarity
             sage: G = graphs.CycleGraph(4) + graphs.CycleGraph(5)
             sage: G.layout_planar() # random
             {1: [3.0, 1],
@@ -6217,12 +6219,12 @@ class GenericGraph(GenericGraph_pyx):
 
             sage: H = graphs.LadderGraph(4) + graphs.CompleteGraph(3)
             sage: em = {0:[1,4], 4:[0,5], 1:[5,2,0], 5:[4,6,1], 2:[1,3,6], 6:[7,5,2], 3:[7,2], 7:[3,6], 8:[10,9], 9:[8,10], 10:[8,9]}
-            sage: p = H.layout_planar(on_embedding=em)
+            sage: p = H.layout_planar(on_embedding=em)                                  # needs planarity
 
         Check that an exception is raised if the input graph is not planar::
 
             sage: G = graphs.PetersenGraph()
-            sage: G.layout(layout='planar')
+            sage: G.layout(layout='planar')                                             # needs planarity
             Traceback (most recent call last):
             ...
             ValueError: Petersen graph is not a planar graph
@@ -6358,8 +6360,8 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: D = graphs.DodecahedralGraph()
-            sage: pos = D.layout(layout='planar', save_pos=True)
-            sage: D.is_drawn_free_of_edge_crossings()
+            sage: pos = D.layout(layout='planar', save_pos=True)                        # needs planarity
+            sage: D.is_drawn_free_of_edge_crossings()                                   # needs planarity
             True
         """
         if self._pos is None:
@@ -6459,6 +6461,7 @@ class GenericGraph(GenericGraph_pyx):
 
         EXAMPLES::
 
+            sage: # needs planarity
             sage: g = graphs.PetersenGraph()
             sage: g.genus() # tests for minimal genus by default
             1
@@ -6480,6 +6483,7 @@ class GenericGraph(GenericGraph_pyx):
         Using the circular argument, we can compute the minimal genus preserving
         a planar, ordered boundary::
 
+            sage: # needs planarity
             sage: cube = graphs.CubeGraph(2)
             sage: cube.genus(circular=['01','10'])
             0
@@ -6522,7 +6526,7 @@ class GenericGraph(GenericGraph_pyx):
         maximal genus::
 
             sage: G = graphs.RandomBlockGraph(10, 5)
-            sage: G.genus()
+            sage: G.genus()                                                             # needs planarity
             10
         """
         if not self.is_connected():
@@ -6625,7 +6629,7 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: P = graphs.PetersenGraph()
-            sage: P.crossing_number()
+            sage: P.crossing_number()                                                   # needs planarity
             2
 
         ALGORITHM:
@@ -6641,23 +6645,23 @@ class GenericGraph(GenericGraph_pyx):
         Empty graph, graph without edges::
 
             sage: E = graphs.EmptyGraph()
-            sage: E.crossing_number()
+            sage: E.crossing_number()                                                   # needs planarity
             0
 
             sage: g = Graph(5)
-            sage: g.crossing_number()
+            sage: g.crossing_number()                                                   # needs planarity
             0
 
         Planar graph::
 
             sage: C4 = graphs.CompleteGraph(4)
-            sage: C4.crossing_number()
+            sage: C4.crossing_number()                                                  # needs planarity
             0
 
         Non-connected graph::
 
             sage: C5x2 = graphs.CompleteGraph(5) * 2
-            sage: C5x2.crossing_number()
+            sage: C5x2.crossing_number()                                                # needs planarity
             2
 
         Test the "un-splitting edges" optimization::
@@ -6665,13 +6669,13 @@ class GenericGraph(GenericGraph_pyx):
             sage: g = graphs.CompleteGraph(4)
             sage: g.subdivide_edges(g.edges(sort=True), 1)
             sage: g.add_edge(0, g.add_vertex())
-            sage: g.crossing_number()
+            sage: g.crossing_number()                                                   # needs planarity
             0
 
             sage: g = graphs.CompleteGraph(5)
             sage: g.subdivide_edges(g.edges(sort=False), 2)
             sage: g.add_edge(0, g.add_vertex())
-            sage: g.crossing_number()
+            sage: g.crossing_number()                                                   # needs planarity
             1
         """
         def _crossing_number(G):
@@ -6775,7 +6779,7 @@ class GenericGraph(GenericGraph_pyx):
 
         With no embedding provided::
 
-            sage: graphs.TetrahedralGraph().faces()
+            sage: graphs.TetrahedralGraph().faces()                                     # needs planarity
             [[(0, 1), (1, 2), (2, 0)],
              [(0, 2), (2, 3), (3, 0)],
              [(0, 3), (3, 1), (1, 0)],
@@ -6783,7 +6787,7 @@ class GenericGraph(GenericGraph_pyx):
 
         With no embedding provided (non-planar graph)::
 
-            sage: graphs.PetersenGraph().faces()
+            sage: graphs.PetersenGraph().faces()                                        # needs planarity
             Traceback (most recent call last):
             ...
             ValueError: no embedding is provided and the graph is not planar
@@ -6799,7 +6803,7 @@ class GenericGraph(GenericGraph_pyx):
 
         The Path Graph has a single face::
 
-            sage: graphs.PathGraph(3).faces()
+            sage: graphs.PathGraph(3).faces()                                           # needs planarity
             [[(0, 1), (1, 2), (2, 1), (1, 0)]]
         """
         if not self.order() or not self.size():
@@ -6875,35 +6879,35 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: T = graphs.TetrahedralGraph()
-            sage: T.num_faces()
+            sage: T.num_faces()                                                         # needs planarity
             4
 
         The external face of a disconnected graph is counted only once::
 
-            sage: (T + T).num_faces()
+            sage: (T + T).num_faces()                                                   # needs planarity
             7
-            sage: (T + T + T).num_faces()
+            sage: (T + T + T).num_faces()                                               # needs planarity
             10
 
         Trees and forests have a single face::
 
             sage: T = graphs.RandomTree(10)
-            sage: T.num_faces()
+            sage: T.num_faces()                                                         # needs planarity
             1
-            sage: (T + T).num_faces()
+            sage: (T + T).num_faces()                                                   # needs planarity
             1
 
         TESTS::
 
             sage: G = graphs.CompleteBipartiteGraph(3, 3)
-            sage: G.num_faces()
+            sage: G.num_faces()                                                         # needs planarity
             Traceback (most recent call last):
             ...
             ValueError: no embedding is provided and the graph is not planar
 
         Issue :issue:`22003` is fixed::
 
-            sage: Graph(1).num_faces()
+            sage: Graph(1).num_faces()                                                  # needs planarity
             1
         """
         if not self:
@@ -6957,6 +6961,7 @@ class GenericGraph(GenericGraph_pyx):
 
         EXAMPLES::
 
+            sage: # needs planarity
             sage: C = graphs.CubeGraph(3)
             sage: C.planar_dual()
             Graph on 6 vertices
@@ -6966,7 +6971,7 @@ class GenericGraph(GenericGraph_pyx):
         The planar dual of the planar dual is isomorphic to the graph itself::
 
             sage: g = graphs.BuckyBall()
-            sage: g.planar_dual().planar_dual().is_isomorphic(g)
+            sage: g.planar_dual().planar_dual().is_isomorphic(g)                        # needs planarity
             True
 
         .. SEEALSO::
@@ -6978,6 +6983,7 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS::
 
+            sage: # needs planarity
             sage: G = graphs.CompleteBipartiteGraph(3, 3)
             sage: G.planar_dual()
             Traceback (most recent call last):
@@ -6996,6 +7002,7 @@ class GenericGraph(GenericGraph_pyx):
 
         This also keeps track of edge labels::
 
+            sage: # needs planarity
             sage: label_dict = {('000', '001'): 1, ('001', '101'): 2, ('101', '100'): 3, ('100', '000'): 4}
             sage: g = graphs.CubeGraph(3)
             sage: for e in label_dict:
@@ -11493,10 +11500,10 @@ class GenericGraph(GenericGraph_pyx):
         Test that :issue:`33759` is fixed::
 
             sage: G = Graph([(1, 4), (2, 3)])
-            sage: G.is_planar(set_embedding=True)
+            sage: G.is_planar(set_embedding=True)                                       # needs planarity
             True
             sage: G.delete_vertex(3)
-            sage: G.is_planar()
+            sage: G.is_planar()                                                         # needs planarity
             True
         """
         if in_order:
@@ -11543,10 +11550,10 @@ class GenericGraph(GenericGraph_pyx):
         Test that :issue:`33759` is fixed::
 
             sage: G = Graph([(1, 4), (2, 3)])
-            sage: G.is_planar(set_embedding=True)
+            sage: G.is_planar(set_embedding=True)                                       # needs planarity
             True
             sage: G.delete_vertices([3])
-            sage: G.is_planar()
+            sage: G.is_planar()                                                         # needs planarity
             True
         """
         vertices = list(vertices)
@@ -14129,11 +14136,11 @@ class GenericGraph(GenericGraph_pyx):
         The appropriate properties are preserved::
 
             sage: g = graphs.PathGraph(10)
-            sage: g.is_planar(set_embedding=True)
+            sage: g.is_planar(set_embedding=True)                                       # needs planarity
             True
             sage: g.set_vertices({v: 'v%d'%v for v in g})
             sage: h = g.subgraph([3..5])
-            sage: sorted(h.get_pos().keys())
+            sage: sorted(h.get_pos().keys())                                            # needs planarity
             [3, 4, 5]
             sage: h.get_vertices()
             {3: 'v3', 4: 'v4', 5: 'v5'}
@@ -14258,11 +14265,11 @@ class GenericGraph(GenericGraph_pyx):
         Properties of the graph are preserved::
 
             sage: g = graphs.PathGraph(10)
-            sage: g.is_planar(set_embedding=True)
+            sage: g.is_planar(set_embedding=True)                                       # needs planarity
             True
             sage: g.set_vertices({v: 'v%d'%v for v in g})
             sage: h = g._subgraph_by_adding([3..5])
-            sage: sorted(h.get_pos().keys())
+            sage: sorted(h.get_pos().keys())                                            # needs planarity
             [3, 4, 5]
             sage: h.get_vertices()
             {3: 'v3', 4: 'v4', 5: 'v5'}
@@ -14432,11 +14439,11 @@ class GenericGraph(GenericGraph_pyx):
         Properties of the graph are preserved::
 
             sage: g = graphs.PathGraph(10)
-            sage: g.is_planar(set_embedding=True)
+            sage: g.is_planar(set_embedding=True)                                       # needs planarity
             True
             sage: g.set_vertices({v: 'v%d'%v for v in g})
             sage: h = g._subgraph_by_deleting([3..5])
-            sage: sorted(h.get_pos().keys())
+            sage: sorted(h.get_pos().keys())                                            # needs planarity
             [3, 4, 5]
             sage: h.get_vertices()
             {3: 'v3', 4: 'v4', 5: 'v5'}
@@ -20532,7 +20539,7 @@ class GenericGraph(GenericGraph_pyx):
         TESTS::
 
             sage: styles = ['spring', 'circular', 'forest']
-            sage: styles += ['planar']                                                  # needs planarity
+            sage: import sage.graphs.planarity; styles += ['planar']    # needs planarity
             sage: for style in styles:
             ....:     for G in [Graph([(1, 2)]), Graph([(1, 2), (2, 3), (3, 4)])]:
             ....:         pos = G.layout(style, save_pos=True)

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1597,6 +1597,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         The example from the original paper::
 
+            sage: # needs sage.combinat
             sage: H = PermutationGroup([[(1,2,3),(7,9,8),(10,12,11)],[(4,5,6),(7,8,9),(10,11,12)],[(5,6),(8,9),(11,12)],[(7,8,9),(10,11,12)]])
             sage: S = H.disjoint_direct_product_decomposition(); S
             {{1, 2, 3}, {4, 5, 6, 7, 8, 9, 10, 11, 12}}
@@ -1614,6 +1615,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         An example with a different domain::
 
+            sage: # needs sage.combinat
             sage: PermutationGroup([[('a','c','d'),('b','e')]]).disjoint_direct_product_decomposition()
             {{'a', 'c', 'd'}, {'b', 'e'}}
             sage: PermutationGroup([[('a','c','d','b','e')]]).disjoint_direct_product_decomposition()
@@ -1621,6 +1623,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         Counting the number of "connected" permutation groups of degree `n`::
 
+            sage: # needs sage.combinat
             sage: seq = [sum(1 for G in SymmetricGroup(n).conjugacy_classes_subgroups() if len(G.disjoint_direct_product_decomposition()) == 1) for n in range(1,8)]; seq
             [1, 1, 2, 6, 6, 27, 20]
             sage: oeis(seq) # optional -- internet

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -69,6 +69,7 @@ so the eval command works.
 
 ::
 
+    sage: # needs sage.libs.singular
     sage: R.<x,y> = PolynomialRing(QQ,2)
     sage: s = F[1][3].sage_polystring(); s
     '-x**5+y**2'

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -2589,11 +2589,11 @@ class Link(SageObject):
             s0^2*s1^-1*(s1^-1*s0)^2*s1^-1
             sage: br = K8_17r.braid(); br
             s0^-1*s1*s0^-2*s1^2*s0^-1*s1
-            sage: b.is_conjugated(br)
+            sage: b.is_conjugated(br)                                                   # needs sage.libs.braiding
             False
             sage: b == br.reverse()
             False
-            sage: b.is_conjugated(br.reverse())
+            sage: b.is_conjugated(br.reverse())                                         # needs sage.libs.braiding
             True
             sage: K8_17b = Link(b)
             sage: K8_17br = K8_17b.reverse()
@@ -2739,7 +2739,7 @@ class Link(SageObject):
             sage: b = B([-1, -1, -1])
             sage: Link(b).jones_polynomial(skein_normalization=True)
             -A^-16 + A^-12 + A^-4
-            sage: Link(b).jones_polynomial()
+            sage: Link(b).jones_polynomial()                                            # needs sage.symbolic
             1/t + 1/t^3 - 1/t^4
             sage: B = BraidGroup(3)
             sage: b = B([-1, -2, -1, -2])
@@ -3143,7 +3143,7 @@ class Link(SageObject):
         EXAMPLES::
 
             sage: Hopf = Link([[1, 3, 2, 4], [4, 2, 3, 1]])
-            sage: Hopf.links_gould_polynomial()
+            sage: Hopf.links_gould_polynomial()                                         # needs sage.libs.singular
             -1 + t1^-1 + t0^-1 - t0^-1*t1^-1
         """
         return self.braid().links_gould_polynomial(varnames=varnames)
@@ -3918,6 +3918,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.braiding
             sage: b = BraidGroup(4)((1, 2, -3, 2, 2, 2, 2, 2, 2, -1, 2, 3, 2))
             sage: L = Link([[2, 5, 4, 1], [5, 7, 6, 4], [7, 9, 8, 6], [9, 11, 10, 8],
             ....:           [11, 13, 12, 10], [13, 15, 14, 12], [15, 17, 16, 14],
@@ -4072,6 +4073,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.homfly
             sage: KnotInfo.L4a1_0.inject()
             Defining L4a1_0
             sage: L4a1_0.link()._knotinfo_matching_dict()
@@ -4197,6 +4199,7 @@ class Link(SageObject):
 
         Lets identify the monster unknot::
 
+            sage: # needs sage.libs.homfly
             sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
             ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
             ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
@@ -4205,7 +4208,7 @@ class Link(SageObject):
 
         Usage of option ``mirror_version``::
 
-            sage: L.get_knotinfo(mirror_version=False) == KnotInfo.K0_1
+            sage: L.get_knotinfo(mirror_version=False) == KnotInfo.K0_1                 # needs sage.libs.homfly
             True
 
         Usage of option ``unique``::
@@ -4533,11 +4536,11 @@ class Link(SageObject):
             sage: l2 = Link([[1, 8, 2, 9], [9, 2, 10, 3], [3, 14, 4, 1],
             ....:            [13, 4, 14, 5], [5, 12, 6, 13], [11, 6, 12, 7],
             ....:            [7, 10, 8, 11]])
-            sage: l1.is_isotopic(l2)
+            sage: l1.is_isotopic(l2)                                                    # needs sage.libs.braiding
             True
 
             sage: l3 = l2.mirror_image()
-            sage: l1.is_isotopic(l3)
+            sage: l1.is_isotopic(l3)                                                    # needs sage.libs.braiding
             False
 
             sage: # optional - database_knotinfo
@@ -4547,22 +4550,22 @@ class Link(SageObject):
             sage: L == L7a7(0)
             True
             sage: l = L.link()
-            sage: l.is_isotopic(L7a7(1).link())
+            sage: l.is_isotopic(L7a7(1).link())                                         # needs sage.libs.braiding
             Traceback (most recent call last):
             ...
             NotImplementedError: comparison not possible!
-            sage: l.is_isotopic(L7a7(2).link())
+            sage: l.is_isotopic(L7a7(2).link())                                         # needs sage.libs.braiding
             True
-            sage: l.is_isotopic(L7a7(3).link())
+            sage: l.is_isotopic(L7a7(3).link())                                         # needs sage.libs.braiding
             False
 
         Using verbosity::
 
             sage: set_verbose(1)
-            sage: l1.is_isotopic(l2)
+            sage: l1.is_isotopic(l2)                                                    # needs sage.libs.braiding
             verbose 1 (... link.py, is_isotopic) identified by KnotInfo (KnotInfo.K7_2, SymmetryMutant.mirror_image)
             True
-            sage: l1.is_isotopic(l3)
+            sage: l1.is_isotopic(l3)                                                    # needs sage.libs.braiding
             verbose 1 (... link.py, is_isotopic) different Homfly-PT polynomials
             False
             sage: set_verbose(0)
@@ -4575,14 +4578,14 @@ class Link(SageObject):
             sage: L1 = L.link()
             sage: L2 = L.link(L.items.braid_notation)
             sage: set_verbose(1)
-            sage: L1.is_isotopic(L2)
+            sage: L1.is_isotopic(L2)                                                    # needs sage.libs.braiding
             verbose 1 (... link.py, is_isotopic) identified by KnotInfo uniquely (KnotInfo.L6a2_0, SymmetryMutant.itself)
             True
-            sage: KnotInfo.K0_1.link().is_isotopic(KnotInfo.L2a1_0.link())
+            sage: KnotInfo.K0_1.link().is_isotopic(KnotInfo.L2a1_0.link())              # needs sage.libs.braiding
             verbose 1 (... link.py, is_isotopic) different number of components
             False
 
-            sage: # optional - database_knotinfo
+            sage: # optional - database_knotinfo, needs sage.libs.braiding
             sage: K = KnotInfo.K10_67
             sage: K1 = K.link()
             sage: K1r = K.link().reverse()

--- a/src/sage/libs/mpmath/utils.pyx
+++ b/src/sage/libs/mpmath/utils.pyx
@@ -173,7 +173,7 @@ def sage_to_mpmath(x, prec):
         mpf('+inf')
         sage: a.sage_to_mpmath(-infinity, 53)
         mpf('-inf')
-        sage: a.sage_to_mpmath(NaN, 53)
+        sage: a.sage_to_mpmath(NaN, 53)                                                 # needs sage.symbolic
         mpf('nan')
         sage: a.sage_to_mpmath(0, 53)
         0

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -4847,6 +4847,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.schemes
             sage: t = ModularSymbols(11,sign=1).hecke_matrix(2)
             sage: w = t.change_ring(ZZ)
             sage: w

--- a/src/sage/modular/pollack_stevens/dist.pyx
+++ b/src/sage/modular/pollack_stevens/dist.pyx
@@ -1,6 +1,7 @@
 # sage_setup: distribution = sagemath-flint
 # distutils: libraries = gmp
 # distutils: extra_compile_args = -D_XPG6
+# sage.doctest: needs sage.schemes
 """
 `p`-adic distributions spaces
 

--- a/src/sage/rings/function_field/function_field.py
+++ b/src/sage/rings/function_field/function_field.py
@@ -1270,12 +1270,12 @@ class FunctionField(Field):
             Place (x + 6)
             sage: c = 15*x + 12
             sage: d = 16/(x + 13)
-            sage: K.hilbert_symbol(c, d, Q)
+            sage: K.hilbert_symbol(c, d, Q)                                             # needs sage.libs.singular
             1
 
         Check that the Hilbert symbol is symmetric and bimultiplicative::
 
-            sage: # needs sage.libs.pari
+            sage: # needs sage.libs.pari sage.libs.singular
             sage: K.<x> = FunctionField(GF(5)); R.<T> = PolynomialRing(K)
             sage: f = ((x^2 + 2*x + 2)*T^5 + (4*x^2 + 2*x + 3)*T^4 + 3*T^3 + 4*T^2
             ....:     + (2/(x^2 + 4*x + 1))*T + 3*x^2 + 2*x + 4)

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -1482,10 +1482,10 @@ cdef class RingHomomorphism(RingMap):
             sage: # needs sage.rings.number_field
             sage: K.<sqrt2> = QuadraticField(2)
             sage: f = K.hom([-sqrt2], K.polynomial_quotient_ring())
-            sage: (f.inverse() * f).is_identity()
+            sage: (f.inverse() * f).is_identity()                                       # needs sage.libs.singular
             True
             sage: g = K.polynomial_quotient_ring().hom([-sqrt2], K)
-            sage: (g.inverse() * g).is_identity()
+            sage: (g.inverse() * g).is_identity()                                       # needs sage.libs.singular
             True
 
         Morphisms involving Galois fields::

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -18,7 +18,7 @@ EXAMPLES::
 
 TESTS::
 
-    sage: # needs sage.libs.flint
+    sage: # needs sage.libs.flint sage.libs.singular
     sage: Pol.<y> = CBF[]
     sage: Quo.<y> = Pol.quotient(y^3)
     sage: CBF.zero()*y

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -1243,6 +1243,7 @@ cdef class RealIntervalFieldElement(RingElement):
 
         TESTS::
 
+            sage: # needs sage.symbolic
             sage: a = RealIntervalField(428)(factorial(100)/exp(2)); a
             1.26303298005073195998439505058085204028142920134742241494671502106333548593576383141666758300089860337889002385197008191910406895?e157
             sage: a.diameter()
@@ -1622,6 +1623,8 @@ cdef class RealIntervalFieldElement(RingElement):
             '2.2f684bda12f69?'
             sage: a.str(no_sci=False)
             '2.185185185185186?e0'
+
+            sage: # needs sage.symbolic
             sage: pi_appr = RIF(pi, 22/7)
             sage: pi_appr.str(style='brackets')
             '[3.1415926535897931 .. 3.1428571428571433]'
@@ -1633,6 +1636,7 @@ cdef class RealIntervalFieldElement(RingElement):
             '3.14223?64'
             sage: pi_appr.str(base=36)
             '3.6?'
+
             sage: RIF(NaN)                                                              # needs sage.symbolic
             [.. NaN ..]
             sage: RIF(pi, infinity)                                                     # needs sage.symbolic
@@ -1795,7 +1799,7 @@ cdef class RealIntervalFieldElement(RingElement):
             -5.00?501e7
             sage: RIF(10^-3, 12345)._str_question_style(10, 3, 'e', False)
             '6.18?618e3'
-            sage: RIF(-golden_ratio, -10^-6)._str_question_style(10, 3, 'e', False)
+            sage: RIF(-golden_ratio, -10^-6)._str_question_style(10, 3, 'e', False)     # needs sage.symbolic
             '-0.810?810'
             sage: RIF(-0.85, 0.85)._str_question_style(10, 0, 'e', False)
             '0.?'
@@ -4091,9 +4095,9 @@ cdef class RealIntervalFieldElement(RingElement):
 
         EXAMPLES::
 
-            sage: RIF(1, 2).union(RIF(pi, 22/7)).str(style='brackets')
+            sage: RIF(1, 2).union(RIF(pi, 22/7)).str(style='brackets')                  # needs sage.symbolic
             '[1.0000000000000000 .. 3.1428571428571433]'
-            sage: RIF(1, 2).union(pi).str(style='brackets')
+            sage: RIF(1, 2).union(pi).str(style='brackets')                             # needs sage.symbolic
             '[1.0000000000000000 .. 3.1415926535897936]'
             sage: RIF(1).union(RIF(0, 2)).str(style='brackets')
             '[0.0000000000000000 .. 2.0000000000000000]'

--- a/src/sage/rings/ring_extension.pyx
+++ b/src/sage/rings/ring_extension.pyx
@@ -89,9 +89,9 @@ One can also compute traces and norms with respect to any base of the tower::
 
 And minimal polynomials::
 
-    sage: u.minpoly()                                                                   # needs sage.rings.finite_rings
+    sage: u.minpoly()                                                                   # needs sage.rings.finite_rings sage.libs.singular
     x^2 + ((3*z2 + 4) + (3*z2 + 4)*a)*x + (z2 + 1) + (4*z2 + 2)*a
-    sage: u.minpoly(F)                                                                  # needs sage.rings.finite_rings
+    sage: u.minpoly(F)                                                                  # needs sage.rings.finite_rings sage.libs.singular
     x^4 + (4*z2 + 4)*x^3 + x^2 + (z2 + 1)*x + 2*z2 + 2
 
 

--- a/src/sage/rings/valuation/augmented_valuation.py
+++ b/src/sage/rings/valuation/augmented_valuation.py
@@ -1042,7 +1042,7 @@ class FinalAugmentedValuation(AugmentedValuation_base, FinalInductiveValuation):
             1/2
 
             sage: w = v.augmentation(x^2 + x + 1, infinity)
-            sage: w.lift(w.residue_ring().gen())                                        # needs sage.rings.number_field
+            sage: w.lift(w.residue_ring().gen())                                        # needs sage.libs.singular sage.rings.number_field
             x
 
         A case with non-trivial base valuation::
@@ -1052,7 +1052,7 @@ class FinalAugmentedValuation(AugmentedValuation_base, FinalInductiveValuation):
             sage: S.<x> = R[]
             sage: v = GaussValuation(S)
             sage: w = v.augmentation(x^2 + x + u, infinity)
-            sage: w.lift(w.residue_ring().gen())                                        # needs sage.rings.number_field
+            sage: w.lift(w.residue_ring().gen())                                        # needs sage.libs.singular sage.rings.number_field
             (1 + O(2^10))*x
 
         TESTS:


### PR DESCRIPTION
- **./sage --fixdoctests --distribution 'sagemath-polyhedra' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-polyhedra[standard]' --update-known-test-failures**
- **src/sage/graphs/generic_graph.py: Add # needs**
- **src/sage/groups/perm_gps/permgroup.py: Add # needs**
- **src/sage/interfaces/gap.py: Add # needs**
- **src/sage/knots/link.py: Add # needs**
- **src/sage/libs/mpmath/utils.pyx: Add # needs**
- **src/sage/matrix/matrix_integer_dense.pyx: Add # needs**
- **src/sage/modular/pollack_stevens/dist.pyx: Add file-level # needs**
- **src/sage/rings: Add # needs**
