### PR TITLE
pkgs/sagemath-combinat: Modularization fixes (# needs)

### DIFF
--- a/pkgs/sagemath-combinat/known-test-failures--graphs.json
+++ b/pkgs/sagemath-combinat/known-test-failures--graphs.json
@@ -2,15 +2,8 @@
     "sage.algebras.cluster_algebra": {
         "ntests": 1
     },
-    "sage.algebras.commutative_dga": {
-        "ntests": 7
-    },
     "sage.algebras.free_algebra": {
         "ntests": 3
-    },
-    "sage.algebras.hecke_algebras.ariki_koike_specht_modules": {
-        "failed": true,
-        "ntests": 98
     },
     "sage.algebras.hecke_algebras.cubic_hecke_algebra": {
         "ntests": 31
@@ -20,10 +13,6 @@
     },
     "sage.algebras.quantum_groups.q_numbers": {
         "ntests": 23
-    },
-    "sage.algebras.quantum_oscillator": {
-        "failed": true,
-        "ntests": 114
     },
     "sage.algebras.steenrod.steenrod_algebra": {
         "ntests": 2
@@ -61,7 +50,7 @@
         "ntests": 72
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.categories.action": {
         "ntests": 78
@@ -198,7 +187,6 @@
         "ntests": 30
     },
     "sage.categories.discrete_valuation": {
-        "failed": true,
         "ntests": 28
     },
     "sage.categories.distributive_magmas_and_additive_magmas": {
@@ -297,7 +285,7 @@
         "ntests": 27
     },
     "sage.categories.fields": {
-        "ntests": 100
+        "ntests": 104
     },
     "sage.categories.filtered_algebras": {
         "failed": true,
@@ -315,7 +303,7 @@
     },
     "sage.categories.filtered_modules_with_basis": {
         "failed": true,
-        "ntests": 72
+        "ntests": 68
     },
     "sage.categories.finite_complex_reflection_groups": {
         "failed": true,
@@ -345,8 +333,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 167
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "ntests": 54
@@ -514,8 +501,7 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
         "ntests": 19
@@ -639,7 +625,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "ntests": 175
+        "ntests": 206
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -676,7 +662,7 @@
     },
     "sage.categories.simplicial_sets": {
         "failed": true,
-        "ntests": 150
+        "ntests": 135
     },
     "sage.categories.subobjects": {
         "ntests": 2
@@ -862,7 +848,7 @@
         "ntests": 12
     },
     "sage.combinat.designs.orthogonal_arrays_build_recursive": {
-        "ntests": 19
+        "ntests": 20
     },
     "sage.combinat.designs.resolvable_bibd": {
         "ntests": 4
@@ -954,7 +940,6 @@
         "ntests": 384
     },
     "sage.combinat.matrices.dancing_links": {
-        "failed": true,
         "ntests": 250
     },
     "sage.combinat.matrices.dlxcpp": {
@@ -996,7 +981,7 @@
     },
     "sage.combinat.partition": {
         "failed": true,
-        "ntests": 1337
+        "ntests": 1333
     },
     "sage.combinat.partition_tuple": {
         "ntests": 394
@@ -1042,7 +1027,7 @@
         "ntests": 515
     },
     "sage.combinat.posets.lattices": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.combinat.posets.linear_extension_iterator": {
         "ntests": 13
@@ -1062,7 +1047,7 @@
     },
     "sage.combinat.q_analogues": {
         "failed": true,
-        "ntests": 135
+        "ntests": 126
     },
     "sage.combinat.q_bernoulli": {
         "ntests": 15
@@ -1358,7 +1343,7 @@
     },
     "sage.data_structures.stream": {
         "failed": true,
-        "ntests": 972
+        "ntests": 951
     },
     "sage.databases.findstat": {
         "failed": true,
@@ -1377,8 +1362,7 @@
         "ntests": 248
     },
     "sage.doctest.check_tolerance": {
-        "failed": true,
-        "ntests": 19
+        "ntests": 9
     },
     "sage.doctest.control": {
         "ntests": 1
@@ -1390,16 +1374,14 @@
         "ntests": 59
     },
     "sage.doctest.forker": {
-        "failed": true,
-        "ntests": 374
+        "ntests": 254
     },
     "sage.doctest.marked_output": {
         "failed": true,
         "ntests": 21
     },
     "sage.doctest.parsing": {
-        "failed": true,
-        "ntests": 270
+        "ntests": 234
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -1417,8 +1399,7 @@
         "ntests": 166
     },
     "sage.env": {
-        "failed": true,
-        "ntests": 45
+        "ntests": 40
     },
     "sage.ext.fast_callable": {
         "failed": true,
@@ -1449,7 +1430,6 @@
         "ntests": 3
     },
     "sage.features.databases": {
-        "failed": true,
         "ntests": 38
     },
     "sage.features.dvipng": {
@@ -1466,6 +1446,9 @@
     },
     "sage.features.fricas": {
         "ntests": 6
+    },
+    "sage.features.frobby": {
+        "ntests": 4
     },
     "sage.features.gap": {
         "ntests": 6
@@ -1487,6 +1470,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -1511,6 +1497,9 @@
     },
     "sage.features.lrs": {
         "ntests": 16
+    },
+    "sage.features.macaulay2": {
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1551,6 +1540,9 @@
     "sage.features.poppler": {
         "ntests": 4
     },
+    "sage.features.qepcad": {
+        "ntests": 4
+    },
     "sage.features.rubiks": {
         "ntests": 28
     },
@@ -1572,6 +1564,9 @@
     "sage.features.symengine_py": {
         "ntests": 4
     },
+    "sage.features.sympow": {
+        "ntests": 4
+    },
     "sage.features.tdlib": {
         "ntests": 2
     },
@@ -1591,13 +1586,13 @@
         "ntests": 94
     },
     "sage.functions.exp_integral": {
-        "ntests": 154
+        "ntests": 156
     },
     "sage.functions.gamma": {
         "ntests": 140
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "ntests": 81
@@ -1619,7 +1614,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 238
+        "ntests": 239
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1667,7 +1662,7 @@
         "ntests": 86
     },
     "sage.graphs.base.graph_backends": {
-        "ntests": 85
+        "ntests": 87
     },
     "sage.graphs.base.overview": {
         "ntests": 1
@@ -1754,6 +1749,7 @@
         "ntests": 6
     },
     "sage.graphs.generators.random": {
+        "failed": true,
         "ntests": 189
     },
     "sage.graphs.generators.smallgraphs": {
@@ -1765,24 +1761,23 @@
     },
     "sage.graphs.generic_graph": {
         "failed": true,
-        "ntests": 3675
+        "ntests": 3569
     },
     "sage.graphs.generic_graph_pyx": {
         "ntests": 139
     },
     "sage.graphs.genus": {
-        "ntests": 51
+        "ntests": 42
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1112
+        "ntests": 1056
     },
     "sage.graphs.graph_coloring": {
         "ntests": 151
     },
     "sage.graphs.graph_database": {
-        "failed": true,
-        "ntests": 50
+        "ntests": 4
     },
     "sage.graphs.graph_decompositions.bandwidth": {
         "ntests": 14
@@ -1801,9 +1796,6 @@
     },
     "sage.graphs.graph_decompositions.modular_decomposition": {
         "ntests": 151
-    },
-    "sage.graphs.graph_decompositions.rankwidth": {
-        "ntests": 23
     },
     "sage.graphs.graph_decompositions.slice_decomposition": {
         "ntests": 131
@@ -1830,8 +1822,7 @@
         "ntests": 7
     },
     "sage.graphs.graph_list": {
-        "failed": true,
-        "ntests": 58
+        "ntests": 55
     },
     "sage.graphs.hyperbolicity": {
         "failed": true,
@@ -1842,10 +1833,6 @@
     },
     "sage.graphs.independent_sets": {
         "ntests": 56
-    },
-    "sage.graphs.isgci": {
-        "failed": true,
-        "ntests": 83
     },
     "sage.graphs.isoperimetric_inequalities": {
         "ntests": 25
@@ -1858,19 +1845,16 @@
     },
     "sage.graphs.matching": {
         "failed": true,
-        "ntests": 249
+        "ntests": 194
     },
     "sage.graphs.orientations": {
-        "ntests": 71
+        "ntests": 154
     },
     "sage.graphs.partial_cube": {
         "ntests": 14
     },
     "sage.graphs.path_enumeration": {
         "ntests": 281
-    },
-    "sage.graphs.planarity": {
-        "ntests": 6
     },
     "sage.graphs.pq_trees": {
         "ntests": 90
@@ -1879,7 +1863,7 @@
         "ntests": 12
     },
     "sage.graphs.schnyder": {
-        "ntests": 103
+        "ntests": 1
     },
     "sage.graphs.spanning_tree": {
         "ntests": 165
@@ -1938,7 +1922,7 @@
         "ntests": 8
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.process": {
         "ntests": 39
@@ -1962,11 +1946,14 @@
     "sage.knots.gauss_code": {
         "ntests": 18
     },
+    "sage.knots.knot": {
+        "ntests": 1
+    },
     "sage.knots.knotinfo": {
         "ntests": 50
     },
     "sage.knots.link": {
-        "ntests": 47
+        "ntests": 63
     },
     "sage.libs.lrcalc.lrcalc": {
         "failed": true,
@@ -2024,7 +2011,7 @@
     },
     "sage.misc.dev_tools": {
         "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.misc.edit_module": {
         "ntests": 16
@@ -2066,10 +2053,9 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 211
+        "ntests": 212
     },
     "sage.misc.latex_macros": {
-        "failed": true,
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
@@ -2182,14 +2168,14 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 324
+        "ntests": 321
     },
     "sage.misc.search": {
         "ntests": 4
     },
     "sage.misc.session": {
         "failed": true,
-        "ntests": 61
+        "ntests": 59
     },
     "sage.misc.sh": {
         "ntests": 1
@@ -2278,8 +2264,7 @@
         "ntests": 85
     },
     "sage.parallel.map_reduce": {
-        "failed": true,
-        "ntests": 289
+        "ntests": 284
     },
     "sage.parallel.multiprocessing_sage": {
         "ntests": 9
@@ -2424,10 +2409,10 @@
         "ntests": 20
     },
     "sage.rings.finite_rings.element_base": {
-        "ntests": 13
+        "ntests": 14
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "ntests": 24
+        "ntests": 26
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "ntests": 17
@@ -2438,6 +2423,9 @@
     "sage.rings.finite_rings.galois_group": {
         "ntests": 1
     },
+    "sage.rings.finite_rings.hom_finite_field": {
+        "ntests": 7
+    },
     "sage.rings.finite_rings.hom_prime_finite_field": {
         "ntests": 15
     },
@@ -2445,7 +2433,7 @@
         "ntests": 539
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 253
+        "ntests": 326
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 41
@@ -2471,7 +2459,7 @@
         "ntests": 7
     },
     "sage.rings.function_field.function_field": {
-        "ntests": 158
+        "ntests": 159
     },
     "sage.rings.function_field.function_field_rational": {
         "ntests": 135
@@ -2517,7 +2505,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1068
+        "ntests": 1069
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -2533,7 +2521,7 @@
     },
     "sage.rings.lazy_series": {
         "failed": true,
-        "ntests": 1568
+        "ntests": 1562
     },
     "sage.rings.lazy_series_ring": {
         "failed": true,
@@ -2544,7 +2532,7 @@
     },
     "sage.rings.morphism": {
         "failed": true,
-        "ntests": 444
+        "ntests": 446
     },
     "sage.rings.multi_power_series_ring": {
         "ntests": 229
@@ -2605,11 +2593,11 @@
         "ntests": 87
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 5
+        "ntests": 7
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 471
+        "ntests": 468
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "ntests": 251
@@ -2627,14 +2615,14 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 135
+        "ntests": 133
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 396
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1844
+        "ntests": 1846
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 194
@@ -2681,8 +2669,7 @@
         "ntests": 247
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
-        "ntests": 471
+        "ntests": 463
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 72
@@ -2699,7 +2686,7 @@
     },
     "sage.rings.rational": {
         "failed": true,
-        "ntests": 533
+        "ntests": 534
     },
     "sage.rings.rational_field": {
         "ntests": 189
@@ -2712,7 +2699,7 @@
         "ntests": 19
     },
     "sage.rings.ring": {
-        "ntests": 206
+        "ntests": 173
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
         "ntests": 16
@@ -2727,7 +2714,7 @@
         "ntests": 120
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -2739,7 +2726,7 @@
         "ntests": 2
     },
     "sage.sandpiles.sandpile": {
-        "ntests": 66
+        "ntests": 64
     },
     "sage.sat.boolean_polynomials": {
         "ntests": 1
@@ -2761,7 +2748,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 282
+        "ntests": 290
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
@@ -2774,7 +2761,7 @@
         "ntests": 167
     },
     "sage.schemes.affine.affine_subscheme": {
-        "ntests": 81
+        "ntests": 79
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
@@ -2791,7 +2778,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 391
+        "ntests": 387
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -2828,7 +2815,7 @@
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 480
+        "ntests": 468
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
@@ -2838,7 +2825,7 @@
         "ntests": 34
     },
     "sage.schemes.projective.projective_space": {
-        "ntests": 381
+        "ntests": 382
     },
     "sage.schemes.projective.projective_subscheme": {
         "ntests": 233
@@ -2925,7 +2912,7 @@
     },
     "sage.structure.element": {
         "failed": true,
-        "ntests": 561
+        "ntests": 562
     },
     "sage.structure.element.pxd": {
         "ntests": 18
@@ -3072,6 +3059,7 @@
         "ntests": 6
     },
     "sage.topology.simplicial_complex_examples": {
+        "failed": true,
         "ntests": 139
     },
     "sage.topology.simplicial_complex_homset": {

--- a/pkgs/sagemath-combinat/known-test-failures--modules.json
+++ b/pkgs/sagemath-combinat/known-test-failures--modules.json
@@ -64,7 +64,7 @@
     },
     "sage.algebras.free_algebra_quotient_element": {
         "failed": true,
-        "ntests": 39
+        "ntests": 42
     },
     "sage.algebras.free_zinbiel_algebra": {
         "ntests": 170
@@ -268,7 +268,7 @@
         "ntests": 77
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.calculus.interpolation": {
         "ntests": 67
@@ -416,7 +416,6 @@
         "ntests": 2
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
         "ntests": 368
     },
     "sage.categories.crystals": {
@@ -536,7 +535,7 @@
     },
     "sage.categories.fields": {
         "failed": true,
-        "ntests": 109
+        "ntests": 113
     },
     "sage.categories.filtered_algebras": {
         "ntests": 5
@@ -555,8 +554,7 @@
         "ntests": 243
     },
     "sage.categories.finite_complex_reflection_groups": {
-        "failed": true,
-        "ntests": 183
+        "ntests": 178
     },
     "sage.categories.finite_coxeter_groups": {
         "ntests": 6
@@ -580,7 +578,7 @@
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
         "failed": true,
-        "ntests": 357
+        "ntests": 354
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "failed": true,
@@ -872,7 +870,7 @@
     },
     "sage.categories.rings": {
         "failed": true,
-        "ntests": 223
+        "ntests": 252
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -1203,7 +1201,6 @@
         "ntests": 384
     },
     "sage.combinat.matrices.dancing_links": {
-        "failed": true,
         "ntests": 250
     },
     "sage.combinat.matrices.dlxcpp": {
@@ -1306,8 +1303,7 @@
         "ntests": 127
     },
     "sage.combinat.permutation": {
-        "failed": true,
-        "ntests": 1262
+        "ntests": 1252
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
@@ -1318,7 +1314,7 @@
     },
     "sage.combinat.q_analogues": {
         "failed": true,
-        "ntests": 135
+        "ntests": 126
     },
     "sage.combinat.q_bernoulli": {
         "ntests": 15
@@ -1381,7 +1377,7 @@
     },
     "sage.combinat.root_system.root_lattice_realizations": {
         "failed": true,
-        "ntests": 489
+        "ntests": 484
     },
     "sage.combinat.root_system.root_space": {
         "ntests": 78
@@ -1866,7 +1862,7 @@
     },
     "sage.data_structures.stream": {
         "failed": true,
-        "ntests": 1067
+        "ntests": 1046
     },
     "sage.databases.findstat": {
         "failed": true,
@@ -1882,8 +1878,7 @@
         "ntests": 230
     },
     "sage.doctest.check_tolerance": {
-        "failed": true,
-        "ntests": 19
+        "ntests": 9
     },
     "sage.doctest.control": {
         "ntests": 3
@@ -1897,7 +1892,7 @@
     },
     "sage.doctest.forker": {
         "failed": true,
-        "ntests": 389
+        "ntests": 269
     },
     "sage.doctest.marked_output": {
         "failed": true,
@@ -1905,7 +1900,7 @@
     },
     "sage.doctest.parsing": {
         "failed": true,
-        "ntests": 270
+        "ntests": 234
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -1923,8 +1918,7 @@
         "ntests": 166
     },
     "sage.env": {
-        "failed": true,
-        "ntests": 45
+        "ntests": 40
     },
     "sage.ext.fast_callable": {
         "failed": true,
@@ -1955,7 +1949,6 @@
         "ntests": 3
     },
     "sage.features.databases": {
-        "failed": true,
         "ntests": 38
     },
     "sage.features.dvipng": {
@@ -1972,6 +1965,9 @@
     },
     "sage.features.fricas": {
         "ntests": 6
+    },
+    "sage.features.frobby": {
+        "ntests": 4
     },
     "sage.features.gap": {
         "ntests": 6
@@ -1993,6 +1989,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -2017,6 +2016,9 @@
     },
     "sage.features.lrs": {
         "ntests": 16
+    },
+    "sage.features.macaulay2": {
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -2057,6 +2059,9 @@
     "sage.features.poppler": {
         "ntests": 4
     },
+    "sage.features.qepcad": {
+        "ntests": 4
+    },
     "sage.features.rubiks": {
         "ntests": 28
     },
@@ -2077,6 +2082,9 @@
         "ntests": 8
     },
     "sage.features.symengine_py": {
+        "ntests": 4
+    },
+    "sage.features.sympow": {
         "ntests": 4
     },
     "sage.features.tdlib": {
@@ -2102,14 +2110,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 154
+        "ntests": 156
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 136
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "failed": true,
@@ -2136,7 +2144,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 245
+        "ntests": 246
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -2179,14 +2187,14 @@
     },
     "sage.geometry.toric_lattice": {
         "failed": true,
-        "ntests": 302
+        "ntests": 298
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 80
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 249
+        "ntests": 251
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 26
@@ -2223,11 +2231,10 @@
         "ntests": 92
     },
     "sage.groups.galois_group": {
-        "ntests": 54
+        "ntests": 40
     },
     "sage.groups.generic": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 110
     },
     "sage.groups.group": {
         "ntests": 45
@@ -2246,11 +2253,10 @@
     },
     "sage.groups.matrix_gps.linear": {
         "failed": true,
-        "ntests": 47
+        "ntests": 37
     },
     "sage.groups.matrix_gps.matrix_group": {
-        "failed": true,
-        "ntests": 55
+        "ntests": 54
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -2315,13 +2321,14 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
+        "failed": true,
         "ntests": 5
     },
     "sage.interfaces.abc": {
         "ntests": 8
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.process": {
         "ntests": 39
@@ -2395,7 +2402,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2061
+        "ntests": 2055
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -2407,7 +2414,7 @@
         "ntests": 35
     },
     "sage.matrix.matrix_double_dense": {
-        "ntests": 21
+        "ntests": 27
     },
     "sage.matrix.matrix_double_sparse": {
         "ntests": 25
@@ -2503,7 +2510,7 @@
     },
     "sage.matroids.matroid": {
         "failed": true,
-        "ntests": 940
+        "ntests": 933
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 22
@@ -2580,7 +2587,7 @@
     },
     "sage.misc.dev_tools": {
         "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.misc.edit_module": {
         "ntests": 16
@@ -2625,7 +2632,7 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 235
+        "ntests": 236
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -2745,14 +2752,14 @@
     },
     "sage.misc.sageinspect": {
         "failed": true,
-        "ntests": 332
+        "ntests": 329
     },
     "sage.misc.search": {
         "ntests": 4
     },
     "sage.misc.session": {
         "failed": true,
-        "ntests": 61
+        "ntests": 59
     },
     "sage.misc.sh": {
         "ntests": 1
@@ -2814,7 +2821,7 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1459
+        "ntests": 1453
     },
     "sage.modules.free_module_element": {
         "failed": true,
@@ -2824,8 +2831,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "failed": true,
-        "ntests": 96
+        "ntests": 8
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -2837,7 +2843,7 @@
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
         "failed": true,
-        "ntests": 156
+        "ntests": 133
     },
     "sage.modules.matrix_morphism": {
         "failed": true,
@@ -2884,7 +2890,7 @@
         "ntests": 46
     },
     "sage.modules.vector_modn_dense": {
-        "ntests": 59
+        "ntests": 64
     },
     "sage.modules.vector_numpy_dense": {
         "ntests": 4
@@ -2966,8 +2972,7 @@
         "ntests": 85
     },
     "sage.parallel.map_reduce": {
-        "failed": true,
-        "ntests": 289
+        "ntests": 284
     },
     "sage.parallel.multiprocessing_sage": {
         "ntests": 9
@@ -2993,8 +2998,7 @@
         "ntests": 19
     },
     "sage.quadratic_forms.binary_qf": {
-        "failed": true,
-        "ntests": 303
+        "ntests": 299
     },
     "sage.quadratic_forms.constructions": {
         "ntests": 5
@@ -3179,15 +3183,14 @@
     },
     "sage.rings.complex_double": {
         "failed": true,
-        "ntests": 327
+        "ntests": 315
     },
     "sage.rings.complex_mpc": {
-        "failed": true,
-        "ntests": 406
+        "ntests": 397
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
-        "ntests": 501
+        "ntests": 497
     },
     "sage.rings.continued_fraction": {
         "failed": true,
@@ -3227,7 +3230,7 @@
         "ntests": 539
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 253
+        "ntests": 326
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 39
@@ -3262,7 +3265,7 @@
         "ntests": 7
     },
     "sage.rings.function_field.function_field": {
-        "ntests": 154
+        "ntests": 155
     },
     "sage.rings.function_field.function_field_rational": {
         "ntests": 135
@@ -3313,7 +3316,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1084
+        "ntests": 1085
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -3348,7 +3351,7 @@
     },
     "sage.rings.morphism": {
         "failed": true,
-        "ntests": 467
+        "ntests": 469
     },
     "sage.rings.multi_power_series_ring": {
         "failed": true,
@@ -3421,12 +3424,11 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "failed": true,
-        "ntests": 126
+        "ntests": 122
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 516
+        "ntests": 513
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
@@ -3445,7 +3447,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 135
+        "ntests": 138
     },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 56
@@ -3465,7 +3467,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1947
+        "ntests": 1949
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -3526,7 +3528,7 @@
     },
     "sage.rings.power_series_ring_element": {
         "failed": true,
-        "ntests": 478
+        "ntests": 470
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 72
@@ -3543,7 +3545,7 @@
     },
     "sage.rings.rational": {
         "failed": true,
-        "ntests": 545
+        "ntests": 546
     },
     "sage.rings.rational_field": {
         "failed": true,
@@ -3569,7 +3571,7 @@
     },
     "sage.rings.ring": {
         "failed": true,
-        "ntests": 210
+        "ntests": 177
     },
     "sage.rings.ring_extension": {
         "ntests": 216
@@ -3594,7 +3596,7 @@
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -3622,7 +3624,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 296
+        "ntests": 304
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
@@ -3635,7 +3637,7 @@
         "ntests": 167
     },
     "sage.schemes.affine.affine_subscheme": {
-        "ntests": 81
+        "ntests": 79
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
@@ -3652,7 +3654,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 395
+        "ntests": 391
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -3691,7 +3693,7 @@
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 499
+        "ntests": 487
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
@@ -3702,7 +3704,7 @@
     },
     "sage.schemes.projective.projective_space": {
         "failed": true,
-        "ntests": 376
+        "ntests": 377
     },
     "sage.schemes.projective.projective_subscheme": {
         "ntests": 240
@@ -3795,7 +3797,7 @@
         "ntests": 2
     },
     "sage.stats.time_series": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.structure.category_object": {
         "failed": true,

--- a/pkgs/sagemath-combinat/known-test-failures.json
+++ b/pkgs/sagemath-combinat/known-test-failures.json
@@ -2,18 +2,11 @@
     "sage.algebras.cluster_algebra": {
         "ntests": 1
     },
-    "sage.algebras.commutative_dga": {
-        "ntests": 7
-    },
     "sage.algebras.down_up_algebra": {
         "ntests": 2
     },
     "sage.algebras.free_algebra": {
         "ntests": 3
-    },
-    "sage.algebras.hecke_algebras.ariki_koike_specht_modules": {
-        "failed": true,
-        "ntests": 98
     },
     "sage.algebras.hecke_algebras.cubic_hecke_algebra": {
         "ntests": 31
@@ -23,10 +16,6 @@
     },
     "sage.algebras.quantum_groups.q_numbers": {
         "ntests": 23
-    },
-    "sage.algebras.quantum_oscillator": {
-        "failed": true,
-        "ntests": 114
     },
     "sage.algebras.steenrod.steenrod_algebra": {
         "ntests": 2
@@ -61,7 +50,7 @@
         "ntests": 72
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.categories.action": {
         "ntests": 78
@@ -193,7 +182,6 @@
         "ntests": 30
     },
     "sage.categories.discrete_valuation": {
-        "failed": true,
         "ntests": 28
     },
     "sage.categories.distributive_magmas_and_additive_magmas": {
@@ -288,7 +276,7 @@
         "ntests": 27
     },
     "sage.categories.fields": {
-        "ntests": 100
+        "ntests": 104
     },
     "sage.categories.filtered_algebras": {
         "failed": true,
@@ -306,11 +294,10 @@
     },
     "sage.categories.filtered_modules_with_basis": {
         "failed": true,
-        "ntests": 72
+        "ntests": 68
     },
     "sage.categories.finite_complex_reflection_groups": {
-        "failed": true,
-        "ntests": 183
+        "ntests": 178
     },
     "sage.categories.finite_coxeter_groups": {
         "ntests": 6
@@ -332,8 +319,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 167
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "ntests": 56
@@ -496,8 +482,7 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
         "ntests": 19
@@ -615,7 +600,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "ntests": 175
+        "ntests": 206
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -837,7 +822,6 @@
         "ntests": 384
     },
     "sage.combinat.matrices.dancing_links": {
-        "failed": true,
         "ntests": 250
     },
     "sage.combinat.matrices.dlxcpp": {
@@ -871,8 +855,7 @@
         "ntests": 267
     },
     "sage.combinat.partition": {
-        "failed": true,
-        "ntests": 1301
+        "ntests": 1297
     },
     "sage.combinat.partition_algebra": {
         "ntests": 2
@@ -901,19 +884,17 @@
         "ntests": 127
     },
     "sage.combinat.permutation": {
-        "failed": true,
-        "ntests": 1251
+        "ntests": 1241
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
     },
     "sage.combinat.plane_partition": {
-        "failed": true,
         "ntests": 352
     },
     "sage.combinat.q_analogues": {
         "failed": true,
-        "ntests": 135
+        "ntests": 126
     },
     "sage.combinat.q_bernoulli": {
         "ntests": 15
@@ -1187,7 +1168,7 @@
     },
     "sage.data_structures.stream": {
         "failed": true,
-        "ntests": 972
+        "ntests": 951
     },
     "sage.databases.findstat": {
         "failed": true,
@@ -1203,8 +1184,7 @@
         "ntests": 230
     },
     "sage.doctest.check_tolerance": {
-        "failed": true,
-        "ntests": 19
+        "ntests": 9
     },
     "sage.doctest.control": {
         "ntests": 3
@@ -1216,16 +1196,14 @@
         "ntests": 59
     },
     "sage.doctest.forker": {
-        "failed": true,
-        "ntests": 374
+        "ntests": 254
     },
     "sage.doctest.marked_output": {
         "failed": true,
         "ntests": 21
     },
     "sage.doctest.parsing": {
-        "failed": true,
-        "ntests": 270
+        "ntests": 234
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -1243,8 +1221,7 @@
         "ntests": 166
     },
     "sage.env": {
-        "failed": true,
-        "ntests": 45
+        "ntests": 40
     },
     "sage.ext.fast_callable": {
         "failed": true,
@@ -1275,7 +1252,6 @@
         "ntests": 3
     },
     "sage.features.databases": {
-        "failed": true,
         "ntests": 38
     },
     "sage.features.dvipng": {
@@ -1292,6 +1268,9 @@
     },
     "sage.features.fricas": {
         "ntests": 6
+    },
+    "sage.features.frobby": {
+        "ntests": 4
     },
     "sage.features.gap": {
         "ntests": 6
@@ -1313,6 +1292,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -1337,6 +1319,9 @@
     },
     "sage.features.lrs": {
         "ntests": 16
+    },
+    "sage.features.macaulay2": {
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1377,6 +1362,9 @@
     "sage.features.poppler": {
         "ntests": 4
     },
+    "sage.features.qepcad": {
+        "ntests": 4
+    },
     "sage.features.rubiks": {
         "ntests": 28
     },
@@ -1398,6 +1386,9 @@
     "sage.features.symengine_py": {
         "ntests": 4
     },
+    "sage.features.sympow": {
+        "ntests": 4
+    },
     "sage.features.tdlib": {
         "ntests": 2
     },
@@ -1417,13 +1408,13 @@
         "ntests": 94
     },
     "sage.functions.exp_integral": {
-        "ntests": 154
+        "ntests": 156
     },
     "sage.functions.gamma": {
         "ntests": 140
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "ntests": 81
@@ -1445,7 +1436,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 238
+        "ntests": 239
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1508,7 +1499,7 @@
         "ntests": 8
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.process": {
         "ntests": 39
@@ -1577,7 +1568,7 @@
     },
     "sage.misc.dev_tools": {
         "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.misc.edit_module": {
         "ntests": 16
@@ -1619,10 +1610,9 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 211
+        "ntests": 212
     },
     "sage.misc.latex_macros": {
-        "failed": true,
         "ntests": 11
     },
     "sage.misc.latex_standalone": {
@@ -1735,14 +1725,14 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 324
+        "ntests": 321
     },
     "sage.misc.search": {
         "ntests": 4
     },
     "sage.misc.session": {
         "failed": true,
-        "ntests": 61
+        "ntests": 59
     },
     "sage.misc.sh": {
         "ntests": 1
@@ -1831,8 +1821,7 @@
         "ntests": 85
     },
     "sage.parallel.map_reduce": {
-        "failed": true,
-        "ntests": 289
+        "ntests": 284
     },
     "sage.parallel.multiprocessing_sage": {
         "ntests": 9
@@ -1977,10 +1966,10 @@
         "ntests": 20
     },
     "sage.rings.finite_rings.element_base": {
-        "ntests": 13
+        "ntests": 14
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "ntests": 24
+        "ntests": 26
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "ntests": 17
@@ -1991,6 +1980,9 @@
     "sage.rings.finite_rings.galois_group": {
         "ntests": 1
     },
+    "sage.rings.finite_rings.hom_finite_field": {
+        "ntests": 7
+    },
     "sage.rings.finite_rings.hom_prime_finite_field": {
         "ntests": 15
     },
@@ -1998,7 +1990,7 @@
         "ntests": 539
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 253
+        "ntests": 326
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 41
@@ -2024,7 +2016,7 @@
         "ntests": 7
     },
     "sage.rings.function_field.function_field": {
-        "ntests": 158
+        "ntests": 159
     },
     "sage.rings.function_field.function_field_rational": {
         "ntests": 135
@@ -2070,7 +2062,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1068
+        "ntests": 1069
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -2086,7 +2078,7 @@
     },
     "sage.rings.lazy_series": {
         "failed": true,
-        "ntests": 1568
+        "ntests": 1562
     },
     "sage.rings.lazy_series_ring": {
         "failed": true,
@@ -2097,7 +2089,7 @@
     },
     "sage.rings.morphism": {
         "failed": true,
-        "ntests": 444
+        "ntests": 446
     },
     "sage.rings.multi_power_series_ring": {
         "ntests": 229
@@ -2158,11 +2150,11 @@
         "ntests": 87
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 5
+        "ntests": 7
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 471
+        "ntests": 468
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "ntests": 251
@@ -2180,14 +2172,14 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 135
+        "ntests": 133
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 396
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1844
+        "ntests": 1846
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 194
@@ -2234,8 +2226,7 @@
         "ntests": 247
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
-        "ntests": 471
+        "ntests": 463
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 72
@@ -2252,7 +2243,7 @@
     },
     "sage.rings.rational": {
         "failed": true,
-        "ntests": 533
+        "ntests": 534
     },
     "sage.rings.rational_field": {
         "ntests": 189
@@ -2265,7 +2256,7 @@
         "ntests": 19
     },
     "sage.rings.ring": {
-        "ntests": 206
+        "ntests": 173
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
         "ntests": 16
@@ -2280,7 +2271,7 @@
         "ntests": 120
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -2308,7 +2299,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 282
+        "ntests": 290
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
@@ -2321,7 +2312,7 @@
         "ntests": 167
     },
     "sage.schemes.affine.affine_subscheme": {
-        "ntests": 81
+        "ntests": 79
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
@@ -2338,7 +2329,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 391
+        "ntests": 387
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -2375,7 +2366,7 @@
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 480
+        "ntests": 468
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
@@ -2385,7 +2376,7 @@
         "ntests": 34
     },
     "sage.schemes.projective.projective_space": {
-        "ntests": 381
+        "ntests": 382
     },
     "sage.schemes.projective.projective_subscheme": {
         "ntests": 233
@@ -2472,7 +2463,7 @@
     },
     "sage.structure.element": {
         "failed": true,
-        "ntests": 561
+        "ntests": 562
     },
     "sage.structure.element.pxd": {
         "ntests": 18

--- a/pkgs/sagemath-combinat/pyproject.toml.m4
+++ b/pkgs/sagemath-combinat/pyproject.toml.m4
@@ -40,9 +40,10 @@ symmetrica      = []
 # by feature
 graphs          = ["passagemath-graphs"]
 modules         = ["passagemath-modules"]
+findstat        = [SPKG_INSTALL_REQUIRES_requests]
 
 # everything
-standard        = ["passagemath-combinat[lrcalc,symmetrica,graphs,modules]"]
+standard        = ["passagemath-combinat[findstat,lrcalc,symmetrica,graphs,modules]"]
 
 [tool.setuptools]
 include-package-data = false

--- a/src/sage/algebras/hecke_algebras/ariki_koike_specht_modules.py
+++ b/src/sage/algebras/hecke_algebras/ariki_koike_specht_modules.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-combinat
+# sage.doctest: needs sage.modules
 r"""
 Ariki-Koike Algebra Representations
 

--- a/src/sage/algebras/quantum_oscillator.py
+++ b/src/sage/algebras/quantum_oscillator.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-combinat
+# sage.doctest: needs sage.modules
 r"""
 Quantum Oscillator Algebras
 

--- a/src/sage/categories/discrete_valuation.py
+++ b/src/sage/categories/discrete_valuation.py
@@ -165,9 +165,9 @@ class DiscreteValuationRings(Category_singleton):
 
                 sage: L = PowerSeriesRing(QQ, 't')
                 sage: t = L.gen()
-                sage: F = algebras.Free(L, ['A', 'B'])                                  # needs sage.combinat
-                sage: A, B = F.gens()                                                   # needs sage.combinat
-                sage: f = t*A + t**2*B/2                                                # needs sage.combinat
+                sage: F = algebras.Free(L, ['A', 'B'])                                  # needs sage.combinat sage.modules
+                sage: A, B = F.gens()                                                   # needs sage.combinat sage.modules
+                sage: f = t*A + t**2*B/2                                                # needs sage.combinat sage.modules
             """
             if not other:
                 raise ZeroDivisionError("Euclidean division by the zero element not defined")

--- a/src/sage/categories/filtered_modules_with_basis.py
+++ b/src/sage/categories/filtered_modules_with_basis.py
@@ -1187,10 +1187,12 @@ class FilteredModulesWithBasis(FilteredModulesCategory):
                     sage: OS.hilbert_series()
                     2*t^2 + 3*t + 1
 
+                    sage: # needs sage.modules
                     sage: OS = matroids.Uniform(5, 3).orlik_solomon_algebra(ZZ)
                     sage: OS.hilbert_series()
                     t^3 + 3*t^2 + 3*t + 1
 
+                    sage: # needs sage.modules
                     sage: OS = matroids.PG(2, 3).orlik_solomon_algebra(ZZ['x','y'])
                     sage: OS.hilbert_series()
                     27*t^3 + 39*t^2 + 13*t + 1

--- a/src/sage/categories/finite_complex_reflection_groups.py
+++ b/src/sage/categories/finite_complex_reflection_groups.py
@@ -550,7 +550,7 @@ class FiniteComplexReflectionGroups(CategoryWithAxiom):
 
             EXAMPLES::
 
-                sage: # needs sage.combinat
+                sage: # needs sage.combinat sage.graphs
                 sage: W = ColoredPermutations(3, 2)
                 sage: P = W.milnor_fiber_poset()
                 sage: P
@@ -1199,8 +1199,8 @@ class FiniteComplexReflectionGroups(CategoryWithAxiom):
                 EXAMPLES::
 
                     sage: W = ColoredPermutations(3, 2)                                 # needs sage.combinat
-                    sage: C = W.milnor_fiber_complex()                                  # needs sage.combinat
-                    sage: C.homology()                                                  # needs sage.combinat
+                    sage: C = W.milnor_fiber_complex()                                  # needs sage.combinat sage.graphs
+                    sage: C.homology()                                                  # needs sage.combinat sage.graphs sage.modules
                     {0: 0, 1: Z x Z x Z x Z}
 
                     sage: W = ReflectionGroup(5)                  # optional - gap3

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -469,6 +469,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                  D{1} + D{1, 2} + D{2, 3} + D{3},
                  D{1, 2, 3} + D{1, 3} + D{2})
 
+                sage: # needs sage.combinat sage.modules
                 sage: scoeffs = {('a','d'): {'a':1}, ('a','e'): {'b':-1},
                 ....:            ('b','d'): {'b':1}, ('b','e'): {'a':1},
                 ....:            ('d','e'): {'c':1}}
@@ -1469,6 +1470,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 [An example of a finite dimensional Lie algebra with basis:
                  the 3-dimensional abelian Lie algebra over Rational Field]
 
+                sage: # needs sage.combinat sage.modules
                 sage: L.<x,y> = LieAlgebra(QQ, {('x','y'): {'x':1}})
                 sage: L.upper_central_series()
                 [Ideal () of Lie algebra on 2 generators (x, y) over Rational Field]

--- a/src/sage/combinat/matrices/dancing_links.pyx
+++ b/src/sage/combinat/matrices/dancing_links.pyx
@@ -974,7 +974,7 @@ cdef class dancing_linksWrapper:
 
             sage: rows = [[0,1,2], [2,3,4,5], [0,1,2,3]]
             sage: d = dlx_solver(rows)
-            sage: d.one_solution_using_sat_solver() is None                             # needs sage.sat
+            sage: d.one_solution_using_sat_solver() is None                             # needs sage.sat sage.numerical.mip
             True
         """
         sat_solver = self.to_sat_solver(solver)

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5397,8 +5397,10 @@ class Partition(CombinatorialElement):
         Checks that the dimension satisfies the obvious recursion relation::
 
             sage: test = lambda larger, smaller: larger.dimension(smaller) == sum(mu.dimension(smaller) for mu in larger.down())
-            sage: all(test(larger,smaller) for l in range(1,8) for s in range(8)
-            ....:     for larger in Partitions(l) for smaller in Partitions(s) if smaller != larger)
+            sage: all(test(larger,smaller)                                              # needs sage.modules
+            ....:     for l in range(1,8) for s in range(8)
+            ....:     for larger in Partitions(l) for smaller in Partitions(s)
+            ....:     if smaller != larger)
             True
 
         ALGORITHM:
@@ -5711,13 +5713,14 @@ class Partition(CombinatorialElement):
 
         EXAMPLES::
 
+            sage: # needs sage.modules
             sage: GP = Partition([3,2,1]).garsia_procesi_module(QQ); GP
             Garsia-Procesi module of shape [3, 2, 1] over Rational Field
             sage: GP.graded_frobenius_image()
             q^4*s[3, 2, 1] + q^3*s[3, 3] + q^3*s[4, 1, 1] + (q^3+q^2)*s[4, 2]
              + (q^2+q)*s[5, 1] + s[6]
 
-            sage: Partition([3,2,1]).garsia_procesi_module(GF(3))
+            sage: Partition([3,2,1]).garsia_procesi_module(GF(3))                       # needs sage.modules
             Garsia-Procesi module of shape [3, 2, 1] over Finite Field of size 3
         """
         from sage.combinat.symmetric_group_representations import GarsiaProcesiModule
@@ -5773,7 +5776,7 @@ class Partition(CombinatorialElement):
             sage: Partition([2,2,1]).simple_module_dimension(GF(3))                     # needs sage.rings.finite_rings
             4
 
-            sage: for la in Partitions(6, regular=3):
+            sage: for la in Partitions(6, regular=3):                                   # needs sage.modules
             ....:     print(la, la.specht_module_dimension(), la.simple_module_dimension(GF(3)))
             [6] 1 1
             [5, 1] 5 4
@@ -5796,6 +5799,7 @@ class Partition(CombinatorialElement):
 
         EXAMPLES::
 
+            sage: # needs sage.modules
             sage: TM = Partition([2,2,1]).tabloid_module(QQ); TM
             Tabloid module of [2, 2, 1] over Rational Field
             sage: TM.frobenius_image()

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -5510,7 +5510,7 @@ class Permutation(CombinatorialElement):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
+            sage: # needs sage.combinat sage.graphs
             sage: sigma = Permutations(5).identity()
             sage: list(sigma.nth_roots(3))
             [[1, 4, 3, 5, 2], [1, 5, 3, 2, 4], [1, 2, 4, 5, 3], [1, 2, 5, 3, 4],
@@ -5535,7 +5535,7 @@ class Permutation(CombinatorialElement):
 
         We compute the number of square roots of the identity (i.e. involutions in `S_n`, :oeis:`A000085`)::
 
-            sage: # needs sage.combinat
+            sage: # needs sage.combinat sage.graphs
             sage: [len(list(Permutations(n).identity().nth_roots(2))) for n in range(2,8)]
             [2, 4, 10, 26, 76, 232]
             sage: list(Permutation('(1)').nth_roots(2))

--- a/src/sage/combinat/plane_partition.py
+++ b/src/sage/combinat/plane_partition.py
@@ -1656,7 +1656,7 @@ class PlanePartitions_box(PlanePartitions):
 
         TESTS::
 
-            sage: all(len(set(PP)) == PP.cardinality()
+            sage: all(len(set(PP)) == PP.cardinality()                                  # needs sage.modules
             ....:     for b in cartesian_product([range(4)]*3)
             ....:     if (PP := PlanePartitions(b)))
             True
@@ -2414,7 +2414,8 @@ class PlanePartitions_TSPP(PlanePartitions):
 
         TESTS::
 
-            sage: all(len(set(PP)) == PP.cardinality() for n in range(5) if (PP := PlanePartitions([n]*3, symmetry='TSPP')))
+            sage: all(len(set(PP)) == PP.cardinality()                                  # needs sage.graphs sage.modules
+            ....:     for n in range(5) if (PP := PlanePartitions([n]*3, symmetry='TSPP')))
             True
         """
         for acl in self.to_poset().antichains_iterator():
@@ -2870,7 +2871,7 @@ class PlanePartitions_SSCPP(PlanePartitions):
 
         TESTS::
 
-            sage: all(len(set(PP)) == PP.cardinality()
+            sage: all(len(set(PP)) == PP.cardinality()                                  # needs sage.graphs sage.modules
             ....:     for a, b in cartesian_product([range(5), range(0, 5, 2)])
             ....:     if (PP := PlanePartitions([a, a, b], symmetry='SSCPP')))
             True
@@ -2971,7 +2972,7 @@ class PlanePartitions_CSTCPP(PlanePartitions):
 
         TESTS::
 
-            sage: all(len(set(PP)) == PP.cardinality()
+            sage: all(len(set(PP)) == PP.cardinality()                                  # needs sage.graphs sage.modules
             ....:     for n in range(0, 5, 2)
             ....:     if (PP := PlanePartitions([n]*3, symmetry='CSTCPP')))
             True

--- a/src/sage/combinat/q_analogues.py
+++ b/src/sage/combinat/q_analogues.py
@@ -1008,6 +1008,7 @@ def number_of_irreducible_polynomials(n, q=None, m=1):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.pari
         sage: number_of_irreducible_polynomials(8, q=2)
         30
         sage: number_of_irreducible_polynomials(9, q=9)
@@ -1017,6 +1018,7 @@ def number_of_irreducible_polynomials(n, q=None, m=1):
 
     ::
 
+        sage: # needs sage.libs.pari
         sage: poly = number_of_irreducible_polynomials(12); poly
         1/12*q^12 - 1/12*q^6 - 1/12*q^4 + 1/12*q^2
         sage: poly(5) == number_of_irreducible_polynomials(12, q=5)
@@ -1028,6 +1030,7 @@ def number_of_irreducible_polynomials(n, q=None, m=1):
 
     This function is *much* faster than enumerating the polynomials::
 
+        sage: # needs sage.libs.pari
         sage: num = number_of_irreducible_polynomials(99, q=101)
         sage: num.bit_length()
         653

--- a/src/sage/combinat/sf/sf.py
+++ b/src/sage/combinat/sf/sf.py
@@ -29,7 +29,7 @@ from sage.categories.unique_factorization_domains import UniqueFactorizationDoma
 from sage.categories.fields import Fields
 from sage.categories.rings import Rings
 from sage.combinat.partition import Partitions
-from sage.combinat.free_module import CombinatorialFreeModule
+from sage.misc.lazy_import import lazy_import
 from sage.rings.rational_field import QQ
 
 from . import schur
@@ -41,6 +41,8 @@ from . import hall_littlewood
 from . import jack
 from . import macdonald
 from . import llt
+
+lazy_import('sage.combinat.free_module', 'CombinatorialFreeModule')
 
 
 class SymmetricFunctions(UniqueRepresentation, Parent):

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1076,9 +1076,8 @@ class Stream_taylor(Stream_inexact):
             sage: f = Stream_taylor(polygen(QQ, 'x')^3, False)
             sage: TestSuite(f).run(skip='_test_pickling')
         """
-        from sage.symbolic.ring import SR
-        from sage.structure.element import parent
-        if parent(function) is SR:
+        from sage.structure.element import Expression
+        if isinstance(function, Expression):
             self._is_symbolic = True
             if function.number_of_arguments() != 1:
                 raise NotImplementedError("the function can only take a single input")

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1047,6 +1047,7 @@ class Stream_taylor(Stream_inexact):
 
     EXAMPLES::
 
+        sage: # needs sage.symbolic
         sage: from sage.data_structures.stream import Stream_taylor
         sage: g(x) = sin(x)
         sage: f = Stream_taylor(g, False)
@@ -1055,12 +1056,14 @@ class Stream_taylor(Stream_inexact):
         sage: [f[i] for i in range(10)]
         [0, 1, 0, -1/6, 0, 1/120, 0, -1/5040, 0, 1/362880]
 
+        sage: # needs sage.symbolic
         sage: g(y) = cos(y)
         sage: f = Stream_taylor(g, False)
         sage: n = f.iterate_coefficients()
         sage: [next(n) for _ in range(10)]
         [1, 0, -1/2, 0, 1/24, 0, -1/720, 0, 1/40320, 0]
 
+        sage: # needs sage.symbolic
         sage: g(z) = 1 / (1 - 2*z)
         sage: f = Stream_taylor(g, True)
         sage: [f[i] for i in range(4)]
@@ -1145,12 +1148,14 @@ class Stream_taylor(Stream_inexact):
 
         EXAMPLES::
 
+            sage: # needs sage.symbolic
             sage: from sage.data_structures.stream import Stream_taylor
             sage: g(x) = exp(x)
             sage: f = Stream_taylor(g, True)
             sage: f.get_coefficient(5)
             1/120
 
+            sage: # needs sage.symbolic
             sage: from sage.data_structures.stream import Stream_taylor
             sage: y = SR.var('y')
             sage: f = Stream_taylor(sin(y), True)

--- a/src/sage/libs/lrcalc/lrcalc.py
+++ b/src/sage/libs/lrcalc/lrcalc.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-combinat
+# sage.doctest: needs lrcalc_python
 r"""
 An interface to Anders Buch's Littlewood-Richardson Calculator ``lrcalc``
 

--- a/src/sage/monoids/indexed_free_monoid.py
+++ b/src/sage/monoids/indexed_free_monoid.py
@@ -1055,7 +1055,7 @@ class IndexedFreeAbelianMonoid(IndexedMonoid):
             ...
             IndexError: 0 is not in the index set
 
-            sage: F = lie_algebras.VirasoroAlgebra(QQ).pbw_basis().indices(); F
+            sage: F = lie_algebras.VirasoroAlgebra(QQ).pbw_basis().indices(); F         # needs sage.combinat sage.modules
             Free abelian monoid indexed by Disjoint union of Family ({'c'}, Integer Ring)
             sage: F.gen('c')
             PBW['c']

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -1662,6 +1662,7 @@ In the latter case, please inform the developers.""".format(self.order()))
             sage: R._lift_residue_field_root(11, 2, f, f.derivative(), Zmod(11)(10))
             []
 
+            sage: # needs sage.libs.pari
             sage: R = Zmod(11**3)
             sage: S.<x> = R[]
             sage: f = x^2 + 123*x + 1
@@ -1801,49 +1802,50 @@ In the latter case, please inform the developers.""".format(self.order()))
         is a product of primes or prime powers:
 
             sage: R.<x> = Zmod(60)[]
-            sage: (x^2 - 1).roots(multiplicities=False)
+            sage: (x^2 - 1).roots(multiplicities=False)                                 # needs sage.libs.pari
             [29, 41, 49, 1, 59, 11, 19, 31]
 
         We may also ask for roots modulo a quotient of the ring over which the
         polynomial is defined:
 
             sage: R.<x> = Zmod(120)[]
-            sage: (x^2 - 1).roots(multiplicities=False)
+            sage: (x^2 - 1).roots(multiplicities=False)                                 # needs sage.libs.pari
             [89, 41, 49, 1, 29, 101, 109, 61, 59, 11, 19, 91, 119, 71, 79, 31]
-            sage: (x^2 - 1).roots(Zmod(60), multiplicities=False)
+            sage: (x^2 - 1).roots(Zmod(60), multiplicities=False)                       # needs sage.libs.pari
             [29, 41, 49, 1, 59, 11, 19, 31]
 
         TESTS::
 
             sage: R.<x> = Zmod(2)[]
-            sage: x.roots()
+            sage: x.roots()                                                             # needs sage.libs.pari
             [(0, 1)]
 
         Test polynomials with content:
 
             sage: R.<x> = Zmod(4)[]
-            sage: (2*x).roots(multiplicities=False)
+            sage: (2*x).roots(multiplicities=False)                                     # needs sage.libs.pari
             [0, 2]
 
             sage: R.<x> = Zmod(6)[]
-            sage: (3*x).roots(multiplicities=False)
+            sage: (3*x).roots(multiplicities=False)                                     # needs sage.libs.pari
             [0, 4, 2]
 
         Test polynomial with many roots:
 
             sage: R.<x> = Zmod(6)[]
             sage: f = x * (x - 1) * (x - 2) * (x - 3) * (x - 4) * (x - 5)
-            sage: len(f.roots(multiplicities=False))
+            sage: len(f.roots(multiplicities=False))                                    # needs sage.libs.pari
             6
 
         Test finding roots over large prime powers:
 
             sage: R.<x> = Zmod(2**16)[]
-            sage: (x^3 + 5).roots(multiplicities=False)
+            sage: (x^3 + 5).roots(multiplicities=False)                                 # needs sage.libs.pari
             [45475]
-            sage: (x^2 + 46*x + 1).roots(multiplicities=False)
+            sage: (x^2 + 46*x + 1).roots(multiplicities=False)                          # needs sage.libs.pari
             [421, 33189, 16805, 49573, 8613, 41381, 24997, 57765, 7725, 40493, 24109, 56877, 15917, 48685, 32301, 65069]
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = Zmod(3**16)[]
             sage: (x^2 + 2).roots(multiplicities=False)
             [24620738, 18425983]
@@ -1854,6 +1856,7 @@ In the latter case, please inform the developers.""".format(self.order()))
 
         Test some larger primes:
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = Zmod(41**4)[]
             sage: (x^2 + 2).roots(multiplicities=False)
             [2208905, 616856]
@@ -1863,6 +1866,7 @@ In the latter case, please inform the developers.""".format(self.order()))
 
         We can't find roots with multiplicities in non-fields:
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = Zmod(6)[]
             sage: (x + 1).roots()
             Traceback (most recent call last):
@@ -1918,6 +1922,7 @@ In the latter case, please inform the developers.""".format(self.order()))
         Sage allows us to coerce polynomials from one modulus to another,
         and that makes the following defined:
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = Zmod(100)[]
             sage: (x^2 - 1).roots(Zmod(99), multiplicities=False) == (x^2 - 1).change_ring(Zmod(99)).roots(multiplicities=False)
             True

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -83,21 +83,23 @@ series in this case are polynomials::
 
 A similar statement is true for lazy symmetric functions::
 
-    sage: h = SymmetricFunctions(QQ).h()                                                # needs sage.combinat
-    sage: L = LazySymmetricFunctions(h)                                                 # needs sage.combinat
-    sage: 1 / (1-L(h[1]))                                                               # needs sage.combinat
+    sage: # needs sage.combinat sage.modules
+    sage: h = SymmetricFunctions(QQ).h()
+    sage: L = LazySymmetricFunctions(h)
+    sage: 1 / (1-L(h[1]))
     h[] + h[1] + (h[1,1]) + (h[1,1,1]) + (h[1,1,1,1]) + (h[1,1,1,1,1]) + (h[1,1,1,1,1,1]) + O^7
 
 We can change the base ring::
 
+    sage: # needs sage.combinat sage.modules
     sage: h = g.change_ring(QQ)
-    sage: h.parent()                                                                    # needs sage.combinat
+    sage: h.parent()
     Lazy Laurent Series Ring in z over Rational Field
-    sage: h                                                                             # needs sage.combinat
+    sage: h
     4*z + 6*z^2 + 8*z^3 + 19*z^4 + 38*z^5 + 71*z^6 + 130*z^7 + O(z^8)
-    sage: hinv = h^-1; hinv                                                             # needs sage.combinat
+    sage: hinv = h^-1; hinv
     1/4*z^-1 - 3/8 + 1/16*z - 17/32*z^2 + 5/64*z^3 - 29/128*z^4 + 165/256*z^5 + O(z^6)
-    sage: hinv.valuation()                                                              # needs sage.combinat
+    sage: hinv.valuation()
     -1
 
 TESTS:
@@ -192,9 +194,10 @@ components are in the correct ring::
     ....:         n += 1
     sage: check(L, gen(), valuation=None)                                               # needs sage.rings.finite_rings
 
-    sage: s = SymmetricFunctions(GF(2)).s()                                             # needs sage.combinat
-    sage: L = LazySymmetricFunctions(s)                                                 # needs sage.combinat
-    sage: check(L, lambda n: sum(k*s(la) for k, la in enumerate(Partitions(n))),        # needs sage.combinat
+    sage: # needs sage.combinat sage.modules
+    sage: s = SymmetricFunctions(GF(2)).s()
+    sage: L = LazySymmetricFunctions(s)
+    sage: check(L, lambda n: sum(k*s(la) for k, la in enumerate(Partitions(n))),
     ....:       valuation=0)
 
 Check that we can invert matrices::
@@ -535,7 +538,7 @@ class LazyModuleElement(Element):
 
         Similarly for lazy symmetric functions::
 
-            sage: # needs sage.combinat
+            sage: # needs sage.combinat sage.modules
             sage: p = SymmetricFunctions(QQ).p()
             sage: L = LazySymmetricFunctions(p)
             sage: f = 1/(1-2*L(p[1])); f
@@ -1372,7 +1375,7 @@ class LazyModuleElement(Element):
 
         We can compute the Frobenius character of unlabeled trees::
 
-            sage: # needs sage.combinat
+            sage: # needs sage.combinat sage.modules
             sage: m = SymmetricFunctions(QQ).m()
             sage: s = SymmetricFunctions(QQ).s()
             sage: L = LazySymmetricFunctions(m)
@@ -3418,12 +3421,12 @@ class LazyCauchyProductSeries(LazyModuleElement):
         Check that division by one does nothing, and division by
         itself gives one::
 
+            sage: # needs sage.combinat sage.modules
             sage: s = SymmetricFunctions(ZZ).s()
             sage: S = LazySymmetricFunctions(s)
             sage: f = S(lambda n: s(Partitions(n).random_element()))
             sage: f / S.one() is f
             True
-
             sage: f / f
             s[]
 
@@ -6733,6 +6736,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat sage.modules
             sage: p = SymmetricFunctions(QQ).p()
             sage: s = SymmetricFunctions(QQ).s()
             sage: lp = LazySymmetricFunctions(p)
@@ -6744,6 +6748,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             ....:     return p.sum_of_terms((Partition([d] * (n // d)),
             ....:          euler_phi(d) / n) for d in divisors(n))
 
+            sage: # needs sage.combinat sage.modules
             sage: A = lp(asso, valuation=2)
             sage: A.legendre_transform()[:5]
             [1/2*p[1, 1] - 1/2*p[2],
@@ -6752,6 +6757,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
 
         TESTS::
 
+            sage: # needs sage.combinat sage.modules
             sage: p = SymmetricFunctions(QQ).p()
             sage: lp = LazySymmetricFunctions(p)
             sage: A = lp(p([1]))
@@ -6838,6 +6844,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat sage.modules
             sage: s = SymmetricFunctions(QQ).s()
             sage: ls = LazySymmetricFunctions(s)
             sage: f = ls(lambda n: s([n]), valuation=1)

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -2060,6 +2060,7 @@ class LazyModuleElement(Element):
 
         Check that non-commutativity is taken into account::
 
+            sage: # needs sage.modules
             sage: M = MatrixSpace(ZZ, 2)
             sage: L.<z> = LazyPowerSeriesRing(M)
             sage: f = L(lambda n: matrix([[1,n],[0,1]]))

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -1817,6 +1817,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
 
         EXAMPLES::
 
+            sage: # needs sage.symbolic
             sage: L.<z> = LazyLaurentSeriesRing(QQ)
             sage: x = SR.var('x')
             sage: f(x) = (1 + x) / (1 - x^2)
@@ -1826,6 +1827,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         For inputs as symbolic functions/expressions, the function must
         not have any poles at `0`::
 
+            sage: # needs sage.symbolic
             sage: f(x) = (1 + x^2) / sin(x^2)
             sage: L.taylor(f)
             <repr(...) failed: ValueError: power::eval(): division by zero>
@@ -2572,6 +2574,7 @@ class LazyPowerSeriesRing(LazySeriesRing):
 
         EXAMPLES::
 
+            sage: # needs sage.symbolic
             sage: L.<z> = LazyPowerSeriesRing(QQ)
             sage: x = SR.var('x')
             sage: f(x) = (1 + x) / (1 - x^3)
@@ -2726,6 +2729,7 @@ class LazyCompletionGradedAlgebra(LazySeriesRing):
 
         Check that :issue:`37625` is fixed::
 
+            sage: # needs sage.combinat sage.modules
             sage: R = algebras.Free(QQ, ('a', 'b'), degrees=(1, 2))
             sage: L = R.completion()
             sage: a, b = R.gens()

--- a/src/sage/rings/polynomial/multi_polynomial_ring.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ring.py
@@ -360,7 +360,7 @@ class MPolynomialRing_polydict(MPolynomialRing_macaulay2_repr, PolynomialRing_si
         Check if we still allow nonsense (see :issue:`7951`)::
 
             sage: P = PolynomialRing(QQ, 0, '')
-            sage: P('pi')
+            sage: P('pi')                                                               # needs sage.symbolic
             Traceback (most recent call last):
             ...
             TypeError: unable to convert pi to a rational

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -2144,6 +2144,7 @@ cdef class Polynomial(CommutativePolynomial):
 
         Ensure that :issue:`37445` is fixed::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = GF(13)[]
             sage: def irr(d, R): return f.monic() if (f := R.random_element(d)).is_irreducible() else irr(d, R)
             sage: f = prod(irr(6, R) for _ in range(10))
@@ -2361,6 +2362,7 @@ cdef class Polynomial(CommutativePolynomial):
         We can also use this function for polynomials which are not defined over finite
         fields, but this simply falls back to a slow method of factorisation::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = ZZ[]
             sage: f = 3*x^4 + 2*x^3
             sage: f.any_irreducible_factor()
@@ -2573,6 +2575,7 @@ cdef class Polynomial(CommutativePolynomial):
 
         Check for :issue:`37034`::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = Zmod(55)[]
             sage: (x^2 + 1).any_root()
             Traceback (most recent call last):

--- a/src/sage/structure/unique_representation.py
+++ b/src/sage/structure/unique_representation.py
@@ -521,9 +521,9 @@ For example, a symmetric function algebra is uniquely determined by the base
 ring. Thus, it is reasonable to use :class:`UniqueRepresentation` in this
 case::
 
-    sage: isinstance(SymmetricFunctions(CC), SymmetricFunctions)                        # needs sage.combinat
+    sage: isinstance(SymmetricFunctions(CC), SymmetricFunctions)                        # needs sage.combinat sage.modules sage.rings.real_mpfr
     True
-    sage: issubclass(SymmetricFunctions, UniqueRepresentation)                          # needs sage.combinat
+    sage: issubclass(SymmetricFunctions, UniqueRepresentation)                          # needs sage.combinat sage.modules
     True
 
 :class:`UniqueRepresentation` differs from :class:`CachedRepresentation` only


### PR DESCRIPTION
- **src/sage/data_structures/stream.py: Do not import SR, use isinstance(..., Expression) instead**
- **src/sage/data_structures/stream.py: Add # needs**
- **src/sage/combinat/sf/sf.py: Use lazy_import**
- **src/sage/algebras: Add # needs**
- **src/sage/categories: Add # needs**
- **src/sage/combinat: Add # needs**
- **src/sage/rings: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-combinat' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-combinat[graphs]' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-combinat[modules]' --update-known-test-failures**
- **pkgs/sagemath-combinat/pyproject.toml.m4: Define extra 'findstat'**
- **src/sage/libs/lrcalc/lrcalc.py: Add # needs**
- **src/sage/structure/unique_representation.py: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/monoids/indexed_free_monoid.py: Add # needs**
