### PR TITLE
pkgs/sagemath-eclib: Fix toplevel

### DIFF
--- a/pkgs/sagemath-eclib/README.rst
+++ b/pkgs/sagemath-eclib/README.rst
@@ -42,6 +42,8 @@ What is included
 
 - `Cremona modular symbols (constructor) <https://doc.sagemath.org/html/en/reference/libs/sage/libs/eclib/constructor.html>`_
 
+- `Interface to the mwrank program <https://doc.sagemath.org/html/en/reference/interfaces/sage/interfaces/mwrank.html#module-sage.interfaces.mwrank>`_
+
 
 Examples
 --------

--- a/src/sage/all__sagemath_eclib.py
+++ b/src/sage/all__sagemath_eclib.py
@@ -12,3 +12,5 @@ try:
     from sage.all__sagemath_schemes import *
 except ImportError:
     pass
+
+from sage.libs.all__sagemath_eclib import *


### PR DESCRIPTION
- **src/sage/all__sagemath_eclib.py: Import from sage.libs**
- **pkgs/sagemath-eclib/README.rst: Add link to sage.interfaces.mwrank documentation**
