### PR TITLE
pkgs/sagemath-{eclib,schemes}: Modularization fixes

### DIFF
--- a/pkgs/sagemath-eclib/known-test-failures.json
+++ b/pkgs/sagemath-eclib/known-test-failures.json
@@ -1,0 +1,182 @@
+{
+    "sage.libs.eclib.constructor": {
+        "ntests": 10
+    },
+    "sage.libs.eclib.homspace": {
+        "ntests": 49
+    },
+    "sage.libs.eclib.interface": {
+        "ntests": 192
+    },
+    "sage.libs.eclib.mat": {
+        "ntests": 36
+    },
+    "sage.libs.eclib.mwrank": {
+        "ntests": 209
+    },
+    "sage.libs.eclib.newforms": {
+        "ntests": 93
+    },
+    "sage.schemes.elliptic_curves.BSD": {
+        "ntests": 50
+    },
+    "sage.schemes.elliptic_curves.Qcurves": {
+        "ntests": 62
+    },
+    "sage.schemes.elliptic_curves.cardinality": {
+        "ntests": 59
+    },
+    "sage.schemes.elliptic_curves.cm": {
+        "ntests": 92
+    },
+    "sage.schemes.elliptic_curves.constructor": {
+        "failed": true,
+        "ntests": 227
+    },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "failed": true,
+        "ntests": 37
+    },
+    "sage.schemes.elliptic_curves.ec_database": {
+        "ntests": 9
+    },
+    "sage.schemes.elliptic_curves.ell_curve_isogeny": {
+        "ntests": 876
+    },
+    "sage.schemes.elliptic_curves.ell_egros": {
+        "failed": true,
+        "ntests": 29
+    },
+    "sage.schemes.elliptic_curves.ell_field": {
+        "failed": true,
+        "ntests": 430
+    },
+    "sage.schemes.elliptic_curves.ell_finite_field": {
+        "failed": true,
+        "ntests": 530
+    },
+    "sage.schemes.elliptic_curves.ell_generic": {
+        "failed": true,
+        "ntests": 540
+    },
+    "sage.schemes.elliptic_curves.ell_local_data": {
+        "ntests": 167
+    },
+    "sage.schemes.elliptic_curves.ell_modular_symbols": {
+        "ntests": 76
+    },
+    "sage.schemes.elliptic_curves.ell_number_field": {
+        "failed": true,
+        "ntests": 839
+    },
+    "sage.schemes.elliptic_curves.ell_point": {
+        "failed": true,
+        "ntests": 961
+    },
+    "sage.schemes.elliptic_curves.ell_rational_field": {
+        "failed": true,
+        "ntests": 847
+    },
+    "sage.schemes.elliptic_curves.ell_tate_curve": {
+        "ntests": 64
+    },
+    "sage.schemes.elliptic_curves.ell_torsion": {
+        "ntests": 77
+    },
+    "sage.schemes.elliptic_curves.ell_wp": {
+        "ntests": 42
+    },
+    "sage.schemes.elliptic_curves.formal_group": {
+        "ntests": 76
+    },
+    "sage.schemes.elliptic_curves.gal_reps": {
+        "ntests": 170
+    },
+    "sage.schemes.elliptic_curves.gal_reps_number_field": {
+        "ntests": 198
+    },
+    "sage.schemes.elliptic_curves.gp_simon": {
+        "ntests": 13
+    },
+    "sage.schemes.elliptic_curves.heegner": {
+        "failed": true,
+        "ntests": 1087
+    },
+    "sage.schemes.elliptic_curves.height": {
+        "failed": true,
+        "ntests": 318
+    },
+    "sage.schemes.elliptic_curves.hom": {
+        "failed": true,
+        "ntests": 344
+    },
+    "sage.schemes.elliptic_curves.hom_composite": {
+        "failed": true,
+        "ntests": 196
+    },
+    "sage.schemes.elliptic_curves.hom_frobenius": {
+        "failed": true,
+        "ntests": 111
+    },
+    "sage.schemes.elliptic_curves.hom_scalar": {
+        "ntests": 138
+    },
+    "sage.schemes.elliptic_curves.hom_sum": {
+        "failed": true,
+        "ntests": 134
+    },
+    "sage.schemes.elliptic_curves.hom_velusqrt": {
+        "failed": true,
+        "ntests": 263
+    },
+    "sage.schemes.elliptic_curves.homset": {
+        "failed": true,
+        "ntests": 59
+    },
+    "sage.schemes.elliptic_curves.isogeny_class": {
+        "ntests": 141
+    },
+    "sage.schemes.elliptic_curves.isogeny_small_degree": {
+        "failed": true,
+        "ntests": 297
+    },
+    "sage.schemes.elliptic_curves.jacobian": {
+        "ntests": 35
+    },
+    "sage.schemes.elliptic_curves.kodaira_symbol": {
+        "ntests": 29
+    },
+    "sage.schemes.elliptic_curves.kraus": {
+        "ntests": 138
+    },
+    "sage.schemes.elliptic_curves.lseries_ell": {
+        "failed": true,
+        "ntests": 51
+    },
+    "sage.schemes.elliptic_curves.mod5family": {
+        "ntests": 2
+    },
+    "sage.schemes.elliptic_curves.mod_poly": {
+        "ntests": 27
+    },
+    "sage.schemes.elliptic_curves.mod_sym_num": {
+        "failed": true,
+        "ntests": 359
+    },
+    "sage.schemes.elliptic_curves.modular_parametrization": {
+        "ntests": 50
+    },
+    "sage.schemes.elliptic_curves.period_lattice": {
+        "failed": true,
+        "ntests": 405
+    },
+    "sage.schemes.elliptic_curves.saturation": {
+        "ntests": 69
+    },
+    "sage.schemes.elliptic_curves.weierstrass_morphism": {
+        "ntests": 244
+    },
+    "sage.schemes.elliptic_curves.weierstrass_transform": {
+        "ntests": 34
+    }
+}

--- a/pkgs/sagemath-eclib/known-test-failures.json
+++ b/pkgs/sagemath-eclib/known-test-failures.json
@@ -1,4 +1,7 @@
 {
+    "sage.interfaces.mwrank": {
+        "ntests": 30
+    },
     "sage.libs.eclib.constructor": {
         "ntests": 10
     },
@@ -67,15 +70,15 @@
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
-        "ntests": 839
+        "ntests": 840
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
-        "ntests": 961
+        "ntests": 960
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 847
+        "ntests": 843
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64

--- a/pkgs/sagemath-eclib/tox.ini
+++ b/pkgs/sagemath-eclib/tox.ini
@@ -64,7 +64,7 @@ commands =
     # Beware of the treacherous non-src layout. "./sage/" shadows the install sage package.
     {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); import sage.libs.eclib'
     bash -c 'cd $(python -c "import sys; \"\" in sys.path and sys.path.remove(\"\"); from sage.env import SAGE_LIB; print(SAGE_LIB)") \
-       && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_eclib --baseline-stats-path={toxinidir}/known-test-failures.json sage/libs/eclib/ sage/schemes/elliptic_curves/ sage/modular/pollack_stevens/space.py'
+       && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_eclib --baseline-stats-path={toxinidir}/known-test-failures.json sage/interfaces/mwrank.py sage/libs/eclib/ sage/schemes/elliptic_curves/ sage/modular/pollack_stevens/space.py'
 
 
 [testenv:.tox]

--- a/pkgs/sagemath-modules/pyproject.toml.m4
+++ b/pkgs/sagemath-modules/pyproject.toml.m4
@@ -42,6 +42,7 @@ test    = ["passagemath-repl"]
 
 # extras by packages
 flint   = ["passagemath-flint"]
+fpylll  = [SPKG_INSTALL_REQUIRES_fpylll]
 gsl     = []  # No extra needed
 linbox  = ["passagemath-linbox"]
 m4ri    = ["passagemath-modules[linbox]"]

--- a/pkgs/sagemath-pari/MANIFEST.in
+++ b/pkgs/sagemath-pari/MANIFEST.in
@@ -57,6 +57,8 @@ include sage/quadratic_forms/special_values.p*
 
 include sage/databases/conway.py
 
+include sage/interfaces/genus2reduction.py
+
 global-exclude *.c
 global-exclude *.cpp
 

--- a/pkgs/sagemath-schemes/MANIFEST.in
+++ b/pkgs/sagemath-schemes/MANIFEST.in
@@ -30,7 +30,9 @@ include sage/databases/cremona.p*
 include sage/databases/db_modular_polynomials.p*
 include sage/databases/stein_watkins.p*
 
+graft sage/lfunctions
 exclude sage/lfunctions/sympow.p*
+exclude sage/lfunctions/lcalc.p*
 
 global-exclude all__sagemath_*.*
 global-include all__sagemath_schemes.py

--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -79,7 +79,7 @@
     },
     "sage.algebras.quatalg.quaternion_algebra": {
         "failed": true,
-        "ntests": 686
+        "ntests": 690
     },
     "sage.algebras.quatalg.quaternion_algebra_cython": {
         "failed": true,
@@ -131,7 +131,7 @@
         "ntests": 77
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.calculus.interpolation": {
         "ntests": 67
@@ -255,7 +255,6 @@
         "ntests": 7
     },
     "sage.categories.commutative_rings": {
-        "failed": true,
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
@@ -271,7 +270,6 @@
         "ntests": 65
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
         "ntests": 368
     },
     "sage.categories.crystals": {
@@ -325,10 +323,6 @@
     },
     "sage.categories.examples.finite_dimensional_algebras_with_basis": {
         "ntests": 17
-    },
-    "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 96
     },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
@@ -386,12 +380,10 @@
         "ntests": 141
     },
     "sage.categories.filtered_algebras": {
-        "failed": true,
         "ntests": 5
     },
     "sage.categories.filtered_algebras_with_basis": {
-        "failed": true,
-        "ntests": 63
+        "ntests": 53
     },
     "sage.categories.filtered_hopf_algebras_with_basis": {
         "ntests": 17
@@ -410,8 +402,7 @@
         "ntests": 6
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "failed": true,
-        "ntests": 128
+        "ntests": 97
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -426,8 +417,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 172
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "ntests": 158
@@ -481,7 +471,6 @@
         "ntests": 11
     },
     "sage.categories.functor": {
-        "failed": true,
         "ntests": 137
     },
     "sage.categories.g_sets": {
@@ -549,7 +538,6 @@
         "ntests": 20
     },
     "sage.categories.homset": {
-        "failed": true,
         "ntests": 222
     },
     "sage.categories.homsets": {
@@ -592,11 +580,9 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
-        "failed": true,
         "ntests": 19
     },
     "sage.categories.lie_conformal_algebras": {
@@ -827,14 +813,12 @@
         "ntests": 47
     },
     "sage.coding.code_constructions": {
-        "failed": true,
         "ntests": 118
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
     },
     "sage.coding.cyclic_code": {
-        "failed": true,
         "ntests": 274
     },
     "sage.coding.databases": {
@@ -869,7 +853,6 @@
         "ntests": 115
     },
     "sage.coding.grs_code": {
-        "failed": true,
         "ntests": 530
     },
     "sage.coding.guava": {
@@ -1200,7 +1183,6 @@
         "ntests": 283
     },
     "sage.crypto.sboxes": {
-        "failed": true,
         "ntests": 27
     },
     "sage.data_structures.bitset": {
@@ -1218,8 +1200,10 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
+    "sage.databases.conway": {
+        "ntests": 42
+    },
     "sage.databases.cremona": {
-        "failed": true,
         "ntests": 155
     },
     "sage.databases.db_modular_polynomials": {
@@ -1238,7 +1222,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 42
+        "ntests": 46
     },
     "sage.doctest.fixtures": {
         "failed": true,
@@ -1266,6 +1250,7 @@
         "ntests": 343
     },
     "sage.doctest.test": {
+        "failed": true,
         "ntests": 23
     },
     "sage.doctest.util": {
@@ -1279,7 +1264,6 @@
         "ntests": 398
     },
     "sage.dynamics.arithmetic_dynamics.endPN_automorphism_group": {
-        "failed": true,
         "ntests": 137
     },
     "sage.dynamics.arithmetic_dynamics.endPN_minimal_model": {
@@ -1287,7 +1271,6 @@
         "ntests": 64
     },
     "sage.dynamics.arithmetic_dynamics.generic_ds": {
-        "failed": true,
         "ntests": 104
     },
     "sage.dynamics.arithmetic_dynamics.product_projective_ds": {
@@ -1345,6 +1328,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
     "sage.features.ecm": {
         "ntests": 4
     },
@@ -1380,6 +1366,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -1454,8 +1443,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "failed": true,
-        "ntests": 188
+        "ntests": 189
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1498,14 +1486,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 160
+        "ntests": 162
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 141
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "failed": true,
@@ -1532,7 +1520,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 244
+        "ntests": 245
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1579,8 +1567,7 @@
         "ntests": 15
     },
     "sage.geometry.cone": {
-        "failed": true,
-        "ntests": 1130
+        "ntests": 1113
     },
     "sage.geometry.cone_catalog": {
         "ntests": 101
@@ -1616,11 +1603,9 @@
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
-        "failed": true,
         "ntests": 24
     },
     "sage.geometry.hyperplane_arrangement.ordered_arrangement": {
-        "failed": true,
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
@@ -1760,7 +1745,7 @@
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
-        "ntests": 6
+        "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
         "failed": true,
@@ -1812,7 +1797,7 @@
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 238
+        "ntests": 240
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 26
@@ -1833,7 +1818,6 @@
         "ntests": 78
     },
     "sage.groups.additive_abelian.additive_abelian_wrapper": {
-        "failed": true,
         "ntests": 125
     },
     "sage.groups.additive_abelian.qmodnz": {
@@ -1855,7 +1839,6 @@
         "ntests": 2
     },
     "sage.groups.generic": {
-        "failed": true,
         "ntests": 236
     },
     "sage.groups.group": {
@@ -1876,7 +1859,7 @@
     },
     "sage.groups.matrix_gps.matrix_group": {
         "failed": true,
-        "ntests": 63
+        "ntests": 64
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -1946,12 +1929,15 @@
     "sage.interfaces.abc": {
         "ntests": 8
     },
+    "sage.interfaces.genus2reduction": {
+        "ntests": 23
+    },
     "sage.interfaces.gp": {
         "failed": true,
         "ntests": 142
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.polymake": {
         "ntests": 188
@@ -1970,10 +1956,22 @@
     },
     "sage.interfaces.singular": {
         "failed": true,
-        "ntests": 412
+        "ntests": 421
     },
     "sage.interfaces.tab_completion": {
         "ntests": 13
+    },
+    "sage.lfunctions.dokchitser": {
+        "failed": true,
+        "ntests": 98
+    },
+    "sage.lfunctions.pari": {
+        "failed": true,
+        "ntests": 182
+    },
+    "sage.lfunctions.zero_sums": {
+        "failed": true,
+        "ntests": 132
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2025,14 +2023,12 @@
         "ntests": 70
     },
     "sage.libs.ntl.ntl_GF2EContext": {
-        "failed": true,
         "ntests": 20
     },
     "sage.libs.ntl.ntl_GF2EX": {
         "ntests": 31
     },
     "sage.libs.ntl.ntl_GF2X": {
-        "failed": true,
         "ntests": 112
     },
     "sage.libs.ntl.ntl_GF2X_linkage.pxi": {
@@ -2134,7 +2130,6 @@
         "ntests": 101
     },
     "sage.libs.singular.singular": {
-        "failed": true,
         "ntests": 171
     },
     "sage.libs.singular.standard_options": {
@@ -2309,6 +2304,14 @@
     "sage.matroids.basis_matroid": {
         "ntests": 150
     },
+    "sage.matroids.chow_ring": {
+        "failed": true,
+        "ntests": 40
+    },
+    "sage.matroids.chow_ring_ideal": {
+        "failed": true,
+        "ntests": 81
+    },
     "sage.matroids.circuit_closures_matroid": {
         "ntests": 86
     },
@@ -2340,7 +2343,8 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "ntests": 948
+        "failed": true,
+        "ntests": 941
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2460,7 +2464,6 @@
         "ntests": 67
     },
     "sage.misc.latex": {
-        "failed": true,
         "ntests": 236
     },
     "sage.misc.latex_macros": {
@@ -2579,7 +2582,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 330
+        "ntests": 326
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2669,7 +2672,6 @@
         "ntests": 45
     },
     "sage.modular.abvar.torsion_subgroup": {
-        "failed": true,
         "ntests": 85
     },
     "sage.modular.arithgroup.arithgroup_element": {
@@ -2703,12 +2705,10 @@
         "ntests": 89
     },
     "sage.modular.btquotients.btquotient": {
-        "failed": true,
-        "ntests": 374
+        "ntests": 6
     },
     "sage.modular.btquotients.pautomorphicform": {
-        "failed": true,
-        "ntests": 388
+        "ntests": 5
     },
     "sage.modular.buzzard": {
         "ntests": 7
@@ -2725,7 +2725,7 @@
     },
     "sage.modular.dirichlet": {
         "failed": true,
-        "ntests": 596
+        "ntests": 593
     },
     "sage.modular.drinfeld_modform.element": {
         "ntests": 114
@@ -2738,8 +2738,7 @@
         "ntests": 12
     },
     "sage.modular.etaproducts": {
-        "failed": true,
-        "ntests": 102
+        "ntests": 87
     },
     "sage.modular.hecke.algebra": {
         "ntests": 91
@@ -2782,7 +2781,7 @@
     },
     "sage.modular.hypergeometric_motive": {
         "failed": true,
-        "ntests": 324
+        "ntests": 320
     },
     "sage.modular.local_comp.liftings": {
         "ntests": 48
@@ -2826,8 +2825,7 @@
         "ntests": 66
     },
     "sage.modular.modform.eis_series": {
-        "failed": true,
-        "ntests": 41
+        "ntests": 42
     },
     "sage.modular.modform.eis_series_cython": {
         "ntests": 6
@@ -2838,7 +2836,7 @@
     },
     "sage.modular.modform.element": {
         "failed": true,
-        "ntests": 624
+        "ntests": 620
     },
     "sage.modular.modform.find_generators": {
         "failed": true,
@@ -2854,11 +2852,9 @@
         "ntests": 3
     },
     "sage.modular.modform.l_series_gross_zagier": {
-        "failed": true,
-        "ntests": 25
+        "ntests": 26
     },
     "sage.modular.modform.l_series_gross_zagier_coeffs": {
-        "failed": true,
         "ntests": 20
     },
     "sage.modular.modform.numerical": {
@@ -2976,11 +2972,7 @@
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
-        "ntests": 174
-    },
-    "sage.modular.pollack_stevens.modsym": {
-        "failed": true,
-        "ntests": 243
+        "ntests": 166
     },
     "sage.modular.pollack_stevens.sigma0": {
         "ntests": 101
@@ -2998,7 +2990,6 @@
         "ntests": 165
     },
     "sage.modular.ssmod.ssmod": {
-        "failed": true,
         "ntests": 77
     },
     "sage.modules.complex_double_vector": {
@@ -3064,7 +3055,6 @@
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "failed": true,
         "ntests": 133
     },
     "sage.modules.real_double_vector": {
@@ -3101,7 +3091,7 @@
         "ntests": 45
     },
     "sage.modules.vector_numpy_integer_dense": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.modules.vector_rational_dense": {
         "ntests": 45
@@ -3113,12 +3103,10 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "failed": true,
         "ntests": 168
     },
     "sage.modules.with_basis.indexed_element": {
-        "failed": true,
-        "ntests": 166
+        "ntests": 160
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353
@@ -3137,8 +3125,7 @@
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
-        "failed": true,
-        "ntests": 266
+        "ntests": 258
     },
     "sage.numerical.backends.logging_backend": {
         "ntests": 45
@@ -3431,7 +3418,6 @@
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
-        "failed": true,
         "ntests": 213
     },
     "sage.rings.bernmm": {
@@ -3462,7 +3448,6 @@
         "ntests": 131
     },
     "sage.rings.complex_mpc": {
-        "failed": true,
         "ntests": 406
     },
     "sage.rings.complex_mpfr": {
@@ -3495,15 +3480,12 @@
         "ntests": 57
     },
     "sage.rings.finite_rings.element_base": {
-        "failed": true,
         "ntests": 243
     },
     "sage.rings.finite_rings.element_givaro": {
-        "failed": true,
-        "ntests": 244
+        "ntests": 240
     },
     "sage.rings.finite_rings.element_ntl_gf2e": {
-        "failed": true,
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
@@ -3515,19 +3497,15 @@
         "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.finite_rings.finite_field_givaro": {
-        "failed": true,
-        "ntests": 122
+        "ntests": 112
     },
     "sage.rings.finite_rings.finite_field_ntl_gf2e": {
-        "failed": true,
         "ntests": 61
     },
     "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "failed": true,
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
@@ -3537,7 +3515,6 @@
         "ntests": 20
     },
     "sage.rings.finite_rings.hom_finite_field": {
-        "failed": true,
         "ntests": 201
     },
     "sage.rings.finite_rings.hom_finite_field_givaro": {
@@ -3547,7 +3524,6 @@
         "ntests": 21
     },
     "sage.rings.finite_rings.homset": {
-        "failed": true,
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
@@ -3573,7 +3549,6 @@
         "ntests": 34
     },
     "sage.rings.fraction_field": {
-        "failed": true,
         "ntests": 262
     },
     "sage.rings.fraction_field_FpT": {
@@ -3671,7 +3646,6 @@
         "ntests": 94
     },
     "sage.rings.function_field.place_polymod": {
-        "failed": true,
         "ntests": 92
     },
     "sage.rings.function_field.place_rational": {
@@ -3777,7 +3751,6 @@
         "ntests": 616
     },
     "sage.rings.number_field.number_field_ideal": {
-        "failed": true,
         "ntests": 760
     },
     "sage.rings.number_field.number_field_ideal_rel": {
@@ -3825,26 +3798,21 @@
         "ntests": 180
     },
     "sage.rings.padics.CA_template.pxi": {
-        "failed": true,
         "ntests": 311
     },
     "sage.rings.padics.CR_template.pxi": {
-        "failed": true,
         "ntests": 431
     },
     "sage.rings.padics.FM_template.pxi": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.padics.FP_template.pxi": {
-        "failed": true,
         "ntests": 342
     },
     "sage.rings.padics.eisenstein_extension_generic": {
         "ntests": 41
     },
     "sage.rings.padics.factory": {
-        "failed": true,
         "ntests": 559
     },
     "sage.rings.padics.generic_nodes": {
@@ -3869,11 +3837,9 @@
         "ntests": 223
     },
     "sage.rings.padics.padic_extension_generic": {
-        "failed": true,
         "ntests": 208
     },
     "sage.rings.padics.padic_extension_leaves": {
-        "failed": true,
         "ntests": 72
     },
     "sage.rings.padics.padic_generic_element": {
@@ -3884,7 +3850,6 @@
         "ntests": 269
     },
     "sage.rings.padics.padic_printing": {
-        "failed": true,
         "ntests": 108
     },
     "sage.rings.padics.padic_relaxed_errors": {
@@ -3904,43 +3869,33 @@
         "ntests": 76
     },
     "sage.rings.padics.pow_computer_relative": {
-        "failed": true,
         "ntests": 97
     },
     "sage.rings.padics.qadic_flint_CA": {
-        "failed": true,
         "ntests": 19
     },
     "sage.rings.padics.qadic_flint_CR": {
-        "failed": true,
         "ntests": 23
     },
     "sage.rings.padics.qadic_flint_FM": {
-        "failed": true,
         "ntests": 17
     },
     "sage.rings.padics.qadic_flint_FP": {
-        "failed": true,
         "ntests": 22
     },
     "sage.rings.padics.relative_extension_leaves": {
-        "failed": true,
         "ntests": 87
     },
     "sage.rings.padics.relative_ramified_CA": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_CR": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FM": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FP": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relaxed_template.pxi": {
@@ -3950,11 +3905,9 @@
         "ntests": 12
     },
     "sage.rings.padics.tutorial": {
-        "failed": true,
         "ntests": 45
     },
     "sage.rings.padics.unramified_extension_generic": {
-        "failed": true,
         "ntests": 33
     },
     "sage.rings.pari_ring": {
@@ -3989,7 +3942,6 @@
         "ntests": 279
     },
     "sage.rings.polynomial.laurent_polynomial": {
-        "failed": true,
         "ntests": 454
     },
     "sage.rings.polynomial.laurent_polynomial_ideal": {
@@ -4002,36 +3954,34 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 127
+        "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 566
+        "ntests": 563
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 532
+        "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true,
-        "ntests": 895
+        "ntests": 891
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
         "ntests": 25
     },
     "sage.rings.polynomial.multi_polynomial_libsingular": {
-        "failed": true,
         "ntests": 1234
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
-        "failed": true,
         "ntests": 149
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "ntests": 249
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 186
+        "ntests": 185
     },
     "sage.rings.polynomial.omega": {
         "ntests": 126
@@ -4048,7 +3998,6 @@
         "ntests": 1
     },
     "sage.rings.polynomial.padics.polynomial_padic": {
-        "failed": true,
         "ntests": 69
     },
     "sage.rings.polynomial.padics.polynomial_padic_capped_relative_dense": {
@@ -4059,7 +4008,7 @@
     },
     "sage.rings.polynomial.plural": {
         "failed": true,
-        "ntests": 638
+        "ntests": 641
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 402
@@ -4070,7 +4019,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2642
+        "ntests": 2644
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -4088,7 +4037,6 @@
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
-        "failed": true,
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
@@ -4099,7 +4047,6 @@
         "ntests": 513
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "failed": true,
         "ntests": 151
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
@@ -4121,7 +4068,6 @@
         "ntests": 30
     },
     "sage.rings.polynomial.polynomial_singular_interface": {
-        "failed": true,
         "ntests": 63
     },
     "sage.rings.polynomial.polynomial_template.pxi": {
@@ -4131,7 +4077,6 @@
         "ntests": 183
     },
     "sage.rings.polynomial.polynomial_zz_pex": {
-        "failed": true,
         "ntests": 155
     },
     "sage.rings.polynomial.real_roots": {
@@ -4184,7 +4129,7 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1358
+        "ntests": 1370
     },
     "sage.rings.qqbar_decorators": {
         "failed": true,
@@ -4229,7 +4174,7 @@
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 907
+        "ntests": 899
     },
     "sage.rings.real_mpfr": {
         "failed": true,
@@ -4240,23 +4185,18 @@
         "ntests": 192
     },
     "sage.rings.ring_extension": {
-        "failed": true,
         "ntests": 442
     },
     "sage.rings.ring_extension_conversion": {
-        "failed": true,
         "ntests": 75
     },
     "sage.rings.ring_extension_element": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.ring_extension_homset": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.ring_extension_morphism": {
-        "failed": true,
         "ntests": 148
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
@@ -4273,7 +4213,7 @@
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -4329,7 +4269,6 @@
         "ntests": 57
     },
     "sage.schemes.affine.affine_morphism": {
-        "failed": true,
         "ntests": 400
     },
     "sage.schemes.affine.affine_point": {
@@ -4340,7 +4279,6 @@
         "ntests": 38
     },
     "sage.schemes.affine.affine_space": {
-        "failed": true,
         "ntests": 190
     },
     "sage.schemes.affine.affine_subscheme": {
@@ -4354,7 +4292,6 @@
         "ntests": 439
     },
     "sage.schemes.curves.closed_point": {
-        "failed": true,
         "ntests": 100
     },
     "sage.schemes.curves.constructor": {
@@ -4388,15 +4325,12 @@
         "ntests": 67
     },
     "sage.schemes.elliptic_curves.BSD": {
-        "failed": true,
-        "ntests": 76
+        "ntests": 69
     },
     "sage.schemes.elliptic_curves.Qcurves": {
-        "failed": true,
         "ntests": 62
     },
     "sage.schemes.elliptic_curves.cardinality": {
-        "failed": true,
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.cm": {
@@ -4404,27 +4338,24 @@
     },
     "sage.schemes.elliptic_curves.constructor": {
         "failed": true,
-        "ntests": 227
+        "ntests": 210
     },
     "sage.schemes.elliptic_curves.descent_two_isogeny": {
         "failed": true,
         "ntests": 37
     },
     "sage.schemes.elliptic_curves.ec_database": {
-        "failed": true,
         "ntests": 9
     },
     "sage.schemes.elliptic_curves.ell_curve_isogeny": {
-        "failed": true,
         "ntests": 876
     },
     "sage.schemes.elliptic_curves.ell_egros": {
-        "failed": true,
-        "ntests": 29
+        "ntests": 22
     },
     "sage.schemes.elliptic_curves.ell_field": {
         "failed": true,
-        "ntests": 439
+        "ntests": 430
     },
     "sage.schemes.elliptic_curves.ell_finite_field": {
         "failed": true,
@@ -4432,59 +4363,51 @@
     },
     "sage.schemes.elliptic_curves.ell_generic": {
         "failed": true,
-        "ntests": 577
+        "ntests": 559
     },
     "sage.schemes.elliptic_curves.ell_local_data": {
-        "failed": true,
         "ntests": 167
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
         "failed": true,
-        "ntests": 133
+        "ntests": 76
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
-        "ntests": 797
+        "ntests": 817
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
-        "ntests": 974
+        "ntests": 965
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 885
+        "ntests": 786
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
-        "failed": true,
         "ntests": 64
     },
     "sage.schemes.elliptic_curves.ell_torsion": {
-        "failed": true,
         "ntests": 77
     },
     "sage.schemes.elliptic_curves.ell_wp": {
-        "failed": true,
         "ntests": 42
     },
     "sage.schemes.elliptic_curves.formal_group": {
-        "failed": true,
         "ntests": 76
     },
     "sage.schemes.elliptic_curves.gal_reps": {
-        "failed": true,
         "ntests": 170
     },
     "sage.schemes.elliptic_curves.gal_reps_number_field": {
-        "failed": true,
         "ntests": 198
     },
     "sage.schemes.elliptic_curves.gp_simon": {
-        "failed": true,
         "ntests": 13
     },
     "sage.schemes.elliptic_curves.heegner": {
         "failed": true,
-        "ntests": 1110
+        "ntests": 1068
     },
     "sage.schemes.elliptic_curves.height": {
         "failed": true,
@@ -4492,7 +4415,7 @@
     },
     "sage.schemes.elliptic_curves.hom": {
         "failed": true,
-        "ntests": 345
+        "ntests": 344
     },
     "sage.schemes.elliptic_curves.hom_composite": {
         "failed": true,
@@ -4503,7 +4426,6 @@
         "ntests": 111
     },
     "sage.schemes.elliptic_curves.hom_scalar": {
-        "failed": true,
         "ntests": 138
     },
     "sage.schemes.elliptic_curves.hom_sum": {
@@ -4519,8 +4441,7 @@
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.isogeny_class": {
-        "failed": true,
-        "ntests": 153
+        "ntests": 141
     },
     "sage.schemes.elliptic_curves.isogeny_small_degree": {
         "failed": true,
@@ -4533,12 +4454,11 @@
         "ntests": 29
     },
     "sage.schemes.elliptic_curves.kraus": {
-        "failed": true,
-        "ntests": 146
+        "ntests": 138
     },
     "sage.schemes.elliptic_curves.lseries_ell": {
         "failed": true,
-        "ntests": 100
+        "ntests": 59
     },
     "sage.schemes.elliptic_curves.mod5family": {
         "ntests": 2
@@ -4551,7 +4471,6 @@
         "ntests": 359
     },
     "sage.schemes.elliptic_curves.modular_parametrization": {
-        "failed": true,
         "ntests": 51
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
@@ -4565,15 +4484,9 @@
         "ntests": 12
     },
     "sage.schemes.elliptic_curves.saturation": {
-        "failed": true,
-        "ntests": 67
-    },
-    "sage.schemes.elliptic_curves.sha_tate": {
-        "failed": true,
-        "ntests": 130
+        "ntests": 69
     },
     "sage.schemes.elliptic_curves.weierstrass_morphism": {
-        "failed": true,
         "ntests": 244
     },
     "sage.schemes.elliptic_curves.weierstrass_transform": {
@@ -4596,8 +4509,7 @@
         "ntests": 19
     },
     "sage.schemes.generic.homset": {
-        "failed": true,
-        "ntests": 143
+        "ntests": 140
     },
     "sage.schemes.generic.hypersurface": {
         "ntests": 42
@@ -4618,11 +4530,9 @@
         "ntests": 32
     },
     "sage.schemes.hyperelliptic_curves.constructor": {
-        "failed": true,
         "ntests": 42
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_finite_field": {
-        "failed": true,
         "ntests": 373
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_g2": {
@@ -4633,7 +4543,6 @@
         "ntests": 202
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_rational_field": {
-        "failed": true,
         "ntests": 8
     },
     "sage.schemes.hyperelliptic_curves.invariants": {
@@ -4651,7 +4560,6 @@
         "ntests": 40
     },
     "sage.schemes.hyperelliptic_curves.jacobian_morphism": {
-        "failed": true,
         "ntests": 198
     },
     "sage.schemes.hyperelliptic_curves.kummer_surface": {
@@ -4665,7 +4573,6 @@
         "ntests": 632
     },
     "sage.schemes.jacobians.abstract_jacobian": {
-        "failed": true,
         "ntests": 56
     },
     "sage.schemes.overview": {
@@ -4679,8 +4586,7 @@
         "ntests": 28
     },
     "sage.schemes.plane_conics.con_number_field": {
-        "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.schemes.plane_conics.con_rational_field": {
         "failed": true,
@@ -4896,7 +4802,6 @@
         "ntests": 6
     },
     "sage.structure.factory": {
-        "failed": true,
         "ntests": 118
     },
     "sage.structure.formal_sum": {
@@ -4932,7 +4837,6 @@
         "ntests": 362
     },
     "sage.structure.parent_gens": {
-        "failed": true,
         "ntests": 41
     },
     "sage.structure.parent_old": {

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -79,7 +79,7 @@
     },
     "sage.algebras.quatalg.quaternion_algebra": {
         "failed": true,
-        "ntests": 686
+        "ntests": 690
     },
     "sage.algebras.quatalg.quaternion_algebra_cython": {
         "failed": true,
@@ -131,7 +131,7 @@
         "ntests": 77
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.calculus.interpolation": {
         "ntests": 67
@@ -255,7 +255,6 @@
         "ntests": 7
     },
     "sage.categories.commutative_rings": {
-        "failed": true,
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
@@ -271,7 +270,6 @@
         "ntests": 65
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
         "ntests": 368
     },
     "sage.categories.crystals": {
@@ -325,10 +323,6 @@
     },
     "sage.categories.examples.finite_dimensional_algebras_with_basis": {
         "ntests": 17
-    },
-    "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 96
     },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
@@ -386,12 +380,10 @@
         "ntests": 141
     },
     "sage.categories.filtered_algebras": {
-        "failed": true,
         "ntests": 5
     },
     "sage.categories.filtered_algebras_with_basis": {
-        "failed": true,
-        "ntests": 63
+        "ntests": 53
     },
     "sage.categories.filtered_hopf_algebras_with_basis": {
         "ntests": 17
@@ -410,8 +402,7 @@
         "ntests": 6
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "failed": true,
-        "ntests": 128
+        "ntests": 97
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -426,8 +417,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 172
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "ntests": 158
@@ -481,7 +471,6 @@
         "ntests": 11
     },
     "sage.categories.functor": {
-        "failed": true,
         "ntests": 137
     },
     "sage.categories.g_sets": {
@@ -549,7 +538,6 @@
         "ntests": 20
     },
     "sage.categories.homset": {
-        "failed": true,
         "ntests": 222
     },
     "sage.categories.homsets": {
@@ -592,11 +580,9 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
-        "failed": true,
         "ntests": 19
     },
     "sage.categories.lie_conformal_algebras": {
@@ -827,14 +813,12 @@
         "ntests": 47
     },
     "sage.coding.code_constructions": {
-        "failed": true,
         "ntests": 118
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
     },
     "sage.coding.cyclic_code": {
-        "failed": true,
         "ntests": 274
     },
     "sage.coding.databases": {
@@ -869,7 +853,6 @@
         "ntests": 115
     },
     "sage.coding.grs_code": {
-        "failed": true,
         "ntests": 530
     },
     "sage.coding.guava": {
@@ -1200,7 +1183,6 @@
         "ntests": 283
     },
     "sage.crypto.sboxes": {
-        "failed": true,
         "ntests": 27
     },
     "sage.data_structures.bitset": {
@@ -1218,8 +1200,10 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
+    "sage.databases.conway": {
+        "ntests": 42
+    },
     "sage.databases.cremona": {
-        "failed": true,
         "ntests": 155
     },
     "sage.databases.db_modular_polynomials": {
@@ -1238,7 +1222,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 42
+        "ntests": 46
     },
     "sage.doctest.fixtures": {
         "failed": true,
@@ -1266,6 +1250,7 @@
         "ntests": 343
     },
     "sage.doctest.test": {
+        "failed": true,
         "ntests": 23
     },
     "sage.doctest.util": {
@@ -1279,7 +1264,6 @@
         "ntests": 398
     },
     "sage.dynamics.arithmetic_dynamics.endPN_automorphism_group": {
-        "failed": true,
         "ntests": 137
     },
     "sage.dynamics.arithmetic_dynamics.endPN_minimal_model": {
@@ -1287,7 +1271,6 @@
         "ntests": 64
     },
     "sage.dynamics.arithmetic_dynamics.generic_ds": {
-        "failed": true,
         "ntests": 104
     },
     "sage.dynamics.arithmetic_dynamics.product_projective_ds": {
@@ -1345,6 +1328,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
     "sage.features.ecm": {
         "ntests": 4
     },
@@ -1380,6 +1366,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -1454,8 +1443,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "failed": true,
-        "ntests": 188
+        "ntests": 189
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1498,14 +1486,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 160
+        "ntests": 162
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 141
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "failed": true,
@@ -1532,7 +1520,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 244
+        "ntests": 245
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1579,8 +1567,7 @@
         "ntests": 15
     },
     "sage.geometry.cone": {
-        "failed": true,
-        "ntests": 1130
+        "ntests": 1113
     },
     "sage.geometry.cone_catalog": {
         "ntests": 101
@@ -1616,11 +1603,9 @@
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
-        "failed": true,
         "ntests": 24
     },
     "sage.geometry.hyperplane_arrangement.ordered_arrangement": {
-        "failed": true,
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
@@ -1760,7 +1745,7 @@
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
-        "ntests": 6
+        "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
         "failed": true,
@@ -1812,7 +1797,7 @@
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 238
+        "ntests": 240
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 26
@@ -1833,7 +1818,6 @@
         "ntests": 78
     },
     "sage.groups.additive_abelian.additive_abelian_wrapper": {
-        "failed": true,
         "ntests": 125
     },
     "sage.groups.additive_abelian.qmodnz": {
@@ -1855,7 +1839,6 @@
         "ntests": 2
     },
     "sage.groups.generic": {
-        "failed": true,
         "ntests": 236
     },
     "sage.groups.group": {
@@ -1876,7 +1859,7 @@
     },
     "sage.groups.matrix_gps.matrix_group": {
         "failed": true,
-        "ntests": 63
+        "ntests": 64
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -1946,12 +1929,15 @@
     "sage.interfaces.abc": {
         "ntests": 8
     },
+    "sage.interfaces.genus2reduction": {
+        "ntests": 23
+    },
     "sage.interfaces.gp": {
         "failed": true,
         "ntests": 142
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.polymake": {
         "ntests": 188
@@ -1970,10 +1956,22 @@
     },
     "sage.interfaces.singular": {
         "failed": true,
-        "ntests": 412
+        "ntests": 421
     },
     "sage.interfaces.tab_completion": {
         "ntests": 13
+    },
+    "sage.lfunctions.dokchitser": {
+        "failed": true,
+        "ntests": 98
+    },
+    "sage.lfunctions.pari": {
+        "failed": true,
+        "ntests": 182
+    },
+    "sage.lfunctions.zero_sums": {
+        "failed": true,
+        "ntests": 132
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2025,14 +2023,12 @@
         "ntests": 70
     },
     "sage.libs.ntl.ntl_GF2EContext": {
-        "failed": true,
         "ntests": 20
     },
     "sage.libs.ntl.ntl_GF2EX": {
         "ntests": 31
     },
     "sage.libs.ntl.ntl_GF2X": {
-        "failed": true,
         "ntests": 112
     },
     "sage.libs.ntl.ntl_GF2X_linkage.pxi": {
@@ -2134,7 +2130,6 @@
         "ntests": 101
     },
     "sage.libs.singular.singular": {
-        "failed": true,
         "ntests": 171
     },
     "sage.libs.singular.standard_options": {
@@ -2309,6 +2304,14 @@
     "sage.matroids.basis_matroid": {
         "ntests": 150
     },
+    "sage.matroids.chow_ring": {
+        "failed": true,
+        "ntests": 40
+    },
+    "sage.matroids.chow_ring_ideal": {
+        "failed": true,
+        "ntests": 81
+    },
     "sage.matroids.circuit_closures_matroid": {
         "ntests": 86
     },
@@ -2340,7 +2343,8 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "ntests": 948
+        "failed": true,
+        "ntests": 941
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2460,7 +2464,6 @@
         "ntests": 67
     },
     "sage.misc.latex": {
-        "failed": true,
         "ntests": 236
     },
     "sage.misc.latex_macros": {
@@ -2579,7 +2582,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 330
+        "ntests": 326
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2669,7 +2672,6 @@
         "ntests": 45
     },
     "sage.modular.abvar.torsion_subgroup": {
-        "failed": true,
         "ntests": 85
     },
     "sage.modular.arithgroup.arithgroup_element": {
@@ -2703,12 +2705,10 @@
         "ntests": 89
     },
     "sage.modular.btquotients.btquotient": {
-        "failed": true,
-        "ntests": 374
+        "ntests": 6
     },
     "sage.modular.btquotients.pautomorphicform": {
-        "failed": true,
-        "ntests": 388
+        "ntests": 5
     },
     "sage.modular.buzzard": {
         "ntests": 7
@@ -2725,7 +2725,7 @@
     },
     "sage.modular.dirichlet": {
         "failed": true,
-        "ntests": 596
+        "ntests": 593
     },
     "sage.modular.drinfeld_modform.element": {
         "ntests": 114
@@ -2738,8 +2738,7 @@
         "ntests": 12
     },
     "sage.modular.etaproducts": {
-        "failed": true,
-        "ntests": 102
+        "ntests": 87
     },
     "sage.modular.hecke.algebra": {
         "ntests": 91
@@ -2782,7 +2781,7 @@
     },
     "sage.modular.hypergeometric_motive": {
         "failed": true,
-        "ntests": 324
+        "ntests": 320
     },
     "sage.modular.local_comp.liftings": {
         "ntests": 48
@@ -2826,8 +2825,7 @@
         "ntests": 66
     },
     "sage.modular.modform.eis_series": {
-        "failed": true,
-        "ntests": 41
+        "ntests": 42
     },
     "sage.modular.modform.eis_series_cython": {
         "ntests": 6
@@ -2838,7 +2836,7 @@
     },
     "sage.modular.modform.element": {
         "failed": true,
-        "ntests": 624
+        "ntests": 620
     },
     "sage.modular.modform.find_generators": {
         "failed": true,
@@ -2854,11 +2852,9 @@
         "ntests": 3
     },
     "sage.modular.modform.l_series_gross_zagier": {
-        "failed": true,
-        "ntests": 25
+        "ntests": 26
     },
     "sage.modular.modform.l_series_gross_zagier_coeffs": {
-        "failed": true,
         "ntests": 20
     },
     "sage.modular.modform.numerical": {
@@ -2961,6 +2957,7 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
+        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -2975,11 +2972,7 @@
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
-        "ntests": 174
-    },
-    "sage.modular.pollack_stevens.modsym": {
-        "failed": true,
-        "ntests": 243
+        "ntests": 166
     },
     "sage.modular.pollack_stevens.sigma0": {
         "ntests": 101
@@ -2997,7 +2990,6 @@
         "ntests": 165
     },
     "sage.modular.ssmod.ssmod": {
-        "failed": true,
         "ntests": 77
     },
     "sage.modules.complex_double_vector": {
@@ -3063,7 +3055,6 @@
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "failed": true,
         "ntests": 133
     },
     "sage.modules.real_double_vector": {
@@ -3100,7 +3091,7 @@
         "ntests": 45
     },
     "sage.modules.vector_numpy_integer_dense": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.modules.vector_rational_dense": {
         "ntests": 45
@@ -3112,12 +3103,10 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "failed": true,
         "ntests": 168
     },
     "sage.modules.with_basis.indexed_element": {
-        "failed": true,
-        "ntests": 166
+        "ntests": 160
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353
@@ -3136,8 +3125,7 @@
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
-        "failed": true,
-        "ntests": 266
+        "ntests": 258
     },
     "sage.numerical.backends.logging_backend": {
         "ntests": 45
@@ -3430,7 +3418,6 @@
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
-        "failed": true,
         "ntests": 213
     },
     "sage.rings.bernmm": {
@@ -3461,7 +3448,6 @@
         "ntests": 131
     },
     "sage.rings.complex_mpc": {
-        "failed": true,
         "ntests": 406
     },
     "sage.rings.complex_mpfr": {
@@ -3494,15 +3480,12 @@
         "ntests": 57
     },
     "sage.rings.finite_rings.element_base": {
-        "failed": true,
         "ntests": 243
     },
     "sage.rings.finite_rings.element_givaro": {
-        "failed": true,
-        "ntests": 244
+        "ntests": 240
     },
     "sage.rings.finite_rings.element_ntl_gf2e": {
-        "failed": true,
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
@@ -3514,19 +3497,15 @@
         "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.finite_rings.finite_field_givaro": {
-        "failed": true,
-        "ntests": 122
+        "ntests": 112
     },
     "sage.rings.finite_rings.finite_field_ntl_gf2e": {
-        "failed": true,
         "ntests": 61
     },
     "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "failed": true,
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
@@ -3536,7 +3515,6 @@
         "ntests": 20
     },
     "sage.rings.finite_rings.hom_finite_field": {
-        "failed": true,
         "ntests": 201
     },
     "sage.rings.finite_rings.hom_finite_field_givaro": {
@@ -3546,7 +3524,6 @@
         "ntests": 21
     },
     "sage.rings.finite_rings.homset": {
-        "failed": true,
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
@@ -3572,7 +3549,6 @@
         "ntests": 34
     },
     "sage.rings.fraction_field": {
-        "failed": true,
         "ntests": 262
     },
     "sage.rings.fraction_field_FpT": {
@@ -3670,7 +3646,6 @@
         "ntests": 94
     },
     "sage.rings.function_field.place_polymod": {
-        "failed": true,
         "ntests": 92
     },
     "sage.rings.function_field.place_rational": {
@@ -3776,7 +3751,6 @@
         "ntests": 616
     },
     "sage.rings.number_field.number_field_ideal": {
-        "failed": true,
         "ntests": 760
     },
     "sage.rings.number_field.number_field_ideal_rel": {
@@ -3824,26 +3798,21 @@
         "ntests": 180
     },
     "sage.rings.padics.CA_template.pxi": {
-        "failed": true,
         "ntests": 311
     },
     "sage.rings.padics.CR_template.pxi": {
-        "failed": true,
         "ntests": 431
     },
     "sage.rings.padics.FM_template.pxi": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.padics.FP_template.pxi": {
-        "failed": true,
         "ntests": 342
     },
     "sage.rings.padics.eisenstein_extension_generic": {
         "ntests": 41
     },
     "sage.rings.padics.factory": {
-        "failed": true,
         "ntests": 559
     },
     "sage.rings.padics.generic_nodes": {
@@ -3868,11 +3837,9 @@
         "ntests": 223
     },
     "sage.rings.padics.padic_extension_generic": {
-        "failed": true,
         "ntests": 208
     },
     "sage.rings.padics.padic_extension_leaves": {
-        "failed": true,
         "ntests": 72
     },
     "sage.rings.padics.padic_generic_element": {
@@ -3883,7 +3850,6 @@
         "ntests": 269
     },
     "sage.rings.padics.padic_printing": {
-        "failed": true,
         "ntests": 108
     },
     "sage.rings.padics.padic_relaxed_errors": {
@@ -3903,43 +3869,33 @@
         "ntests": 76
     },
     "sage.rings.padics.pow_computer_relative": {
-        "failed": true,
         "ntests": 97
     },
     "sage.rings.padics.qadic_flint_CA": {
-        "failed": true,
         "ntests": 19
     },
     "sage.rings.padics.qadic_flint_CR": {
-        "failed": true,
         "ntests": 23
     },
     "sage.rings.padics.qadic_flint_FM": {
-        "failed": true,
         "ntests": 17
     },
     "sage.rings.padics.qadic_flint_FP": {
-        "failed": true,
         "ntests": 22
     },
     "sage.rings.padics.relative_extension_leaves": {
-        "failed": true,
         "ntests": 87
     },
     "sage.rings.padics.relative_ramified_CA": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_CR": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FM": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FP": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relaxed_template.pxi": {
@@ -3949,11 +3905,9 @@
         "ntests": 12
     },
     "sage.rings.padics.tutorial": {
-        "failed": true,
         "ntests": 45
     },
     "sage.rings.padics.unramified_extension_generic": {
-        "failed": true,
         "ntests": 33
     },
     "sage.rings.pari_ring": {
@@ -3988,7 +3942,6 @@
         "ntests": 279
     },
     "sage.rings.polynomial.laurent_polynomial": {
-        "failed": true,
         "ntests": 454
     },
     "sage.rings.polynomial.laurent_polynomial_ideal": {
@@ -4001,36 +3954,34 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 127
+        "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 566
+        "ntests": 563
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 532
+        "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true,
-        "ntests": 895
+        "ntests": 891
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
         "ntests": 25
     },
     "sage.rings.polynomial.multi_polynomial_libsingular": {
-        "failed": true,
         "ntests": 1234
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
-        "failed": true,
         "ntests": 149
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "ntests": 249
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 186
+        "ntests": 185
     },
     "sage.rings.polynomial.omega": {
         "ntests": 126
@@ -4047,7 +3998,6 @@
         "ntests": 1
     },
     "sage.rings.polynomial.padics.polynomial_padic": {
-        "failed": true,
         "ntests": 69
     },
     "sage.rings.polynomial.padics.polynomial_padic_capped_relative_dense": {
@@ -4058,7 +4008,7 @@
     },
     "sage.rings.polynomial.plural": {
         "failed": true,
-        "ntests": 638
+        "ntests": 641
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 402
@@ -4069,7 +4019,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2642
+        "ntests": 2644
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -4087,7 +4037,6 @@
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
-        "failed": true,
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
@@ -4098,7 +4047,6 @@
         "ntests": 513
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "failed": true,
         "ntests": 151
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
@@ -4120,7 +4068,6 @@
         "ntests": 30
     },
     "sage.rings.polynomial.polynomial_singular_interface": {
-        "failed": true,
         "ntests": 63
     },
     "sage.rings.polynomial.polynomial_template.pxi": {
@@ -4130,7 +4077,6 @@
         "ntests": 183
     },
     "sage.rings.polynomial.polynomial_zz_pex": {
-        "failed": true,
         "ntests": 155
     },
     "sage.rings.polynomial.real_roots": {
@@ -4183,7 +4129,7 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1358
+        "ntests": 1370
     },
     "sage.rings.qqbar_decorators": {
         "failed": true,
@@ -4228,7 +4174,7 @@
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 907
+        "ntests": 899
     },
     "sage.rings.real_mpfr": {
         "failed": true,
@@ -4239,23 +4185,18 @@
         "ntests": 192
     },
     "sage.rings.ring_extension": {
-        "failed": true,
         "ntests": 442
     },
     "sage.rings.ring_extension_conversion": {
-        "failed": true,
         "ntests": 75
     },
     "sage.rings.ring_extension_element": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.ring_extension_homset": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.ring_extension_morphism": {
-        "failed": true,
         "ntests": 148
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
@@ -4272,7 +4213,7 @@
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -4328,7 +4269,6 @@
         "ntests": 57
     },
     "sage.schemes.affine.affine_morphism": {
-        "failed": true,
         "ntests": 400
     },
     "sage.schemes.affine.affine_point": {
@@ -4339,7 +4279,6 @@
         "ntests": 38
     },
     "sage.schemes.affine.affine_space": {
-        "failed": true,
         "ntests": 190
     },
     "sage.schemes.affine.affine_subscheme": {
@@ -4353,7 +4292,6 @@
         "ntests": 439
     },
     "sage.schemes.curves.closed_point": {
-        "failed": true,
         "ntests": 100
     },
     "sage.schemes.curves.constructor": {
@@ -4387,15 +4325,12 @@
         "ntests": 67
     },
     "sage.schemes.elliptic_curves.BSD": {
-        "failed": true,
-        "ntests": 76
+        "ntests": 69
     },
     "sage.schemes.elliptic_curves.Qcurves": {
-        "failed": true,
         "ntests": 62
     },
     "sage.schemes.elliptic_curves.cardinality": {
-        "failed": true,
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.cm": {
@@ -4403,27 +4338,24 @@
     },
     "sage.schemes.elliptic_curves.constructor": {
         "failed": true,
-        "ntests": 227
+        "ntests": 210
     },
     "sage.schemes.elliptic_curves.descent_two_isogeny": {
         "failed": true,
         "ntests": 37
     },
     "sage.schemes.elliptic_curves.ec_database": {
-        "failed": true,
         "ntests": 9
     },
     "sage.schemes.elliptic_curves.ell_curve_isogeny": {
-        "failed": true,
         "ntests": 876
     },
     "sage.schemes.elliptic_curves.ell_egros": {
-        "failed": true,
-        "ntests": 29
+        "ntests": 22
     },
     "sage.schemes.elliptic_curves.ell_field": {
         "failed": true,
-        "ntests": 439
+        "ntests": 430
     },
     "sage.schemes.elliptic_curves.ell_finite_field": {
         "failed": true,
@@ -4431,59 +4363,51 @@
     },
     "sage.schemes.elliptic_curves.ell_generic": {
         "failed": true,
-        "ntests": 577
+        "ntests": 559
     },
     "sage.schemes.elliptic_curves.ell_local_data": {
-        "failed": true,
         "ntests": 167
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
         "failed": true,
-        "ntests": 133
+        "ntests": 76
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
-        "ntests": 797
+        "ntests": 817
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
-        "ntests": 974
+        "ntests": 965
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 885
+        "ntests": 786
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
-        "failed": true,
         "ntests": 64
     },
     "sage.schemes.elliptic_curves.ell_torsion": {
-        "failed": true,
         "ntests": 77
     },
     "sage.schemes.elliptic_curves.ell_wp": {
-        "failed": true,
         "ntests": 42
     },
     "sage.schemes.elliptic_curves.formal_group": {
-        "failed": true,
         "ntests": 76
     },
     "sage.schemes.elliptic_curves.gal_reps": {
-        "failed": true,
         "ntests": 170
     },
     "sage.schemes.elliptic_curves.gal_reps_number_field": {
-        "failed": true,
         "ntests": 198
     },
     "sage.schemes.elliptic_curves.gp_simon": {
-        "failed": true,
         "ntests": 13
     },
     "sage.schemes.elliptic_curves.heegner": {
         "failed": true,
-        "ntests": 1110
+        "ntests": 1068
     },
     "sage.schemes.elliptic_curves.height": {
         "failed": true,
@@ -4491,7 +4415,7 @@
     },
     "sage.schemes.elliptic_curves.hom": {
         "failed": true,
-        "ntests": 345
+        "ntests": 344
     },
     "sage.schemes.elliptic_curves.hom_composite": {
         "failed": true,
@@ -4502,7 +4426,6 @@
         "ntests": 111
     },
     "sage.schemes.elliptic_curves.hom_scalar": {
-        "failed": true,
         "ntests": 138
     },
     "sage.schemes.elliptic_curves.hom_sum": {
@@ -4518,8 +4441,7 @@
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.isogeny_class": {
-        "failed": true,
-        "ntests": 153
+        "ntests": 141
     },
     "sage.schemes.elliptic_curves.isogeny_small_degree": {
         "failed": true,
@@ -4532,12 +4454,11 @@
         "ntests": 29
     },
     "sage.schemes.elliptic_curves.kraus": {
-        "failed": true,
-        "ntests": 146
+        "ntests": 138
     },
     "sage.schemes.elliptic_curves.lseries_ell": {
         "failed": true,
-        "ntests": 100
+        "ntests": 59
     },
     "sage.schemes.elliptic_curves.mod5family": {
         "ntests": 2
@@ -4550,7 +4471,6 @@
         "ntests": 359
     },
     "sage.schemes.elliptic_curves.modular_parametrization": {
-        "failed": true,
         "ntests": 51
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
@@ -4564,15 +4484,9 @@
         "ntests": 12
     },
     "sage.schemes.elliptic_curves.saturation": {
-        "failed": true,
-        "ntests": 67
-    },
-    "sage.schemes.elliptic_curves.sha_tate": {
-        "failed": true,
-        "ntests": 130
+        "ntests": 69
     },
     "sage.schemes.elliptic_curves.weierstrass_morphism": {
-        "failed": true,
         "ntests": 244
     },
     "sage.schemes.elliptic_curves.weierstrass_transform": {
@@ -4595,8 +4509,7 @@
         "ntests": 19
     },
     "sage.schemes.generic.homset": {
-        "failed": true,
-        "ntests": 143
+        "ntests": 140
     },
     "sage.schemes.generic.hypersurface": {
         "ntests": 42
@@ -4617,11 +4530,9 @@
         "ntests": 32
     },
     "sage.schemes.hyperelliptic_curves.constructor": {
-        "failed": true,
         "ntests": 42
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_finite_field": {
-        "failed": true,
         "ntests": 373
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_g2": {
@@ -4632,7 +4543,6 @@
         "ntests": 202
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_rational_field": {
-        "failed": true,
         "ntests": 8
     },
     "sage.schemes.hyperelliptic_curves.invariants": {
@@ -4650,7 +4560,6 @@
         "ntests": 40
     },
     "sage.schemes.hyperelliptic_curves.jacobian_morphism": {
-        "failed": true,
         "ntests": 198
     },
     "sage.schemes.hyperelliptic_curves.kummer_surface": {
@@ -4664,7 +4573,6 @@
         "ntests": 632
     },
     "sage.schemes.jacobians.abstract_jacobian": {
-        "failed": true,
         "ntests": 56
     },
     "sage.schemes.overview": {
@@ -4678,8 +4586,7 @@
         "ntests": 28
     },
     "sage.schemes.plane_conics.con_number_field": {
-        "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.schemes.plane_conics.con_rational_field": {
         "failed": true,
@@ -4895,7 +4802,6 @@
         "ntests": 6
     },
     "sage.structure.factory": {
-        "failed": true,
         "ntests": 118
     },
     "sage.structure.formal_sum": {
@@ -4931,7 +4837,6 @@
         "ntests": 362
     },
     "sage.structure.parent_gens": {
-        "failed": true,
         "ntests": 41
     },
     "sage.structure.parent_old": {

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -79,7 +79,7 @@
     },
     "sage.algebras.quatalg.quaternion_algebra": {
         "failed": true,
-        "ntests": 686
+        "ntests": 690
     },
     "sage.algebras.quatalg.quaternion_algebra_cython": {
         "failed": true,
@@ -131,7 +131,7 @@
         "ntests": 77
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.calculus.interpolation": {
         "ntests": 67
@@ -255,7 +255,6 @@
         "ntests": 7
     },
     "sage.categories.commutative_rings": {
-        "failed": true,
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
@@ -271,7 +270,6 @@
         "ntests": 65
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
         "ntests": 368
     },
     "sage.categories.crystals": {
@@ -325,10 +323,6 @@
     },
     "sage.categories.examples.finite_dimensional_algebras_with_basis": {
         "ntests": 17
-    },
-    "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 96
     },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
@@ -386,12 +380,10 @@
         "ntests": 141
     },
     "sage.categories.filtered_algebras": {
-        "failed": true,
         "ntests": 5
     },
     "sage.categories.filtered_algebras_with_basis": {
-        "failed": true,
-        "ntests": 63
+        "ntests": 53
     },
     "sage.categories.filtered_hopf_algebras_with_basis": {
         "ntests": 17
@@ -410,8 +402,7 @@
         "ntests": 6
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "failed": true,
-        "ntests": 128
+        "ntests": 97
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -426,8 +417,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 172
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "ntests": 158
@@ -481,7 +471,6 @@
         "ntests": 11
     },
     "sage.categories.functor": {
-        "failed": true,
         "ntests": 137
     },
     "sage.categories.g_sets": {
@@ -549,7 +538,6 @@
         "ntests": 20
     },
     "sage.categories.homset": {
-        "failed": true,
         "ntests": 222
     },
     "sage.categories.homsets": {
@@ -592,11 +580,9 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
-        "failed": true,
         "ntests": 19
     },
     "sage.categories.lie_conformal_algebras": {
@@ -827,14 +813,12 @@
         "ntests": 47
     },
     "sage.coding.code_constructions": {
-        "failed": true,
         "ntests": 118
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
     },
     "sage.coding.cyclic_code": {
-        "failed": true,
         "ntests": 274
     },
     "sage.coding.databases": {
@@ -869,7 +853,6 @@
         "ntests": 115
     },
     "sage.coding.grs_code": {
-        "failed": true,
         "ntests": 530
     },
     "sage.coding.guava": {
@@ -1200,7 +1183,6 @@
         "ntests": 283
     },
     "sage.crypto.sboxes": {
-        "failed": true,
         "ntests": 27
     },
     "sage.data_structures.bitset": {
@@ -1218,8 +1200,10 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
+    "sage.databases.conway": {
+        "ntests": 42
+    },
     "sage.databases.cremona": {
-        "failed": true,
         "ntests": 155
     },
     "sage.databases.db_modular_polynomials": {
@@ -1238,7 +1222,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 43
+        "ntests": 46
     },
     "sage.doctest.fixtures": {
         "failed": true,
@@ -1266,6 +1250,7 @@
         "ntests": 343
     },
     "sage.doctest.test": {
+        "failed": true,
         "ntests": 23
     },
     "sage.doctest.util": {
@@ -1279,7 +1264,6 @@
         "ntests": 398
     },
     "sage.dynamics.arithmetic_dynamics.endPN_automorphism_group": {
-        "failed": true,
         "ntests": 137
     },
     "sage.dynamics.arithmetic_dynamics.endPN_minimal_model": {
@@ -1287,7 +1271,6 @@
         "ntests": 64
     },
     "sage.dynamics.arithmetic_dynamics.generic_ds": {
-        "failed": true,
         "ntests": 104
     },
     "sage.dynamics.arithmetic_dynamics.product_projective_ds": {
@@ -1345,6 +1328,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
     "sage.features.ecm": {
         "ntests": 4
     },
@@ -1381,6 +1367,9 @@
     "sage.features.imagemagick": {
         "ntests": 10
     },
+    "sage.features.info": {
+        "ntests": 4
+    },
     "sage.features.interfaces": {
         "ntests": 34
     },
@@ -1406,7 +1395,7 @@
         "ntests": 16
     },
     "sage.features.macaulay2": {
-        "ntests": 4
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1454,8 +1443,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "failed": true,
-        "ntests": 188
+        "ntests": 189
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1498,14 +1486,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 160
+        "ntests": 162
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 141
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "failed": true,
@@ -1532,7 +1520,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 244
+        "ntests": 245
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1579,8 +1567,7 @@
         "ntests": 15
     },
     "sage.geometry.cone": {
-        "failed": true,
-        "ntests": 1130
+        "ntests": 1113
     },
     "sage.geometry.cone_catalog": {
         "ntests": 101
@@ -1616,11 +1603,9 @@
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
-        "failed": true,
         "ntests": 24
     },
     "sage.geometry.hyperplane_arrangement.ordered_arrangement": {
-        "failed": true,
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
@@ -1760,7 +1745,7 @@
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
-        "ntests": 6
+        "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
         "failed": true,
@@ -1812,7 +1797,7 @@
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 238
+        "ntests": 240
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 26
@@ -1833,7 +1818,6 @@
         "ntests": 78
     },
     "sage.groups.additive_abelian.additive_abelian_wrapper": {
-        "failed": true,
         "ntests": 125
     },
     "sage.groups.additive_abelian.qmodnz": {
@@ -1855,7 +1839,6 @@
         "ntests": 2
     },
     "sage.groups.generic": {
-        "failed": true,
         "ntests": 236
     },
     "sage.groups.group": {
@@ -1876,7 +1859,7 @@
     },
     "sage.groups.matrix_gps.matrix_group": {
         "failed": true,
-        "ntests": 63
+        "ntests": 64
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -1946,12 +1929,15 @@
     "sage.interfaces.abc": {
         "ntests": 8
     },
+    "sage.interfaces.genus2reduction": {
+        "ntests": 23
+    },
     "sage.interfaces.gp": {
         "failed": true,
         "ntests": 142
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.polymake": {
         "ntests": 188
@@ -1970,10 +1956,22 @@
     },
     "sage.interfaces.singular": {
         "failed": true,
-        "ntests": 412
+        "ntests": 421
     },
     "sage.interfaces.tab_completion": {
         "ntests": 13
+    },
+    "sage.lfunctions.dokchitser": {
+        "failed": true,
+        "ntests": 98
+    },
+    "sage.lfunctions.pari": {
+        "failed": true,
+        "ntests": 182
+    },
+    "sage.lfunctions.zero_sums": {
+        "failed": true,
+        "ntests": 132
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2025,14 +2023,12 @@
         "ntests": 70
     },
     "sage.libs.ntl.ntl_GF2EContext": {
-        "failed": true,
         "ntests": 20
     },
     "sage.libs.ntl.ntl_GF2EX": {
         "ntests": 31
     },
     "sage.libs.ntl.ntl_GF2X": {
-        "failed": true,
         "ntests": 112
     },
     "sage.libs.ntl.ntl_GF2X_linkage.pxi": {
@@ -2134,7 +2130,6 @@
         "ntests": 101
     },
     "sage.libs.singular.singular": {
-        "failed": true,
         "ntests": 171
     },
     "sage.libs.singular.standard_options": {
@@ -2172,7 +2167,7 @@
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 447
+        "ntests": 441
     },
     "sage.matrix.matrix2": {
         "failed": true,
@@ -2309,6 +2304,14 @@
     "sage.matroids.basis_matroid": {
         "ntests": 150
     },
+    "sage.matroids.chow_ring": {
+        "failed": true,
+        "ntests": 40
+    },
+    "sage.matroids.chow_ring_ideal": {
+        "failed": true,
+        "ntests": 81
+    },
     "sage.matroids.circuit_closures_matroid": {
         "ntests": 86
     },
@@ -2340,7 +2343,8 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "ntests": 948
+        "failed": true,
+        "ntests": 941
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2460,7 +2464,6 @@
         "ntests": 67
     },
     "sage.misc.latex": {
-        "failed": true,
         "ntests": 236
     },
     "sage.misc.latex_macros": {
@@ -2579,7 +2582,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 330
+        "ntests": 326
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2669,7 +2672,6 @@
         "ntests": 45
     },
     "sage.modular.abvar.torsion_subgroup": {
-        "failed": true,
         "ntests": 85
     },
     "sage.modular.arithgroup.arithgroup_element": {
@@ -2703,12 +2705,10 @@
         "ntests": 89
     },
     "sage.modular.btquotients.btquotient": {
-        "failed": true,
-        "ntests": 374
+        "ntests": 6
     },
     "sage.modular.btquotients.pautomorphicform": {
-        "failed": true,
-        "ntests": 388
+        "ntests": 5
     },
     "sage.modular.buzzard": {
         "ntests": 7
@@ -2725,7 +2725,7 @@
     },
     "sage.modular.dirichlet": {
         "failed": true,
-        "ntests": 596
+        "ntests": 593
     },
     "sage.modular.drinfeld_modform.element": {
         "ntests": 114
@@ -2738,8 +2738,7 @@
         "ntests": 12
     },
     "sage.modular.etaproducts": {
-        "failed": true,
-        "ntests": 102
+        "ntests": 87
     },
     "sage.modular.hecke.algebra": {
         "ntests": 91
@@ -2782,7 +2781,7 @@
     },
     "sage.modular.hypergeometric_motive": {
         "failed": true,
-        "ntests": 324
+        "ntests": 320
     },
     "sage.modular.local_comp.liftings": {
         "ntests": 48
@@ -2826,8 +2825,7 @@
         "ntests": 66
     },
     "sage.modular.modform.eis_series": {
-        "failed": true,
-        "ntests": 41
+        "ntests": 42
     },
     "sage.modular.modform.eis_series_cython": {
         "ntests": 6
@@ -2838,7 +2836,7 @@
     },
     "sage.modular.modform.element": {
         "failed": true,
-        "ntests": 624
+        "ntests": 620
     },
     "sage.modular.modform.find_generators": {
         "failed": true,
@@ -2854,11 +2852,9 @@
         "ntests": 3
     },
     "sage.modular.modform.l_series_gross_zagier": {
-        "failed": true,
-        "ntests": 25
+        "ntests": 26
     },
     "sage.modular.modform.l_series_gross_zagier_coeffs": {
-        "failed": true,
         "ntests": 20
     },
     "sage.modular.modform.numerical": {
@@ -2961,6 +2957,7 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
+        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -2975,11 +2972,7 @@
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
-        "ntests": 174
-    },
-    "sage.modular.pollack_stevens.modsym": {
-        "failed": true,
-        "ntests": 243
+        "ntests": 166
     },
     "sage.modular.pollack_stevens.sigma0": {
         "ntests": 101
@@ -2997,7 +2990,6 @@
         "ntests": 165
     },
     "sage.modular.ssmod.ssmod": {
-        "failed": true,
         "ntests": 77
     },
     "sage.modules.complex_double_vector": {
@@ -3025,11 +3017,11 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1485
+        "ntests": 1484
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 979
+        "ntests": 974
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
@@ -3063,7 +3055,6 @@
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "failed": true,
         "ntests": 133
     },
     "sage.modules.real_double_vector": {
@@ -3100,7 +3091,7 @@
         "ntests": 45
     },
     "sage.modules.vector_numpy_integer_dense": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.modules.vector_rational_dense": {
         "ntests": 45
@@ -3112,12 +3103,10 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "failed": true,
         "ntests": 168
     },
     "sage.modules.with_basis.indexed_element": {
-        "failed": true,
-        "ntests": 166
+        "ntests": 160
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353
@@ -3136,8 +3125,7 @@
         "ntests": 22
     },
     "sage.numerical.backends.interactivelp_backend": {
-        "failed": true,
-        "ntests": 266
+        "ntests": 258
     },
     "sage.numerical.backends.logging_backend": {
         "ntests": 45
@@ -3342,7 +3330,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 116
+        "ntests": 113
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3430,7 +3418,6 @@
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
-        "failed": true,
         "ntests": 213
     },
     "sage.rings.bernmm": {
@@ -3461,7 +3448,6 @@
         "ntests": 131
     },
     "sage.rings.complex_mpc": {
-        "failed": true,
         "ntests": 406
     },
     "sage.rings.complex_mpfr": {
@@ -3494,15 +3480,12 @@
         "ntests": 57
     },
     "sage.rings.finite_rings.element_base": {
-        "failed": true,
         "ntests": 243
     },
     "sage.rings.finite_rings.element_givaro": {
-        "failed": true,
-        "ntests": 244
+        "ntests": 240
     },
     "sage.rings.finite_rings.element_ntl_gf2e": {
-        "failed": true,
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
@@ -3511,22 +3494,18 @@
     },
     "sage.rings.finite_rings.finite_field_base": {
         "failed": true,
-        "ntests": 345
+        "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.finite_rings.finite_field_givaro": {
-        "failed": true,
-        "ntests": 122
+        "ntests": 112
     },
     "sage.rings.finite_rings.finite_field_ntl_gf2e": {
-        "failed": true,
         "ntests": 61
     },
     "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "failed": true,
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
@@ -3536,7 +3515,6 @@
         "ntests": 20
     },
     "sage.rings.finite_rings.hom_finite_field": {
-        "failed": true,
         "ntests": 201
     },
     "sage.rings.finite_rings.hom_finite_field_givaro": {
@@ -3546,15 +3524,13 @@
         "ntests": 21
     },
     "sage.rings.finite_rings.homset": {
-        "failed": true,
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
         "ntests": 583
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "failed": true,
-        "ntests": 369
+        "ntests": 367
     },
     "sage.rings.finite_rings.maps_finite_field": {
         "ntests": 31
@@ -3573,7 +3549,6 @@
         "ntests": 34
     },
     "sage.rings.fraction_field": {
-        "failed": true,
         "ntests": 262
     },
     "sage.rings.fraction_field_FpT": {
@@ -3671,7 +3646,6 @@
         "ntests": 94
     },
     "sage.rings.function_field.place_polymod": {
-        "failed": true,
         "ntests": 92
     },
     "sage.rings.function_field.place_rational": {
@@ -3690,8 +3664,7 @@
         "ntests": 55
     },
     "sage.rings.ideal": {
-        "failed": true,
-        "ntests": 370
+        "ntests": 361
     },
     "sage.rings.ideal_monoid": {
         "ntests": 48
@@ -3707,8 +3680,7 @@
         "ntests": 1
     },
     "sage.rings.integer_ring": {
-        "failed": true,
-        "ntests": 230
+        "ntests": 229
     },
     "sage.rings.invariants.invariant_theory": {
         "ntests": 883
@@ -3779,7 +3751,6 @@
         "ntests": 616
     },
     "sage.rings.number_field.number_field_ideal": {
-        "failed": true,
         "ntests": 760
     },
     "sage.rings.number_field.number_field_ideal_rel": {
@@ -3827,26 +3798,21 @@
         "ntests": 180
     },
     "sage.rings.padics.CA_template.pxi": {
-        "failed": true,
         "ntests": 311
     },
     "sage.rings.padics.CR_template.pxi": {
-        "failed": true,
         "ntests": 431
     },
     "sage.rings.padics.FM_template.pxi": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.padics.FP_template.pxi": {
-        "failed": true,
         "ntests": 342
     },
     "sage.rings.padics.eisenstein_extension_generic": {
         "ntests": 41
     },
     "sage.rings.padics.factory": {
-        "failed": true,
         "ntests": 559
     },
     "sage.rings.padics.generic_nodes": {
@@ -3871,11 +3837,9 @@
         "ntests": 223
     },
     "sage.rings.padics.padic_extension_generic": {
-        "failed": true,
         "ntests": 208
     },
     "sage.rings.padics.padic_extension_leaves": {
-        "failed": true,
         "ntests": 72
     },
     "sage.rings.padics.padic_generic_element": {
@@ -3886,7 +3850,6 @@
         "ntests": 269
     },
     "sage.rings.padics.padic_printing": {
-        "failed": true,
         "ntests": 108
     },
     "sage.rings.padics.padic_relaxed_errors": {
@@ -3906,43 +3869,33 @@
         "ntests": 76
     },
     "sage.rings.padics.pow_computer_relative": {
-        "failed": true,
         "ntests": 97
     },
     "sage.rings.padics.qadic_flint_CA": {
-        "failed": true,
         "ntests": 19
     },
     "sage.rings.padics.qadic_flint_CR": {
-        "failed": true,
         "ntests": 23
     },
     "sage.rings.padics.qadic_flint_FM": {
-        "failed": true,
         "ntests": 17
     },
     "sage.rings.padics.qadic_flint_FP": {
-        "failed": true,
         "ntests": 22
     },
     "sage.rings.padics.relative_extension_leaves": {
-        "failed": true,
         "ntests": 87
     },
     "sage.rings.padics.relative_ramified_CA": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_CR": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FM": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FP": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relaxed_template.pxi": {
@@ -3952,11 +3905,9 @@
         "ntests": 12
     },
     "sage.rings.padics.tutorial": {
-        "failed": true,
         "ntests": 45
     },
     "sage.rings.padics.unramified_extension_generic": {
-        "failed": true,
         "ntests": 33
     },
     "sage.rings.pari_ring": {
@@ -3991,7 +3942,6 @@
         "ntests": 279
     },
     "sage.rings.polynomial.laurent_polynomial": {
-        "failed": true,
         "ntests": 454
     },
     "sage.rings.polynomial.laurent_polynomial_ideal": {
@@ -4004,11 +3954,11 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 127
+        "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 566
+        "ntests": 563
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
@@ -4016,24 +3966,22 @@
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true,
-        "ntests": 913
+        "ntests": 891
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
         "ntests": 25
     },
     "sage.rings.polynomial.multi_polynomial_libsingular": {
-        "failed": true,
-        "ntests": 1246
+        "ntests": 1234
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
-        "failed": true,
-        "ntests": 155
+        "ntests": 149
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "ntests": 249
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 186
+        "ntests": 185
     },
     "sage.rings.polynomial.omega": {
         "ntests": 126
@@ -4050,7 +3998,6 @@
         "ntests": 1
     },
     "sage.rings.polynomial.padics.polynomial_padic": {
-        "failed": true,
         "ntests": 69
     },
     "sage.rings.polynomial.padics.polynomial_padic_capped_relative_dense": {
@@ -4061,7 +4008,7 @@
     },
     "sage.rings.polynomial.plural": {
         "failed": true,
-        "ntests": 638
+        "ntests": 641
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 402
@@ -4072,7 +4019,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2642
+        "ntests": 2644
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -4090,7 +4037,6 @@
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
-        "failed": true,
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
@@ -4101,7 +4047,6 @@
         "ntests": 513
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "failed": true,
         "ntests": 151
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
@@ -4113,7 +4058,7 @@
     },
     "sage.rings.polynomial.polynomial_ring": {
         "failed": true,
-        "ntests": 536
+        "ntests": 534
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -4123,7 +4068,6 @@
         "ntests": 30
     },
     "sage.rings.polynomial.polynomial_singular_interface": {
-        "failed": true,
         "ntests": 63
     },
     "sage.rings.polynomial.polynomial_template.pxi": {
@@ -4133,7 +4077,6 @@
         "ntests": 183
     },
     "sage.rings.polynomial.polynomial_zz_pex": {
-        "failed": true,
         "ntests": 155
     },
     "sage.rings.polynomial.real_roots": {
@@ -4146,8 +4089,7 @@
         "ntests": 97
     },
     "sage.rings.polynomial.term_order": {
-        "failed": true,
-        "ntests": 361
+        "ntests": 360
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 51
@@ -4187,19 +4129,18 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1358
+        "ntests": 1370
     },
     "sage.rings.qqbar_decorators": {
         "failed": true,
         "ntests": 17
     },
     "sage.rings.quotient_ring": {
-        "failed": true,
-        "ntests": 261
+        "ntests": 257
     },
     "sage.rings.quotient_ring_element": {
         "failed": true,
-        "ntests": 200
+        "ntests": 191
     },
     "sage.rings.rational": {
         "failed": true,
@@ -4207,7 +4148,7 @@
     },
     "sage.rings.rational_field": {
         "failed": true,
-        "ntests": 213
+        "ntests": 212
     },
     "sage.rings.real_arb": {
         "failed": true,
@@ -4233,7 +4174,7 @@
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 907
+        "ntests": 899
     },
     "sage.rings.real_mpfr": {
         "failed": true,
@@ -4244,23 +4185,18 @@
         "ntests": 192
     },
     "sage.rings.ring_extension": {
-        "failed": true,
         "ntests": 442
     },
     "sage.rings.ring_extension_conversion": {
-        "failed": true,
         "ntests": 75
     },
     "sage.rings.ring_extension_element": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.ring_extension_homset": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.ring_extension_morphism": {
-        "failed": true,
         "ntests": 148
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
@@ -4277,7 +4213,7 @@
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -4333,7 +4269,6 @@
         "ntests": 57
     },
     "sage.schemes.affine.affine_morphism": {
-        "failed": true,
         "ntests": 400
     },
     "sage.schemes.affine.affine_point": {
@@ -4344,7 +4279,6 @@
         "ntests": 38
     },
     "sage.schemes.affine.affine_space": {
-        "failed": true,
         "ntests": 190
     },
     "sage.schemes.affine.affine_subscheme": {
@@ -4358,7 +4292,6 @@
         "ntests": 439
     },
     "sage.schemes.curves.closed_point": {
-        "failed": true,
         "ntests": 100
     },
     "sage.schemes.curves.constructor": {
@@ -4392,15 +4325,12 @@
         "ntests": 67
     },
     "sage.schemes.elliptic_curves.BSD": {
-        "failed": true,
-        "ntests": 76
+        "ntests": 69
     },
     "sage.schemes.elliptic_curves.Qcurves": {
-        "failed": true,
         "ntests": 62
     },
     "sage.schemes.elliptic_curves.cardinality": {
-        "failed": true,
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.cm": {
@@ -4408,27 +4338,24 @@
     },
     "sage.schemes.elliptic_curves.constructor": {
         "failed": true,
-        "ntests": 227
+        "ntests": 210
     },
     "sage.schemes.elliptic_curves.descent_two_isogeny": {
         "failed": true,
         "ntests": 37
     },
     "sage.schemes.elliptic_curves.ec_database": {
-        "failed": true,
         "ntests": 9
     },
     "sage.schemes.elliptic_curves.ell_curve_isogeny": {
-        "failed": true,
         "ntests": 876
     },
     "sage.schemes.elliptic_curves.ell_egros": {
-        "failed": true,
-        "ntests": 29
+        "ntests": 22
     },
     "sage.schemes.elliptic_curves.ell_field": {
         "failed": true,
-        "ntests": 439
+        "ntests": 430
     },
     "sage.schemes.elliptic_curves.ell_finite_field": {
         "failed": true,
@@ -4436,59 +4363,51 @@
     },
     "sage.schemes.elliptic_curves.ell_generic": {
         "failed": true,
-        "ntests": 577
+        "ntests": 559
     },
     "sage.schemes.elliptic_curves.ell_local_data": {
-        "failed": true,
         "ntests": 167
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
         "failed": true,
-        "ntests": 133
+        "ntests": 76
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
-        "ntests": 797
+        "ntests": 817
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
-        "ntests": 974
+        "ntests": 965
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 885
+        "ntests": 786
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
-        "failed": true,
         "ntests": 64
     },
     "sage.schemes.elliptic_curves.ell_torsion": {
-        "failed": true,
         "ntests": 77
     },
     "sage.schemes.elliptic_curves.ell_wp": {
-        "failed": true,
         "ntests": 42
     },
     "sage.schemes.elliptic_curves.formal_group": {
-        "failed": true,
         "ntests": 76
     },
     "sage.schemes.elliptic_curves.gal_reps": {
-        "failed": true,
         "ntests": 170
     },
     "sage.schemes.elliptic_curves.gal_reps_number_field": {
-        "failed": true,
         "ntests": 198
     },
     "sage.schemes.elliptic_curves.gp_simon": {
-        "failed": true,
         "ntests": 13
     },
     "sage.schemes.elliptic_curves.heegner": {
         "failed": true,
-        "ntests": 1110
+        "ntests": 1068
     },
     "sage.schemes.elliptic_curves.height": {
         "failed": true,
@@ -4496,7 +4415,7 @@
     },
     "sage.schemes.elliptic_curves.hom": {
         "failed": true,
-        "ntests": 345
+        "ntests": 344
     },
     "sage.schemes.elliptic_curves.hom_composite": {
         "failed": true,
@@ -4507,7 +4426,6 @@
         "ntests": 111
     },
     "sage.schemes.elliptic_curves.hom_scalar": {
-        "failed": true,
         "ntests": 138
     },
     "sage.schemes.elliptic_curves.hom_sum": {
@@ -4523,8 +4441,7 @@
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.isogeny_class": {
-        "failed": true,
-        "ntests": 153
+        "ntests": 141
     },
     "sage.schemes.elliptic_curves.isogeny_small_degree": {
         "failed": true,
@@ -4537,12 +4454,11 @@
         "ntests": 29
     },
     "sage.schemes.elliptic_curves.kraus": {
-        "failed": true,
-        "ntests": 146
+        "ntests": 138
     },
     "sage.schemes.elliptic_curves.lseries_ell": {
         "failed": true,
-        "ntests": 100
+        "ntests": 59
     },
     "sage.schemes.elliptic_curves.mod5family": {
         "ntests": 2
@@ -4555,7 +4471,6 @@
         "ntests": 359
     },
     "sage.schemes.elliptic_curves.modular_parametrization": {
-        "failed": true,
         "ntests": 51
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
@@ -4569,15 +4484,9 @@
         "ntests": 12
     },
     "sage.schemes.elliptic_curves.saturation": {
-        "failed": true,
-        "ntests": 67
-    },
-    "sage.schemes.elliptic_curves.sha_tate": {
-        "failed": true,
-        "ntests": 130
+        "ntests": 69
     },
     "sage.schemes.elliptic_curves.weierstrass_morphism": {
-        "failed": true,
         "ntests": 244
     },
     "sage.schemes.elliptic_curves.weierstrass_transform": {
@@ -4600,8 +4509,7 @@
         "ntests": 19
     },
     "sage.schemes.generic.homset": {
-        "failed": true,
-        "ntests": 143
+        "ntests": 140
     },
     "sage.schemes.generic.hypersurface": {
         "ntests": 42
@@ -4622,11 +4530,9 @@
         "ntests": 32
     },
     "sage.schemes.hyperelliptic_curves.constructor": {
-        "failed": true,
         "ntests": 42
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_finite_field": {
-        "failed": true,
         "ntests": 373
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_g2": {
@@ -4637,7 +4543,6 @@
         "ntests": 202
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_rational_field": {
-        "failed": true,
         "ntests": 8
     },
     "sage.schemes.hyperelliptic_curves.invariants": {
@@ -4655,7 +4560,6 @@
         "ntests": 40
     },
     "sage.schemes.hyperelliptic_curves.jacobian_morphism": {
-        "failed": true,
         "ntests": 198
     },
     "sage.schemes.hyperelliptic_curves.kummer_surface": {
@@ -4669,7 +4573,6 @@
         "ntests": 632
     },
     "sage.schemes.jacobians.abstract_jacobian": {
-        "failed": true,
         "ntests": 56
     },
     "sage.schemes.overview": {
@@ -4683,8 +4586,7 @@
         "ntests": 28
     },
     "sage.schemes.plane_conics.con_number_field": {
-        "failed": true,
-        "ntests": 61
+        "ntests": 62
     },
     "sage.schemes.plane_conics.con_rational_field": {
         "failed": true,
@@ -4900,7 +4802,6 @@
         "ntests": 6
     },
     "sage.structure.factory": {
-        "failed": true,
         "ntests": 118
     },
     "sage.structure.formal_sum": {
@@ -4936,7 +4837,6 @@
         "ntests": 362
     },
     "sage.structure.parent_gens": {
-        "failed": true,
         "ntests": 41
     },
     "sage.structure.parent_old": {

--- a/pkgs/sagemath-schemes/pyproject.toml.m4
+++ b/pkgs/sagemath-schemes/pyproject.toml.m4
@@ -93,7 +93,7 @@ toric           = ["passagemath-polyhedra",
 padics          = ["passagemath-schemes[Zp]"]
 
 # the whole package
-standard        = ["passagemath-schemes[toric,padics,NumberField,FiniteField,flint,linbox,mpfi,ntl,numpy,pari,singular]"]
+standard        = ["passagemath-schemes[toric,padics,NumberField,FiniteField,flint,linbox,mpfi,ntl,numpy,pari,singular,eclib,sympow]"]
 
 [tool.cibuildwheel.linux]
 # Unfortunately CIBW_REPAIR_WHEEL_COMMAND does not expand {project} (and other placeholders),

--- a/pkgs/sagemath-schemes/pyproject.toml.m4
+++ b/pkgs/sagemath-schemes/pyproject.toml.m4
@@ -58,6 +58,8 @@ pari    = ["passagemath-pari"]
 # extras by packages (specific to sagemath-schemes)
 
 eclib   = ["passagemath-eclib"]
+msolve  = ["passagemath-msolve"]
+qepcad  = ["passagemath-qepcad"]
 singular = []  # no extra needed
 sympow  = ["passagemath-sympow"]
 

--- a/pkgs/sagemath-schemes/pyproject.toml.m4
+++ b/pkgs/sagemath-schemes/pyproject.toml.m4
@@ -42,18 +42,24 @@ test    = ["passagemath-repl"]
 
 # extras by packages (same as sagemath-modules)
 flint   = ["passagemath-flint"]
-linbox  = []  # FIXME
-m4ri    = []  # FIXME
-m4rie   = []  # FIXME
+fpylll  = [SPKG_INSTALL_REQUIRES_fpylll]
+gsl     = []  # No extra needed
+linbox  = ["passagemath-linbox"]
+m4ri    = ["passagemath-modules[linbox]"]
+m4rie   = ["passagemath-modules[linbox]"]
 meataxe = ["passagemath-meataxe"]
-mpfi    = []  # FIXME
+mpfi    = ["passagemath-modules[flint]"]
+mpfr    = []  # No extra needed
+mpmath  = []  # No extra needed
 ntl     = ["passagemath-ntl"]
 numpy   = [SPKG_INSTALL_REQUIRES_numpy]
 pari    = ["passagemath-pari"]
 
 # extras by packages (specific to sagemath-schemes)
 
+eclib   = ["passagemath-eclib"]
 singular = []  # no extra needed
+sympow  = ["passagemath-sympow"]
 
 # extras by rings; same as in sagemath-modules
 RDF     = ["passagemath-schemes[numpy]"]

--- a/src/.relint.yml
+++ b/src/.relint.yml
@@ -46,7 +46,7 @@
     namespace package. Type import_statements("SOME_IDENTIFIER") to find a more specific import,
     or use 'sage --fiximports' to fix automatically in the source file.
   # Keep in sync with SAGE_ROOT/src/sage/misc/replace_dot_all.py
-  pattern: 'from\s+sage(|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|symbolic|tensor)[a-z0-9_.]*|[.]libs)[.]all\s+import'
+  pattern: 'from\s+sage(|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|lfunctions|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|symbolic|tensor)[a-z0-9_.]*|[.]libs)[.]all\s+import'
   # imports from .all are allowed in all.py; also allow in some modules that need sage.all
   filePattern: '(.*/|)(?!(all|benchmark|dev_tools|parsing|sage_eval|explain_pickle|.*_test))[^/.]*[.](py|pyx|pxi)$'
 
@@ -57,7 +57,7 @@
     and rewrite the import statement as "from sage.PAC.KAGE.MODULE import ..."
     or "lazy_import('sage.PAC.KAGE.MODULE', '...')".
   # Keep in sync with above; but for now we ignore sage.{arith,categories}
-  pattern: '^import\s+sage(|[.](combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|symbolic|tensor)[a-z0-9_.]*|[.]libs)[.]all'
+  pattern: '^import\s+sage(|[.](combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|lfunctions|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|symbolic|tensor)[a-z0-9_.]*|[.]libs)[.]all'
   # imports from .all are allowed in all.py; also allow in some modules that need sage.all
   filePattern: '(.*/|)(?!(all|benchmark|dev_tools|parsing|sage_eval|explain_pickle|.*_test))[^/.]*[.](py|pyx|pxi)$'
 

--- a/src/sage/all.py
+++ b/src/sage/all.py
@@ -114,7 +114,6 @@ lazy_import('sage.interacts', 'all', 'interacts')
 try:
     from .all__sagemath_plot import *
     from .all__sagemath_symbolics import *
-    from sage.lfunctions.all import *
 except ImportError:
     pass
 

--- a/src/sage/all__sagemath_schemes.py
+++ b/src/sage/all__sagemath_schemes.py
@@ -15,6 +15,7 @@ from .all__sagemath_polyhedra import *
 
 from .all__sagemath_singular import *
 
+from sage.lfunctions.all import *
 from sage.modular.all    import *
 from sage.schemes.all    import *
 from sage.databases.all__sagemath_schemes import *

--- a/src/sage/categories/number_fields.py
+++ b/src/sage/categories/number_fields.py
@@ -185,7 +185,7 @@ class NumberFields(Category_singleton):
                 PARI zeta function associated to Rational Field
             """
             if algorithm == 'gp':
-                from sage.lfunctions.all import Dokchitser
+                from sage.lfunctions.dokchitser import Dokchitser
                 r1, r2 = self.signature()
                 zero = [0]
                 one = [1]

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -497,7 +497,7 @@ class DocTestController(SageObject):
                         if pkg.name in options.hide:
                             continue
                         # Skip features for which we have a more specific runtime feature test.
-                        if pkg.name in ['bliss', 'coxeter3', 'ecm', 'fricas', 'frobby', 'gfan', 'giac', 'jmol', 'latte_int', 'macaulay2', 'mcqd', 'meataxe', 'msolve', 'sirocco', 'tdlib']:
+                        if pkg.name in ['bliss', 'coxeter3', 'eclib', 'ecm', 'fricas', 'frobby', 'gfan', 'giac', 'jmol', 'latte_int', 'macaulay2', 'mcqd', 'meataxe', 'msolve', 'sirocco', 'tdlib']:
                             continue
                         if pkg.is_installed() and pkg.installed_version == pkg.remote_version:
                             options.optional.add(pkg.name)

--- a/src/sage/features/eclib.py
+++ b/src/sage/features/eclib.py
@@ -1,0 +1,46 @@
+# sage_setup: distribution = sagemath-environment
+r"""
+Feature for testing the presence of eclib
+"""
+
+# *****************************************************************************
+#       Copyright (C) 2024 Matthias Koeppe
+#
+#  Distributed under the terms of the GNU General Public License (GPL)
+#  as published by the Free Software Foundation; either version 2 of
+#  the License, or (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# *****************************************************************************
+
+import subprocess
+from . import Executable, FeatureTestResult, PythonModule
+from .join_feature import JoinFeature
+
+
+class Mwrank(Executable):
+    r"""
+    A :class:`~sage.features.Feature` describing the presence of mwrank.
+
+    EXAMPLES::
+
+        sage: from sage.features.eclib import Mwrank
+        sage: Mwrank().is_present()                             # needs eclib
+        FeatureTestResult('mwrank', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.eclib import Mwrank
+            sage: isinstance(Mwrank(), Mwrank)
+            True
+        """
+        Executable.__init__(self, "mwrank", executable='mwrank',
+                            spkg='eclib')
+
+
+def all_features():
+    return [JoinFeature("eclib",
+                        (Mwrank(),
+                         PythonModule('sage.libs.eclib')),
+                        spkg='sagemath_eclib')]

--- a/src/sage/features/eclib.py
+++ b/src/sage/features/eclib.py
@@ -36,11 +36,11 @@ class Mwrank(Executable):
             True
         """
         Executable.__init__(self, "mwrank", executable='mwrank',
-                            spkg='eclib')
+                            spkg='eclib', type='standard')
 
 
 def all_features():
     return [JoinFeature("eclib",
                         (Mwrank(),
                          PythonModule('sage.libs.eclib')),
-                        spkg='sagemath_eclib')]
+                        spkg='sagemath_eclib', type='standard')]

--- a/src/sage/features/sympow.py
+++ b/src/sage/features/sympow.py
@@ -14,7 +14,8 @@ Feature for testing the presence of ``sympow``
 
 import subprocess
 
-from . import Executable
+from . import Executable, PythonModule
+from .join_feature import JoinFeature
 
 
 class Sympow(Executable):
@@ -41,4 +42,7 @@ class Sympow(Executable):
 
 
 def all_features():
-    return [Sympow()]
+    return [JoinFeature("sympow",
+                        (Sympow(),
+                         PythonModule('sage.lfunctions.sympow')),
+                        spkg='sagemath_sympow', type='standard')]

--- a/src/sage/geometry/polyhedron/library.py
+++ b/src/sage/geometry/polyhedron/library.py
@@ -719,10 +719,10 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: ico = polytopes.icosahedron()                                         # needs sage.rings.number_field
-            sage: ico.f_vector()                                                        # needs sage.rings.number_field
+            sage: ico = polytopes.icosahedron()                                         # needs sage.groups sage.rings.number_field
+            sage: ico.f_vector()                                                        # needs sage.groups sage.rings.number_field
             (1, 12, 30, 20, 1)
-            sage: ico.volume()                                                          # needs sage.rings.number_field
+            sage: ico.volume()                                                          # needs sage.groups sage.rings.number_field
             5/12*sqrt5 + 5/4
 
         Its non exact version::

--- a/src/sage/interfaces/genus2reduction.py
+++ b/src/sage/interfaces/genus2reduction.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-pari
 r"""
 Conductor and reduction types for genus 2 curves
 

--- a/src/sage/interfaces/mwrank.py
+++ b/src/sage/interfaces/mwrank.py
@@ -19,7 +19,11 @@ Interface to mwrank
 # ****************************************************************************
 
 import os
+import shlex
 import weakref
+
+from sage.features.eclib import Mwrank as mwrank_executable
+
 from .expect import Expect
 
 instances = {}
@@ -190,7 +194,7 @@ class Mwrank_class(Expect):
         Expect.__init__(self,
                         name='mwrank',
                         prompt='Enter curve: ',
-                        command="mwrank %s" % options,
+                        command=f"{shlex.quote(mwrank_executable().absolute_filename())} {options}",
                         server=server,
                         server_tmpdir=server_tmpdir,
                         restart_on_ctrlc=True,
@@ -363,4 +367,4 @@ def mwrank_console():
     from sage.repl.rich_output.display_manager import get_display_manager
     if not get_display_manager().is_in_terminal():
         raise RuntimeError('Can use the console only in the terminal. Try %%mwrank magics instead.')
-    os.system('mwrank')
+    os.system(f'{shlex.quote(mwrank_executable().absolute_filename())}')

--- a/src/sage/lfunctions/all.py
+++ b/src/sage/lfunctions/all.py
@@ -1,10 +1,15 @@
 # sage_setup: distribution = sagemath-schemes
+from .all__sagemath_lcalc import *
 from .all__sagemath_sympow import *
+
+try:
+    from .all__sagemath_sympow import *
+except ImportError:
+    pass
 
 from sage.misc.lazy_import import lazy_import
 
 lazy_import("sage.lfunctions.dokchitser", "Dokchitser")
 lazy_import("sage.lfunctions.zero_sums", "LFunctionZeroSum")
-lazy_import("sage.lfunctions.lcalc", "lcalc")
 
 del lazy_import

--- a/src/sage/lfunctions/all.py
+++ b/src/sage/lfunctions/all.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-schemes
 from .all__sagemath_sympow import *
 
 from sage.misc.lazy_import import lazy_import

--- a/src/sage/lfunctions/all.py
+++ b/src/sage/lfunctions/all.py
@@ -1,6 +1,9 @@
 # sage_setup: distribution = sagemath-schemes
-from .all__sagemath_lcalc import *
-from .all__sagemath_sympow import *
+
+try:
+    from .all__sagemath_lcalc import *
+except ImportError:
+    pass
 
 try:
     from .all__sagemath_sympow import *

--- a/src/sage/lfunctions/all__sagemath_lcalc.py
+++ b/src/sage/lfunctions/all__sagemath_lcalc.py
@@ -1,1 +1,7 @@
 # sage_setup: distribution = sagemath-lcalc
+
+from sage.misc.lazy_import import lazy_import
+
+lazy_import("sage.lfunctions.lcalc", "lcalc")
+
+del lazy_import

--- a/src/sage/lfunctions/dokchitser.py
+++ b/src/sage/lfunctions/dokchitser.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-schemes
 """
 Dokchitser's `L`-functions calculator
 

--- a/src/sage/lfunctions/pari.py
+++ b/src/sage/lfunctions/pari.py
@@ -314,6 +314,7 @@ def lfun_number_field(K):
         sage: L(3)
         1.20205690315959
 
+        sage: x = polygen(QQ, 'x')
         sage: K = NumberField(x**2 - 2, 'a')
         sage: L = LFunction(lfun_number_field(K))
         sage: L(3)
@@ -477,7 +478,7 @@ class LFunction(SageObject):
 
     We compute with the Dedekind zeta function of a number field::
 
-        sage: x = var('x')
+        sage: x = polygen(QQ, 'x')
         sage: K = NumberField(x**4 - x**2 - 1,'a')
         sage: L = K.zeta_function(algorithm='pari')
         sage: L.conductor

--- a/src/sage/lfunctions/pari.py
+++ b/src/sage/lfunctions/pari.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-schemes
 """
 `L`-functions from PARI
 

--- a/src/sage/lfunctions/zero_sums.pyx
+++ b/src/sage/lfunctions/zero_sums.pyx
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-schemes
 r"""
 Class for computing sums over zeros of motivic `L`-functions
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -1650,7 +1650,7 @@ def regulator(x):
         sage: x = polygen(ZZ, 'x')
         sage: regulator(NumberField(x^2 - 2, 'a'))                                      # needs sage.rings.number_field
         0.881373587019543
-        sage: regulator(EllipticCurve('11a'))                                           # needs sage.schemes
+        sage: regulator(EllipticCurve('11a'))                                           # needs eclib sage.schemes
         1.00000000000000
     """
     return x.regulator()

--- a/src/sage/misc/replace_dot_all.py
+++ b/src/sage/misc/replace_dot_all.py
@@ -73,7 +73,7 @@ __import__("sage.all", globals(), locals(), ["*"])
 # Keep in sync with SAGE_ROOT/src/.relint.yml (namespace_pkg_all_import)
 
 default_package_regex = (r"sage("
-                         r"|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|tensor)[a-z0-9_.]*|[.]libs"
+                         r"|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|lfunctions|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|tensor)[a-z0-9_.]*|[.]libs"
                          r")[.]all")
 
 

--- a/src/sage/modular/abvar/abvar.py
+++ b/src/sage/modular/abvar/abvar.py
@@ -3720,7 +3720,7 @@ class ModularAbelianVariety_abstract(Parent):
         By a theorem the modular degree must thus be `3`::
 
             sage: E = EllipticCurve('33a')
-            sage: E.modular_degree()
+            sage: E.modular_degree()                                                    # needs sympow
             3
 
         Next we compute the dual of a `2`-dimensional new simple

--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
-# sage.doctest: needs sage.libs.pari
+# sage.doctest: needs sage.graphs sage.libs.pari
 r"""
 Quotients of the Bruhat-Tits tree
 

--- a/src/sage/modular/btquotients/pautomorphicform.py
+++ b/src/sage/modular/btquotients/pautomorphicform.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
-# sage.doctest: needs sage.libs.pari
+# sage.doctest: needs sage.graphs sage.libs.pari
 #########################################################################
 #       Copyright (C) 2011 Cameron Franc and Marc Masdeu
 #
@@ -167,10 +167,10 @@ class BruhatTitsHarmonicCocycleElement(HeckeModuleElement):
     subtracted from each other::
 
         sage: X = BruhatTitsQuotient(5,23)
-        sage: H = X.harmonic_cocycles(2,prec=10)
+        sage: H = X.harmonic_cocycles(2, prec=10)
         sage: v1 = H.basis()[0]; v2 = H.basis()[1] # indirect doctest
-        sage: v3 = v1+v2
-        sage: v1 == v3-v2
+        sage: v3 = v1 + v2
+        sage: v1 == v3 - v2
         True
 
     and rescaled::

--- a/src/sage/modular/dirichlet.py
+++ b/src/sage/modular/dirichlet.py
@@ -770,9 +770,9 @@ class DirichletCharacter(MultiplicativeGroupElement):
         With the algorithm "lcalc"::
 
             sage: a = a.primitive_character()
-            sage: L = a.lfunction(algorithm='lcalc'); L
+            sage: L = a.lfunction(algorithm='lcalc'); L                                 # needs lcalc
             L-function with complex Dirichlet coefficients
-            sage: L.value(4)  # abs tol 1e-8
+            sage: L.value(4)  # abs tol 1e-8                                            # needs lcalc
             0.988944551741105 + 0.0*I
         """
         if algorithm is None:
@@ -1628,11 +1628,13 @@ class DirichletCharacter(MultiplicativeGroupElement):
 
         TESTS::
 
+            sage: # needs sage.libs.gap sage.rings.number_field
             sage: G = DirichletGroup(20, UniversalCyclotomicField())
             sage: e = G([1 for u in G.unit_gens()])
             sage: e.kloosterman_sum(7,17)
             -2*E(5) - 4*E(5)^2 - 4*E(5)^3 - 2*E(5)^4
 
+            sage: # needs sage.rings.number_field
             sage: G = DirichletGroup(12, QQbar)
             sage: e = G.gens()[0]
             sage: e.kloosterman_sum(5, 4)

--- a/src/sage/modular/etaproducts.py
+++ b/src/sage/modular/etaproducts.py
@@ -144,6 +144,7 @@ class EtaGroupElement(Element):
 
         EXAMPLES::
 
+            sage: # needs fpylll
             sage: eta1, eta2 = EtaGroup(4).basis() # indirect doctest
             sage: eta1 * eta2
             Eta product of level 4 : (eta_1)^24 (eta_2)^-48 (eta_4)^24
@@ -159,6 +160,7 @@ class EtaGroupElement(Element):
 
         EXAMPLES::
 
+            sage: # needs fpylll
             sage: eta1, eta2 = EtaGroup(4).basis()
             sage: eta1 / eta2 # indirect doctest
             Eta product of level 4 : (eta_1)^-8 (eta_4)^8
@@ -176,6 +178,7 @@ class EtaGroupElement(Element):
 
         EXAMPLES::
 
+            sage: # needs fpylll
             sage: eta1, eta2 = EtaGroup(4).basis()
             sage: ~eta2  # indirect doctest
             Eta product of level 4 : (eta_1)^-16 (eta_2)^24 (eta_4)^-8
@@ -503,6 +506,7 @@ class EtaGroup_class(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
+            sage: # needs fpylll
             sage: EtaGroup(5).basis()
             [Eta product of level 5 : (eta_1)^6 (eta_5)^-6]
             sage: EtaGroup(12).basis()
@@ -593,6 +597,7 @@ class EtaGroup_class(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
+            sage: # needs fpylll
             sage: EtaGroup(4).reduce_basis([ EtaProduct(4, {1:8,2:24,4:-32}), EtaProduct(4, {1:8, 4:-8})])
             [Eta product of level 4 : (eta_1)^8 (eta_4)^-8,
              Eta product of level 4 : (eta_1)^-8 (eta_2)^24 (eta_4)^-16]
@@ -1023,6 +1028,7 @@ def _eta_relations_helper(eta1, eta2, degree, qexp_terms, labels, verbose):
 
     EXAMPLES::
 
+        sage: # needs fpylll
         sage: from sage.modular.etaproducts import _eta_relations_helper
         sage: r,s = EtaGroup(4).basis()
         sage: _eta_relations_helper(r,s,4,100,['a','b'],False)

--- a/src/sage/modular/hecke/submodule.py
+++ b/src/sage/modular/hecke/submodule.py
@@ -514,7 +514,7 @@ class HeckeSubmodule(module.HeckeModule_free_module):
 
         We test that :issue:`5080` is fixed::
 
-            sage: EllipticCurve('128a').congruence_number()
+            sage: EllipticCurve('128a').congruence_number()                             # needs sympow
             32
         """
 

--- a/src/sage/modular/modform/eis_series.py
+++ b/src/sage/modular/modform/eis_series.py
@@ -426,7 +426,7 @@ def eisenstein_series_lseries(weight, prec=53,
         -5.0235535164599797471968418348135050804419155747868718371029
     """
     f = eisenstein_series_qexp(weight, prec)
-    from sage.lfunctions.all import Dokchitser
+    from sage.lfunctions.dokchitser import Dokchitser
     j = weight
     L = Dokchitser(conductor=1,
                    gammaV=[0, 1],

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -751,6 +751,7 @@ class ModularForm_abstract(ModuleElement):
         These can be used to express the periods of `f` as exact
         linear combinations of the real and the imaginary period of `E`::
 
+            sage: # needs eclib
             sage: s = E.modular_symbol(sign=+1)
             sage: t = E.modular_symbol(sign=-1, implementation='sage')
             sage: s(3/11), t(3/11)

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -128,7 +128,7 @@ def delta_lseries(prec=53, max_imaginary_part=0,
         algorithm = 'pari'
 
     if algorithm == 'gp':
-        from sage.lfunctions.all import Dokchitser
+        from sage.lfunctions.dokchitser import Dokchitser
         L = Dokchitser(conductor=1, gammaV=[0, 1], weight=12, eps=1,
                        prec=prec)
         s = 'tau(n) = (5*sigma(n,3)+7*sigma(n,5))*n/12-35*sum(k=1,n-1,(6*k-4*(n-k))*sigma(k,3)*sigma(n-k,5));'
@@ -984,7 +984,7 @@ class ModularForm_abstract(ModuleElement):
             sage: L(1)
             0.588879583428483
         """
-        from sage.lfunctions.all import Dokchitser
+        from sage.lfunctions.dokchitser import Dokchitser
 
         # compute the requested embedding
         C = ComplexField(prec)
@@ -1093,7 +1093,7 @@ class ModularForm_abstract(ModuleElement):
         - David Loeffler (2015) -- added support for twists, integrated into
           Sage library
         """
-        from sage.lfunctions.all import Dokchitser
+        from sage.lfunctions.dokchitser import Dokchitser
         weight = self.weight()
         C = ComplexField(prec)
         if self.level() != 1:

--- a/src/sage/modular/pollack_stevens/fund_domain.py
+++ b/src/sage/modular/pollack_stevens/fund_domain.py
@@ -1452,6 +1452,7 @@ class ManinRelations(PollackStevensModularDomain):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()

--- a/src/sage/modular/pollack_stevens/modsym.py
+++ b/src/sage/modular/pollack_stevens/modsym.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
+# sage.doctest: needs eclib
 r"""
 Element class for Pollack-Stevens' modular symbols
 

--- a/src/sage/numerical/backends/interactivelp_backend.pyx
+++ b/src/sage/numerical/backends/interactivelp_backend.pyx
@@ -53,7 +53,7 @@ cdef class InteractiveLPBackend:
 
         This backend can work with irrational algebraic numbers::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs sage.groups sage.rings.number_field
             sage: poly = polytopes.dodecahedron(base_ring=AA)
             sage: lp, x = poly.to_linear_program(solver='InteractiveLP', return_variable=True)
             sage: lp.set_objective(x[0] + x[1] + x[2])

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1633,6 +1633,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.gap
             sage: S.<b> = GF(5^2); S
             Finite Field in b of size 5^2
             sage: (4*b+3)._gap_init_()

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -522,14 +522,20 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             except (ValueError, IndexError, TypeError):
                 raise TypeError("no coercion defined")
 
-        elif isinstance(x, sage.libs.gap.element.GapElement_FiniteField):
-            try:
-                self.construct_from(x.sage(ring=self._parent))
-            except (ValueError, IndexError, TypeError):
-                raise TypeError("no coercion defined")
-
         else:
-            raise TypeError("no coercion defined")
+            try:
+                from sage.libs.gap.element import GapElement_FiniteField
+            except ImportError:
+                raise TypeError("no coercion defined")
+            else:
+                if isinstance(x, GapElement_FiniteField):
+                    try:
+                        self.construct_from(x.sage(ring=self._parent))
+                    except (ValueError, IndexError, TypeError):
+                        raise TypeError("no coercion defined")
+                else:
+                    raise TypeError("no coercion defined")
+
 
     def _repr_(self):
         """

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -205,7 +205,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         a
         sage: b = gap(a^3); b                                                           # needs sage.libs.gap
         Z(2^3)^3
-        sage: F(b)
+        sage: F(b)                                                                      # needs sage.libs.gap
         a + 1
         sage: a^3
         a + 1

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -996,16 +996,16 @@ cdef class FiniteField(Field):
             sage: k = GF(199)
             sage: k.modulus()
             x + 198
-            sage: var('x')
+            sage: var('x')                                                              # needs sage.symbolic
             x
-            sage: k = GF(199, modulus=x+1)
-            sage: k.modulus()
+            sage: k = GF(199, modulus=x+1)                                              # needs sage.symbolic
+            sage: k.modulus()                                                           # needs sage.symbolic
             x + 1
 
         The given modulus is always made monic::
 
-            sage: k.<a> = GF(7^2, modulus=2*x^2 - 3, impl='pari_ffelt')
-            sage: k.modulus()
+            sage: k.<a> = GF(7^2, modulus=2*x^2 - 3, impl='pari_ffelt')                 # needs sage.symbolic
+            sage: k.modulus()                                                           # needs sage.symbolic
             x^2 + 2
 
         TESTS:

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -337,10 +337,10 @@ class FiniteFieldFactory(UniqueFactory):
 
         sage: K.<a> = GF(13^3, modulus=[1,0,0,2])
         sage: K.<a> = GF(13^10, modulus=pari("ffinit(13,10)"))
-        sage: var('x')
+        sage: var('x')                                                                  # needs sage.symbolic
         x
-        sage: K.<a> = GF(13^2, modulus=x^2 - 2)
-        sage: K.<a> = GF(13^2, modulus=sin(x))
+        sage: K.<a> = GF(13^2, modulus=x^2 - 2)                                         # needs sage.symbolic
+        sage: K.<a> = GF(13^2, modulus=sin(x))                                          # needs sage.symbolic
         Traceback (most recent call last):
         ...
         TypeError: self must be a numeric expression
@@ -352,7 +352,7 @@ class FiniteFieldFactory(UniqueFactory):
 
     ::
 
-        sage: K.<a> = GF(5**2, name='a', modulus=x^2 + 2, check_irreducible=False)
+        sage: K.<a> = GF(5**2, name='a', modulus=x^2 + 2, check_irreducible=False)      # needs sage.symbolic
 
     Even for prime fields, you can specify a modulus. This will not
     change how Sage computes in this field, but it will change the

--- a/src/sage/rings/finite_rings/finite_field_givaro.py
+++ b/src/sage/rings/finite_rings/finite_field_givaro.py
@@ -337,6 +337,7 @@ class FiniteField_givaro(FiniteField):
 
         GAP elements need to be finite field elements::
 
+            sage: # needs sage.libs.gap
             sage: x = gap('Z(13)')
             sage: F = FiniteField(13, impl='givaro')
             sage: F(x)

--- a/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
@@ -564,8 +564,8 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
 
     and recover its small roots::
 
-        sage: Kbar = f.small_roots()[0]
-        sage: K == Kbar
+        sage: Kbar = f.small_roots()[0]                                                 # needs fpylll
+        sage: K == Kbar                                                                 # needs fpylll
         True
 
     The same algorithm can be used to factor `N = pq` if partial

--- a/src/sage/schemes/elliptic_curves/BSD.py
+++ b/src/sage/schemes/elliptic_curves/BSD.py
@@ -99,7 +99,7 @@ def simon_two_descent_work(E, two_tor_rk):
         ...
         (0, 0, 0, 0, [])
         sage: E = EllipticCurve('37a')
-        sage: simon_two_descent_work(E, E.two_torsion_rank())
+        sage: simon_two_descent_work(E, E.two_torsion_rank())                           # needs eclib
         (1, 1, 0, 0, [(0 : 0 : 1)])
     """
     from sage.misc.superseded import deprecation
@@ -136,10 +136,10 @@ def mwrank_two_descent_work(E, two_tor_rk):
 
         sage: from sage.schemes.elliptic_curves.BSD import mwrank_two_descent_work
         sage: E = EllipticCurve('14a')
-        sage: mwrank_two_descent_work(E, E.two_torsion_rank())
+        sage: mwrank_two_descent_work(E, E.two_torsion_rank())                          # needs eclib
         (0, 0, 0, 0, [])
         sage: E = EllipticCurve('37a')
-        sage: mwrank_two_descent_work(E, E.two_torsion_rank())
+        sage: mwrank_two_descent_work(E, E.two_torsion_rank())                          # needs eclib
         (1, 1, 0, 0, [(0 : -1 : 1)])
     """
     MWRC = E.mwrank_curve()
@@ -178,13 +178,13 @@ def pari_two_descent_work(E):
         sage: pari_two_descent_work(E)
         (0, 0, 0, 0, [])
         sage: E = EllipticCurve('37a')
-        sage: pari_two_descent_work(E) # random, up to sign
+        sage: pari_two_descent_work(E) # random, up to sign                             # needs eclib
         (1, 1, 0, 0, [(0 : -1 : 1)])
         sage: E = EllipticCurve('210e7')
-        sage: pari_two_descent_work(E)
+        sage: pari_two_descent_work(E)                                                  # needs eclib
         (0, 2, 0, 2, [])
         sage: E = EllipticCurve('66b3')
-        sage: pari_two_descent_work(E)
+        sage: pari_two_descent_work(E)                                                  # needs eclib
         (0, 0, 2, 2, [])
     """
     ep = E.pari_curve()

--- a/src/sage/schemes/elliptic_curves/BSD.py
+++ b/src/sage/schemes/elliptic_curves/BSD.py
@@ -376,7 +376,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 3 by Kolyvagin bound
         True for p = 5 by Kolyvagin bound
         []
-        sage: E.prove_BSD(two_desc='pari')
+        sage: E.prove_BSD(two_desc='pari')                                              # needs sage.graphs
         []
 
     A rank two curve::

--- a/src/sage/schemes/elliptic_curves/BSD.py
+++ b/src/sage/schemes/elliptic_curves/BSD.py
@@ -21,9 +21,9 @@ class BSD_data:
         sage: D = BSD_data()
         sage: D.Sha is None
         True
-        sage: D.curve=EllipticCurve('11a')
-        sage: D.update()
-        sage: D.Sha
+        sage: D.curve = EllipticCurve('11a')
+        sage: D.update()                                                                # needs sage.graphs
+        sage: D.Sha                                                                     # needs sage.graphs
         Tate-Shafarevich group for the Elliptic Curve
          defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
     """
@@ -54,8 +54,8 @@ class BSD_data:
             sage: D.Sha is None
             True
             sage: D.curve = EllipticCurve('11a')
-            sage: D.update()
-            sage: D.Sha
+            sage: D.update()                                                            # needs sage.graphs
+            sage: D.Sha                                                                 # needs sage.graphs
             Tate-Shafarevich group for the Elliptic Curve
              defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
         """
@@ -264,7 +264,7 @@ def heegner_index_work(E):
     EXAMPLES::
 
         sage: from sage.schemes.elliptic_curves.BSD import heegner_index_work
-        sage: heegner_index_work(EllipticCurve('14a'))
+        sage: heegner_index_work(EllipticCurve('14a'))                                  # needs sage.graphs
         (1, -31)
     """
     for D in E.heegner_discriminants_list(10):
@@ -346,14 +346,14 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     EXAMPLES::
 
-        sage: EllipticCurve('11a').prove_BSD(verbosity=2)
+        sage: EllipticCurve('11a').prove_BSD(verbosity=2)                               # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 5} by Kolyvagin.
         Kolyvagin's bound for p = 5 applies by Lawson-Wuthrich
         True for p = 5 by Kolyvagin bound
         []
 
-        sage: EllipticCurve('14a').prove_BSD(verbosity=2)
+        sage: EllipticCurve('14a').prove_BSD(verbosity=2)                               # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 3} by Kolyvagin.
         Kolyvagin's bound for p = 3 applies by Lawson-Wuthrich
@@ -361,14 +361,14 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         []
 
         sage: E = EllipticCurve("20a1")
-        sage: E.prove_BSD(verbosity=2)
+        sage: E.prove_BSD(verbosity=2)                                                  # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 3} by Kolyvagin.
         Kato further implies that #Sha[3] is trivial.
         []
 
         sage: E = EllipticCurve("50b1")
-        sage: E.prove_BSD(verbosity=2)
+        sage: E.prove_BSD(verbosity=2)                                                  # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 3, 5} by Kolyvagin.
         Kolyvagin's bound for p = 3 applies by Lawson-Wuthrich
@@ -385,18 +385,18 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     We know nothing with proof=True::
 
-        sage: E.prove_BSD()
+        sage: E.prove_BSD()                                                             # needs sage.graphs
         Set of all prime numbers: 2, 3, 5, 7, ...
 
     We (think we) know everything with proof=False::
 
-        sage: E.prove_BSD(proof=False)
+        sage: E.prove_BSD(proof=False)                                                  # needs sage.graphs
         []
 
     A curve of rank 0 and prime conductor::
 
         sage: E = EllipticCurve('19a')
-        sage: E.prove_BSD(verbosity=2)
+        sage: E.prove_BSD(verbosity=2)                                                  # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 3} by Kolyvagin.
         Kolyvagin's bound for p = 3 applies by Lawson-Wuthrich
@@ -409,7 +409,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         sage: E._EllipticCurve_rational_field__rank
         (1, True)
         sage: E.analytic_rank = lambda : 0
-        sage: E.prove_BSD()
+        sage: E.prove_BSD()                                                             # needs sage.graphs
         Traceback (most recent call last):
         ...
         RuntimeError: It seems that the rank conjecture does not hold for this curve
@@ -425,7 +425,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         sage: def foo(use_database):
         ....:  return 4
         sage: S.an = foo
-        sage: E.prove_BSD()
+        sage: E.prove_BSD()                                                             # needs sage.graphs
         Traceback (most recent call last):
         ...
         RuntimeError: Apparent contradiction: 0 <= rank(sha[2]) <= 0, but ord_2(sha_an) = 2
@@ -433,7 +433,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     An example with a Tamagawa number at 5::
 
         sage: E = EllipticCurve('123a1')
-        sage: E.prove_BSD(verbosity=2)
+        sage: E.prove_BSD(verbosity=2)                                                  # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 5} by Kolyvagin.
         Kolyvagin's bound for p = 5 applies by Lawson-Wuthrich
@@ -443,7 +443,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     A curve for which 3 divides the order of the Tate-Shafarevich group::
 
         sage: E = EllipticCurve('681b')
-        sage: E.prove_BSD(verbosity=2)               # long time
+        sage: E.prove_BSD(verbosity=2)               # long time                        # needs sage.graphs
         p = 2: True by 2-descent...
         True for p not in {2, 3} by Kolyvagin....
         Remaining primes:
@@ -455,7 +455,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     A curve for which we need to use ``heegner_index_bound``::
 
         sage: E = EllipticCurve('198b')
-        sage: E.prove_BSD(verbosity=1, secs_hi=1)
+        sage: E.prove_BSD(verbosity=1, secs_hi=1)                                       # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2, 3} by Kolyvagin.
         [3]
@@ -463,6 +463,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     The ``return_BSD`` option gives an object with detailed information
     about the proof::
 
+        sage: # needs sage.graphs
         sage: E = EllipticCurve('26b')
         sage: B = E.prove_BSD(return_BSD=True)
         sage: B.two_tor_rk
@@ -480,7 +481,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     This was fixed by :issue:`8184` and :issue:`7575`::
 
-        sage: EllipticCurve('438e1').prove_BSD(verbosity=1)
+        sage: EllipticCurve('438e1').prove_BSD(verbosity=1)                             # needs sage.graphs
         p = 2: True by 2-descent...
         True for p not in {2} by Kolyvagin.
         []
@@ -488,7 +489,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     ::
 
         sage: E = EllipticCurve('960d1')
-        sage: E.prove_BSD(verbosity=1)  # long time (4s on sage.math, 2011)
+        sage: E.prove_BSD(verbosity=1)  # long time (4s on sage.math, 2011)             # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2} by Kolyvagin.
         []
@@ -496,7 +497,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     ::
 
         sage: E = EllipticCurve('66b3')
-        sage: E.prove_BSD(two_desc="pari",verbosity=1)
+        sage: E.prove_BSD(two_desc="pari",verbosity=1)                                  # needs sage.graphs
         p = 2: True by 2-descent
         True for p not in {2} by Kolyvagin.
         []

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -473,6 +473,7 @@ class EllipticCurveFactory(UniqueFactory):
 
         ``names`` is ignored at the moment, however it is used to support a convenient way to get a generator::
 
+            sage: # needs eclib
             sage: E.<P> = EllipticCurve(QQ, [1, 3])
             sage: P
             (-1 : 1 : 1)
@@ -958,6 +959,7 @@ def EllipticCurve_from_cubic(F, P=None, morphism=True):
     points on the cubic.  First we find the preimages of multiples of
     the generator::
 
+        sage: # needs eclib
         sage: E = f.codomain()
         sage: E.label()
         '720e2'
@@ -979,6 +981,7 @@ def EllipticCurve_from_cubic(F, P=None, morphism=True):
 
     The elliptic curve also has torsion, which we can map back::
 
+        sage: # needs eclib
         sage: E.torsion_points()
         [(0 : 1 : 0),
          (-144000000/17689 : 3533760000000/2352637 : 1),
@@ -1470,6 +1473,7 @@ def EllipticCurves_with_good_reduction_outside_S(S=[], proof=None, verbose=False
 
     EXAMPLES::
 
+        sage: # needs eclib
         sage: EllipticCurves_with_good_reduction_outside_S([])
         []
         sage: elist = EllipticCurves_with_good_reduction_outside_S([2])
@@ -1485,13 +1489,14 @@ def EllipticCurves_with_good_reduction_outside_S(S=[], proof=None, verbose=False
 
     Without ``Proof=False``, this example gives two warnings::
 
+        sage: # needs eclib
         sage: elist = EllipticCurves_with_good_reduction_outside_S([11], proof=False)   # long time (14s on sage.math, 2011)
         sage: len(elist)                                                                # long time
         12
         sage: ', '.join(e.label() for e in elist)                                       # long time
         '11a1, 11a2, 11a3, 121a1, 121a2, 121b1, 121b2, 121c1, 121c2, 121d1, 121d2, 121d3'
 
-        sage: # long time
+        sage: # long time, needs eclib
         sage: elist = EllipticCurves_with_good_reduction_outside_S([2,3])               # long time (26s on sage.math, 2011)
         sage: len(elist)
         752

--- a/src/sage/schemes/elliptic_curves/ell_egros.py
+++ b/src/sage/schemes/elliptic_curves/ell_egros.py
@@ -320,9 +320,10 @@ def egros_from_jlist(jlist, S=[]):
 
     EXAMPLES::
 
+        sage: # needs eclib
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_get_j, egros_from_jlist
-        sage: jlist=egros_get_j([3])
-        sage: elist=egros_from_jlist(jlist,[3])
+        sage: jlist = egros_get_j([3])
+        sage: elist = egros_from_jlist(jlist,[3])
         sage: [e.label() for e in elist]
         ['27a1', '27a2', '27a3', '27a4', '243a1', '243a2', '243b1', '243b2']
         sage: [e.ainvs() for e in elist]
@@ -372,6 +373,7 @@ def egros_get_j(S=[], proof=None, verbose=False):
 
     EXAMPLES::
 
+        sage: # needs eclib
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_get_j
         sage: egros_get_j([])
         [1728]

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2496,6 +2496,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         TESTS::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve(GF(11), j=0)
             sage: G0 = E.isogeny_ell_graph(2, directed=False)
             sage: G0.is_directed()

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -1467,7 +1467,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             ...
             NotImplementedError: not implemented.
             sage: E = EllipticCurve(QQ, [1,1])
-            sage: E.gens()
+            sage: E.gens()                                                              # needs eclib
             [(0 : 1 : 1)]
         """
         raise NotImplementedError("not implemented.")
@@ -2145,11 +2145,12 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         ::
 
             sage: E = EllipticCurve("37a")
-            sage: P = E.gens()[0]
-            sage: x = P[0]
+            sage: P = E.gens()[0]                                                       # needs eclib
+            sage: x = P[0]                                                              # needs eclib
 
         ::
 
+            sage: # needs eclib
             sage: (35*P)[0]
             -804287518035141565236193151/1063198259901027900600665796
             sage: E._multiple_x_numerator(35, x)
@@ -2159,6 +2160,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs eclib
             sage: (36*P)[0]
             54202648602164057575419038802/15402543997324146892198790401
             sage: E._multiple_x_numerator(36, x)
@@ -2266,6 +2268,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs eclib
             sage: E = EllipticCurve("43a")
             sage: P = E.gens()[0]
             sage: x = P[0]

--- a/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
+++ b/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
@@ -40,6 +40,8 @@ EXAMPLES::
     1/3
     sage: m(1/17)
     -2/3
+
+    sage: # needs sage.graphs
     sage: m2 = E.modular_symbol(-1, implementation='sage')
     sage: m2(0)
     0
@@ -174,6 +176,8 @@ class ModularSymbol(SageObject):
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.sign()
             1
+
+            sage: # needs sage.graphs
             sage: m = EllipticCurve('11a1').modular_symbol(sign=-1, implementation='sage')
             sage: m.sign()
             -1
@@ -214,6 +218,8 @@ class ModularSymbol(SageObject):
             sage: m
             Modular symbol with sign 1 over Rational Field attached to
              Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
+
+            sage: # needs sage.graphs
             sage: m = EllipticCurve('43a1').modular_symbol(sign=-1, implementation='sage')
             sage: m
             Modular symbol with sign -1 over Rational Field attached to
@@ -401,6 +407,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve('11a1')
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolSage
             sage: M = ModularSymbolSage(E, +1)
@@ -420,6 +427,7 @@ class ModularSymbolSage(ModularSymbol):
         This is a rank 1 case with vanishing positive twists.
         The modular symbol is adjusted by -2::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve('121b1')
             sage: M = ModularSymbolSage(E, -1, normalize='L_ratio')
             sage: M(1/3)
@@ -427,6 +435,7 @@ class ModularSymbolSage(ModularSymbol):
             sage: M._scaling
             1
 
+            sage: # needs sage.graphs
             sage: M = EllipticCurve('121d1').modular_symbol(implementation='sage')
             sage: M(0)
             2
@@ -435,6 +444,7 @@ class ModularSymbolSage(ModularSymbol):
             sage: M(0)
             1
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve('15a1')
             sage: [C.modular_symbol(implementation='sage', normalize='L_ratio')(0)
             ....:  for C in E.isogeny_class()]
@@ -486,6 +496,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m._scaling
             1/5
@@ -513,6 +524,7 @@ class ModularSymbolSage(ModularSymbol):
 
         Some harder cases fail::
 
+            sage: # needs sage.graphs
             sage: m = EllipticCurve('121b1').modular_symbol(implementation='sage')
             Warning : Could not normalize the modular symbols, maybe all further results will be multiplied by -1 and a power of 2
             sage: m._scaling
@@ -520,6 +532,7 @@ class ModularSymbolSage(ModularSymbol):
 
         TESTS::
 
+            sage: # needs sage.graphs
             sage: rk0 = ['11a1', '11a2', '15a1', '27a1', '37b1']
             sage: for la in rk0:  # long time (3s on sage.math, 2011)
             ....:          E = EllipticCurve(la)
@@ -532,6 +545,7 @@ class ModularSymbolSage(ModularSymbol):
             1/3 1/3 1/3
             2/3 2/3 2/3
 
+            sage: # needs sage.graphs
             sage: rk1 = ['37a1','43a1','53a1', '91b1','91b2','91b3']
             sage: [EllipticCurve(la).modular_symbol()(0) for la in rk1]  # long time (1s on sage.math, 2011)
             [0, 0, 0, 0, 0, 0]
@@ -610,6 +624,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve('11a1')
             sage: m = E.modular_symbol(sign=+1, implementation='sage')
             sage: m.__lalg__(1)
@@ -715,6 +730,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m._call_with_caching(0)
             1/5
@@ -736,6 +752,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m(0)
             1/5

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -1965,6 +1965,8 @@ class EllipticCurve_number_field(EllipticCurve_field):
             Traceback (most recent call last):
             ...
             ValueError: The ideal must be prime.
+
+            sage: x = polygen(QQ)
             sage: K = QQ.extension(x^2 + x + 1, "a")
             sage: E = EllipticCurve([1024*K.0, 1024*K.0])
             sage: E.reduction(2*K)
@@ -2669,8 +2671,8 @@ class EllipticCurve_number_field(EllipticCurve_field):
         The isogeny class may be visualized by obtaining its graph and
         plotting it::
 
-            sage: G = C.graph()
-            sage: G.show(edge_labels=True) # long time
+            sage: G = C.graph()                                                         # needs sage.graphs
+            sage: G.show(edge_labels=True)  # long time                                 # needs sage.graphs
 
             sage: K.<i> = QuadraticField(-1)
             sage: E = EllipticCurve([1+i, -i, i, 1, 0])
@@ -2789,6 +2791,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         blocks, by contrast, the prime entries `2` are unique
         determined::
 
+            sage: # needs sage.graphs
             sage: G = C.graph()  # long time
             sage: G.adjacency_matrix()  # long time # random
             [0 1 1 0 0 1]
@@ -2802,13 +2805,13 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         To display the graph without any edge labels::
 
-            sage: G.show()  # not tested
+            sage: G.show()  # not tested                                                # needs sage.graphs
 
         To display the graph with edge labels: by default, for curves
         with rational CM, the labels are the coefficients of the
         associated quadratic forms::
 
-            sage: G.show(edge_labels=True)  # not tested
+            sage: G.show(edge_labels=True)  # not tested                                # needs sage.graphs
 
         For an alternative view, first relabel the edges using only 2
         labels to distinguish between isogenies between curves with
@@ -2816,9 +2819,9 @@ class EllipticCurve_number_field(EllipticCurve_field):
         different endomorphism rings, then use a 3-dimensional plot
         which can be rotated::
 
-            sage: for i, j, l in G.edge_iterator():  # long time
+            sage: for i, j, l in G.edge_iterator():  # long time                        # needs sage.graphs
             ....:     G.set_edge_label(i, j, l.count(','))
-            sage: G.show3d(color_by_label=True)  # long time
+            sage: G.show3d(color_by_label=True)  # long time                            # needs sage.graphs sage.plot
 
         A class number `6` example.  First we set up the fields: ``pol``
         defines the same field as ``pol26`` but is simpler::
@@ -2903,14 +2906,14 @@ class EllipticCurve_number_field(EllipticCurve_field):
         edges than in the non-CM case, it may be preferable to omit
         the edge_labels::
 
-            sage: G = C.graph()
-            sage: G.show(edge_labels=False) # long time
+            sage: G = C.graph()                                                         # needs sage.graphs
+            sage: G.show(edge_labels=False)  # long time                                # needs sage.graphs sage.plot
 
         It is possible to display a 3-dimensional plot, with colours
         to represent the different edge labels, in a form which can be
         rotated!::
 
-            sage: G.show3d(color_by_label=True) # long time
+            sage: G.show3d(color_by_label=True) # long time                             # needs sage.graphs sage.plot
 
         Over larger number fields several options make computations
         tractable.  Here we use algorithm 'heuristic' which avoids a

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -20,6 +20,7 @@ isogenies defined over `K`.
 
 EXAMPLES::
 
+    sage: x = polygen(QQ)
     sage: K.<i> = NumberField(x^2 + 1)
     sage: E = EllipticCurve([0, 4+i])
     sage: E.discriminant()
@@ -110,6 +111,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
     EXAMPLES::
 
+        sage: x = polygen(QQ)
         sage: K.<i> = NumberField(x^2 + 1)
         sage: EllipticCurve([i, i - 1, i + 1, 24*i + 15, 14*i + 35])
         Elliptic Curve defined by
@@ -122,6 +124,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         A curve from the database of curves over `\QQ`, but over a larger field::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: EllipticCurve(K,'389a1')
             Elliptic Curve defined by y^2 + y = x^3 + x^2 + (-2)*x
@@ -527,6 +530,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: P1, P2 = K.primes_above(5)
             sage: E = EllipticCurve([i/5,i/5,i/5,i/5,i/5])
@@ -557,6 +561,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: P1, P2 = K.primes_above(5)
             sage: E = EllipticCurve([i/5,i/5,i/5,i/5,i/5])
@@ -584,6 +589,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve([i/5,i/5,i/5,i/5,i/5])
             sage: P1, P2 = K.primes_above(5)
@@ -599,6 +605,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve([i/5,i/5,i/5,i/5,i/5])
             sage: P1, P2 = K.primes_above(5)
@@ -609,6 +616,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         :issue:`7935`::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 38)
             sage: E = EllipticCurve([a,1/2])
             sage: E.global_integral_model()
@@ -617,6 +625,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         :issue:`9266`::
 
+            sage: x = polygen(QQ)
             sage: K.<s> = NumberField(x^2 - 5)
             sage: w = (1+s)/2
             sage: E = EllipticCurve(K, [2,w])
@@ -626,6 +635,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         :issue:`12151`::
 
+            sage: x = polygen(QQ)
             sage: K.<v> = NumberField(x^2 + 161*x - 150)
             sage: E = EllipticCurve([25105/216*v - 3839/36, 634768555/7776*v - 98002625/1296, 634768555/7776*v - 98002625/1296, 0, 0])
             sage: M = E.global_integral_model(); M # choice varies, not tested
@@ -647,6 +657,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Check the skipped test from above::
 
+            sage: x = polygen(QQ)
             sage: K.<v> = NumberField(x^2 + 161*x - 150)
             sage: E = EllipticCurve([25105/216*v - 3839/36, 634768555/7776*v - 98002625/1296, 634768555/7776*v - 98002625/1296, 0, 0])
             sage: M = E.global_integral_model()
@@ -870,6 +881,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve([1 + i, 0, 1, 0, 0])
             sage: E.local_data()
@@ -967,6 +979,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve(K, [0,1,0,-160,308])
             sage: p = K.ideal(i + 1)
@@ -1034,6 +1047,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve([20, 225, 750, 1250*a + 6250, 62500*a + 15625])
             sage: P = K.ideal(a)
@@ -1072,6 +1086,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: [(p, E.has_good_reduction(p)) for p in prime_range(15)]
             [(2, False), (3, True), (5, True), (7, False), (11, True), (13, True)]
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P17a, P17b = [P for P,e in K.factor(17)]
             sage: E = EllipticCurve([0,0,0,0,2*a+1])
@@ -1106,6 +1121,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: [(p, E.has_bad_reduction(p)) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, True), (11, False), (13, False)]
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P17a, P17b = [P for P,e in K.factor(17)]
             sage: E = EllipticCurve([0,0,0,0,2*a+1])
@@ -1141,6 +1157,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: [(p, E.has_multiplicative_reduction(p)) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, True), (11, False), (13, False)]
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P17a, P17b = [P for P,e in K.factor(17)]
             sage: E = EllipticCurve([0,0,0,0,2*a+1])
@@ -1170,6 +1187,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: [(p, E.has_split_multiplicative_reduction(p)) for p in prime_range(15)]
             [(2, False), (3, False), (5, False), (7, True), (11, False), (13, False)]
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P17a, P17b = [P for P,e in K.factor(17)]
             sage: E = EllipticCurve([0,0,0,0,2*a+1])
@@ -1200,6 +1218,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: [(p, E.has_nonsplit_multiplicative_reduction(p)) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, False), (11, False), (13, False)]
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P17a, P17b = [P for P,e in K.factor(17)]
             sage: E = EllipticCurve([0,0,0,0,2*a+1])
@@ -1230,6 +1249,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: [(p, E.has_additive_reduction(p)) for p in prime_range(15)]
             [(2, False), (3, True), (5, False), (7, False), (11, False), (13, False)]
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P17a, P17b = [P for P,e in K.factor(17)]
             sage: E = EllipticCurve([0,0,0,0,2*a+1])
@@ -1285,6 +1305,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             [2, 3, 1]
             sage: vector(e.tamagawa_numbers())
             (2, 3, 1)
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 + 3)
             sage: eK = e.base_extend(K)
             sage: eK.tamagawa_numbers()
@@ -1310,6 +1331,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve([20, 225, 750, 625*a + 6875, 31250*a + 46875])
             sage: [E.tamagawa_exponent(P) for P in E.discriminant().support()]
@@ -1340,6 +1362,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve([0, 2+i])
             sage: E.tamagawa_product()
@@ -1393,6 +1416,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve([0, 2+i])
             sage: E.tamagawa_product_bsd()
@@ -1454,6 +1478,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve([20, 225, 750, 625*a + 6875, 31250*a + 46875])
             sage: bad_primes = E.discriminant().support(); bad_primes
@@ -1482,6 +1507,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<i> = NumberField(x^2 + 1)
             sage: EllipticCurve([i, i - 1, i + 1, 24*i + 15, 14*i + 35]).conductor()
             Fractional ideal (21*i - 3)
@@ -1491,6 +1517,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         A not so well known curve with everywhere good reduction::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 38)
             sage: E = EllipticCurve([0,0,0, 21796814856932765568243810*a - 134364590724198567128296995, 121774567239345229314269094644186997594*a - 750668847495706904791115375024037711300])
             sage: E.conductor()
@@ -1498,6 +1525,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example which used to fail (see :issue:`5307`)::
 
+            sage: x = polygen(QQ)
             sage: K.<w> = NumberField(x^2 + x + 6)
             sage: E = EllipticCurve([w, -1, 0, -w-6, 0])
             sage: E.conductor()
@@ -1505,6 +1533,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example raised in :issue:`11346`::
 
+            sage: x = polygen(QQ)
             sage: K.<g> = NumberField(x^2 - x - 1)
             sage: E1 = EllipticCurve(K, [0, 0, 0, -1/48, -161/864])
             sage: [(p.smallest_integer(), e) for p,e in E1.conductor().factor()]
@@ -1539,6 +1568,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - x - 57)
             sage: K.class_number()
             3
@@ -1560,6 +1590,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         If (and only if) the curve has everywhere good reduction the
         result is the unit ideal::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 26)
             sage: E = EllipticCurve([a, a-1, a+1, 4*a+10, 2*a+6])
             sage: E.conductor()
@@ -1595,6 +1626,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 10)
             sage: E = EllipticCurve([0, 0, 0, -22500, 750000*a])
             sage: E.non_minimal_primes()
@@ -1643,6 +1675,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 10)
             sage: E = EllipticCurve([0, 0, 0, -22500, 750000*a])
             sage: E.is_global_minimal_model()
@@ -1690,6 +1723,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         A curve defined over a field of class number 2 with no global
         minimal model was a nontrivial minimality class::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 10)
             sage: K.class_number()
             2
@@ -1747,6 +1781,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 10)
             sage: E = EllipticCurve([0, 0, 0, 4536*a+14148, -163728*a-474336])
             sage: E.is_global_minimal_model()
@@ -1787,6 +1822,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 38)
             sage: E = EllipticCurve([0,0,0, 21796814856932765568243810*a - 134364590724198567128296995, 121774567239345229314269094644186997594*a - 750668847495706904791115375024037711300])
             sage: E2 = E.global_minimal_model()
@@ -1799,6 +1835,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         See :issue:`11347`::
 
+            sage: x = polygen(QQ)
             sage: K.<g> = NumberField(x^2 - x - 1)
             sage: E = EllipticCurve(K, [0, 0, 0, -1/48, 161/864])
             sage: E2 = E.integral_model().global_minimal_model(); E2
@@ -1811,6 +1848,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         See :issue:`14472`, this used not to work over a relative extension::
 
+            sage: x = polygen(QQ)
             sage: K1.<w> = NumberField(x^2 + x + 1)
             sage: m = polygen(K1)
             sage: K2.<v> = K1.extension(m^2 - w + 1)
@@ -1823,6 +1861,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         even when global minimal models did exist, their computation
         was not implemented.  Now it is::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - 10)
             sage: K.class_number()
             2
@@ -1866,6 +1905,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         An example of a curve with everywhere good reduction but which
         has no model with unit discriminant::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - x - 16)
             sage: K.class_number()
             2
@@ -2404,6 +2444,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         First define a field with two real embeddings::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: E = EllipticCurve([0,0,0,a,2])
             sage: embs = K.embeddings(CC); len(embs)
@@ -3639,6 +3680,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             False
             sage: E.cm_discriminant()
             -20
+            sage: x = polygen(QQ)
             sage: E.has_rational_cm(K.extension(x^2 + 5, 'b'))
             True
 
@@ -3903,6 +3945,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         Another number field::
 
             sage: E = EllipticCurve('389a1')
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - x + 1)
             sage: EK = E.change_ring(K)
             sage: P = EK(-1,1); Q = EK(0,-1)

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -2827,6 +2827,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         defines the same field as ``pol26`` but is simpler::
 
             sage: pol26 = hilbert_class_polynomial(-4*26)
+            sage: x = polygen(QQ, 'x')
             sage: pol = x^6 - x^5 + 2*x^4 + x^3 - 2*x^2 - x - 1
             sage: K.<a> = NumberField(pol)
             sage: L.<b> = K.extension(x^2 + 26)

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -158,10 +158,10 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
             sage: E = EllipticCurve([1, 0, 1, -1751, -31352])
             sage: K.<d> = QuadraticField(5)
-            sage: E.gens()
+            sage: E.gens()                                                              # needs eclib
             [(52 : 111 : 1)]
             sage: EK = E.base_extend(K)
-            sage: EK.gens()
+            sage: EK.gens()                                                             # needs eclib
             [(52 : 111 : 1)]
         """
         E = super().base_extend(R)
@@ -333,11 +333,12 @@ class EllipticCurve_number_field(EllipticCurve_field):
         EXAMPLES::
 
             sage: E = EllipticCurve([0, 0, 1, -1, 0])
-            sage: E.height_pairing_matrix()
+            sage: E.height_pairing_matrix()                                             # needs eclib
             [0.0511114082399688]
 
         For rank 0 curves, the result is a valid 0x0 matrix::
 
+            sage: # needs eclib
             sage: EllipticCurve('11a').height_pairing_matrix()
             []
             sage: E = EllipticCurve('5077a1')
@@ -349,7 +350,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E = EllipticCurve('389a1')
             sage: E = EllipticCurve('389a1')
             sage: P, Q = E.point([-1,1,1]), E.point([0,-1,1])
-            sage: E.height_pairing_matrix([P,Q])
+            sage: E.height_pairing_matrix([P,Q])                                        # needs eclib
             [0.686667083305587 0.268478098806726]
             [0.268478098806726 0.327000773651605]
 
@@ -358,7 +359,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: x = polygen(QQ)
             sage: K.<t> = NumberField(x^2 + 47)
             sage: EK = E.base_extend(K)
-            sage: EK.height_pairing_matrix([EK(P),EK(Q)])
+            sage: EK.height_pairing_matrix([EK(P),EK(Q)])                               # needs eclib
             [0.686667083305587 0.268478098806726]
             [0.268478098806726 0.327000773651605]
 
@@ -368,10 +369,10 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E = EllipticCurve([0,0,0,i,i])
             sage: P = E(-9+4*i, -18-25*i)
             sage: Q = E(i,-i)
-            sage: E.height_pairing_matrix([P,Q])
+            sage: E.height_pairing_matrix([P,Q])                                        # needs eclib
             [  2.16941934493768 -0.870059380421505]
             [-0.870059380421505  0.424585837470709]
-            sage: E.regulator_of_points([P,Q])
+            sage: E.regulator_of_points([P,Q])                                          # needs eclib
             0.164101403936070
 
         When the parameter ``normalised`` is set to ``False``, each
@@ -493,6 +494,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('389a1')
             sage: P,Q = E.gens()
             sage: E.regulator_of_points([P,Q])
@@ -2369,7 +2371,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23, 'a')
             sage: E = EllipticCurve(K,[0,0,0,101,0])
-            sage: E.gens()
+            sage: E.gens()                                                              # needs eclib
             [(23831509/8669448*a - 2867471/8669448 : 76507317707/18049790736*a - 424166479633/18049790736 : 1),
              (-2031032029/969232392*a + 58813561/969232392 : -15575984630401/21336681877488*a + 451041199309/21336681877488 : 1),
              (-186948623/4656964 : 549438861195/10049728312*a : 1)]
@@ -2377,18 +2379,20 @@ class EllipticCurve_number_field(EllipticCurve_field):
         It can happen that no points are found if the height bounds
         used in the search are too small (see :issue:`10745`)::
 
+            sage: # needs eclib
             sage: K.<t> = NumberField(x^4 + x^2 - 7)
             sage: E = EllipticCurve(K, [1, 0, 5*t^2 + 16, 0, 0])
             sage: E.gens(lim1=1, lim3=1)
             []
             sage: E.rank()
             1
-            sage: gg=E.gens(lim3=13); gg  # long time (about 4s)
+            sage: gg = E.gens(lim3=13); gg  # long time (about 4s)
             [(... : 1)]
 
         Check that the the point found has infinite order, and that it is on the curve::
 
-            sage: P=gg[0]; P.order()  # long time
+            sage: # needs eclib
+            sage: P = gg[0]; P.order()  # long time
             +Infinity
             sage: E.defining_polynomial()(*P)  # long time
             0
@@ -2397,7 +2401,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
             sage: K.<t> = NumberField(x^2 - 17)
             sage: E = EllipticCurve(K, [-4, 0])
-            sage: E.gens()
+            sage: E.gens()                                                              # needs eclib
             [(-1/2*t + 1/2 : -1/2*t + 1/2 : 1), (-t + 3 : -2*t + 10 : 1)]
             sage: E.rank()
             2
@@ -2409,7 +2413,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: EK = E.base_extend(K)
             sage: EK.rank()
             0
-            sage: EK.gens()
+            sage: EK.gens()                                                             # needs eclib
             []
 
         IMPLEMENTATION:
@@ -3411,6 +3415,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Some examples over `\QQ`::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([0, 1, 1, -2, 42])
             sage: Pi = E.gens(); Pi
             [(-4 : 1 : 1), (-3 : 5 : 1), (-11/4 : 43/8 : 1), (-2 : 6 : 1)]
@@ -3460,6 +3465,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example to show the explicit use of the height pairing matrix::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([0, 1, 1, -2, 42])
             sage: Pi = E.gens()
             sage: H = E.height_pairing_matrix(Pi,3)
@@ -4099,30 +4105,30 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E = EllipticCurve([1,2,3,40,50])
             sage: E.conductor()
             2123582
-            sage: E.gens()
+            sage: E.gens()                                                              # needs eclib
             [(5 : 17 : 1)]
             sage: K.<i> = QuadraticField(-1)
             sage: EK = E.change_ring(K)
-            sage: EK.gens_quadratic()
+            sage: EK.gens_quadratic()                                                   # needs eclib
             [(5 : 17 : 1), (-13 : 48*i + 5 : 1)]
 
-            sage: E.change_ring(QuadraticField(3, 'a')).gens_quadratic()
+            sage: E.change_ring(QuadraticField(3, 'a')).gens_quadratic()                # needs eclib
             [(5 : 17 : 1), (-1 : 2*a - 1 : 1), (11/4 : 33/4*a - 23/8 : 1)]
 
             sage: K.<a> = QuadraticField(-7)
             sage: E = EllipticCurve([0,0,0,197,0])
             sage: E.conductor()
             2483776
-            sage: E.gens()
+            sage: E.gens()                                                              # needs eclib
             [(47995604297578081/7389879786648100 : -25038161802544048018837479/635266655830129794121000 : 1)]
             sage: K.<a> = QuadraticField(7)
-            sage: E.change_ring(K).gens_quadratic()
+            sage: E.change_ring(K).gens_quadratic()                                     # needs eclib
             [(-1209642055/59583566*a + 1639995844/29791783 : -377240626321899/1720892553212*a + 138577803462855/245841793316 : 1),
              (1/28 : 393/392*a : 1),
              (-61*a + 162 : 1098*a - 2916 : 1)]
 
             sage: E = EllipticCurve([1, a])
-            sage: E.gens_quadratic()
+            sage: E.gens_quadratic()                                                    # needs eclib
             Traceback (most recent call last):
             ...
             ValueError: gens_quadratic() requires the elliptic curve to be a base change from Q

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -247,7 +247,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
     Test pickling an elliptic curve that has known points on it::
 
-        sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e
+        sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e   # needs eclib
         True
 
     Test that the refactoring from :issue:`14711` did preserve the behaviour
@@ -496,8 +496,8 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
             (0 : 1 : 0)
             sage: P.is_zero()
             True
-            sage: P = E.gens()[0]
-            sage: P.is_zero()
+            sage: P = E.gens()[0]                                                       # needs eclib
+            sage: P.is_zero()                                                           # needs eclib
             False
         """
         return bool(self._coords[2])
@@ -696,10 +696,10 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         Example to show that bug :issue:`4820` is fixed::
 
-            sage: [type(c) for c in 2*EllipticCurve('37a1').gen(0)]
+            sage: [type(c) for c in 2*EllipticCurve('37a1').gen(0)]                     # needs eclib
             [<... 'sage.rings.rational.Rational'>,
-            <... 'sage.rings.rational.Rational'>,
-            <... 'sage.rings.rational.Rational'>]
+             <... 'sage.rings.rational.Rational'>,
+             <... 'sage.rings.rational.Rational'>]
 
         Checks that :issue:`15964` is fixed::
 
@@ -805,7 +805,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         Example to show that bug :issue:`4820` is fixed::
 
-            sage: [type(c) for c in -EllipticCurve('37a1').gen(0)]
+            sage: [type(c) for c in -EllipticCurve('37a1').gen(0)]                      # needs eclib
             [<... 'sage.rings.rational.Rational'>,
              <... 'sage.rings.rational.Rational'>,
              <... 'sage.rings.rational.Rational'>]
@@ -2435,7 +2435,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
     Test pickling an elliptic curve that has known points on it::
 
-        sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e
+        sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e   # needs ecl
         True
     """
 
@@ -2749,6 +2749,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('990e1')
             sage: P = E.gen(0); P
             (15 : 51 : 1)
@@ -2960,7 +2961,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             0.0511114082399688
             sage: P.order()
             +Infinity
-            sage: E.regulator()
+            sage: E.regulator()                                 # needs eclib
             0.0511114082399688...
 
             sage: def naive_height(P):

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1233,26 +1233,26 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         normalized::
 
             sage: E = EllipticCurve('11a2')
-            sage: E.modular_symbol(implementation = 'eclib')(0)
+            sage: E.modular_symbol(implementation='eclib')(0)
             1
-            sage: E.modular_symbol(implementation = 'sage', normalize='L_ratio')(0)
+            sage: E.modular_symbol(implementation='sage', normalize='L_ratio')(0)   # needs sage.graphs
             1
-            sage: E.modular_symbol(implementation = 'sage', normalize='none')(0)
+            sage: E.modular_symbol(implementation='sage', normalize='none')(0)      # needs sage.graphs
             1
-            sage: E.modular_symbol(implementation = 'sage', normalize='period')(0)
+            sage: E.modular_symbol(implementation='sage', normalize='period')(0)    # needs sage.graphs
             1
 
         Here is an example where both normalization methods work,
         while the non-normalized symbol is incorrect::
 
             sage: E = EllipticCurve('11a3')
-            sage: E.modular_symbol(implementation = 'eclib')(0)
+            sage: E.modular_symbol(implementation='eclib')(0)
             1/25
-            sage: E.modular_symbol(implementation = 'sage', normalize='none')(0)
+            sage: E.modular_symbol(implementation='sage', normalize='none')(0)      # needs sage.graphs
             1
-            sage: E.modular_symbol(implementation = 'sage', normalize='L_ratio')(0)
+            sage: E.modular_symbol(implementation='sage', normalize='L_ratio')(0)   # needs sage.graphs
             1/25
-            sage: E.modular_symbol(implementation = 'sage', normalize='period')(0)
+            sage: E.modular_symbol(implementation='sage', normalize='period')(0)    # needs sage.graphs
             1/25
 
         Since :issue:`10256`, the interface for negative modular symbols in eclib is available::
@@ -4710,7 +4710,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: isocls = EllipticCurve('37b').isogeny_class('database', order='lmfdb'); isocls.curves
+            sage: isocls = EllipticCurve('37b').isogeny_class('database', order='lmfdb'); isocls.curves     # needs sage.groups
             (Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational Field,
              Elliptic Curve defined by y^2 + y = x^3 + x^2 - 23*x - 50 over Rational Field,
              Elliptic Curve defined by y^2 + y = x^3 + x^2 - 3*x + 1 over Rational Field)
@@ -5198,7 +5198,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         ::
 
             sage: E = EllipticCurve('195a')
-            sage: G = E.isogeny_graph()
+            sage: G = E.isogeny_graph()                                                                     # needs sage.graphs
             sage: for v in G: print("{} {}".format(v, G.get_vertex(v)))
             1 Elliptic Curve defined by y^2 + x*y  = x^3 - 110*x + 435 over Rational Field
             2 Elliptic Curve defined by y^2 + x*y  = x^3 - 115*x + 392 over Rational Field
@@ -5208,7 +5208,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             6 Elliptic Curve defined by y^2 + x*y  = x^3 - 8125*x - 282568 over Rational Field
             7 Elliptic Curve defined by y^2 + x*y  = x^3 - 7930*x - 296725 over Rational Field
             8 Elliptic Curve defined by y^2 + x*y  = x^3 - 130000*x - 18051943 over Rational Field
-            sage: G.plot(edge_labels=True)                                              # needs sage.plot
+            sage: G.plot(edge_labels=True)                                              # needs sage.graphs sage.plot
             Graphics object consisting of 23 graphics primitives
         """
         return self.isogeny_class(order=order).graph()
@@ -5305,6 +5305,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: EllipticCurve('11a1')._shortest_paths()
             ((Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field,
               Elliptic Curve defined by y^2 + y = x^3 - x^2 over Rational Field,
@@ -5343,6 +5344,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve('11a1')
             sage: E._multiple_of_degree_of_isogeny_to_optimal_curve()
             5
@@ -7286,6 +7288,7 @@ def elliptic_curve_congruence_graph(curves):
 
     EXAMPLES::
 
+        sage: # needs sage.graphs
         sage: from sage.schemes.elliptic_curves.ell_rational_field import elliptic_curve_congruence_graph
         sage: curves = list(cremona_optimal_curves([11..30]))
         sage: G = elliptic_curve_congruence_graph(curves)

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -3901,7 +3901,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
             sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree()
             1984
-            sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree(algorithm='sympow')
+            sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree(algorithm='sympow')    # needs sympow
             1984
             sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree(algorithm='magma')  # optional - magma
             1984

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -3924,7 +3924,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
             except AttributeError:
                 if algorithm == 'sympow':
-                    from sage.lfunctions.all import sympow
+                    from sage.lfunctions.sympow import sympow
                     m = sympow.modular_degree(self)
                 elif algorithm == 'magma':
                     from sage.interfaces.magma import magma

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -310,7 +310,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('5077a1')
-            sage: E.modular_degree()
+            sage: E.modular_degree()                            # needs sympow
             1984
             sage: E._set_modular_degree(123456789)
             sage: E.modular_degree()
@@ -1479,9 +1479,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve('389a')
             sage: E.analytic_rank(algorithm='pari')
             2
-            sage: E.analytic_rank(algorithm='rubinstein')
+            sage: E.analytic_rank(algorithm='rubinstein')       # needs lcalc
             2
-            sage: E.analytic_rank(algorithm='sympow')
+            sage: E.analytic_rank(algorithm='sympow')           # needs sympow
             2
             sage: E.analytic_rank(algorithm='magma')    # optional - magma
             2
@@ -4696,6 +4696,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.groups
             sage: isocls = EllipticCurve('37b').isogeny_class(order='lmfdb')
             sage: isocls
             Elliptic curve isogeny class 37b
@@ -4778,14 +4779,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 171*x - 874 over Rational Field
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 11*x + 12 over Rational Field
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 2731*x - 55146 over Rational Field
-            sage: isocls2 = isocls.reorder('lmfdb'); isocls2.matrix()
+            sage: isocls2 = isocls.reorder('lmfdb'); isocls2.matrix()                   # needs sage.groups
             [ 1  2  3  9 18  6]
             [ 2  1  6 18  9  3]
             [ 3  6  1  3  6  2]
             [ 9 18  3  1  2  6]
             [18  9  6  2  1  3]
             [ 6  3  2  6  3  1]
-            sage: print("\n".join(repr(C) for C in isocls2.curves))
+            sage: print("\n".join(repr(C) for C in isocls2.curves))                     # needs sage.groups
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 2731*x - 55146 over Rational Field
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 171*x - 874 over Rational Field
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 36*x - 70 over Rational Field
@@ -5184,7 +5185,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: LL = []
-            sage: for e in cremona_optimal_curves(range(1, 38)):  # long time
+            sage: for e in cremona_optimal_curves(range(1, 38)):  # long time           # needs sage.graphs
             ....:  G = e.isogeny_graph()
             ....:  already = False
             ....:  for H in LL:
@@ -5193,13 +5194,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             ....:          break
             ....:  if not already:
             ....:      LL.append(G)
-            sage: graphs_list.show_graphs(LL)  # long time
+            sage: graphs_list.show_graphs(LL)  # long time                              # needs sage.graphs
 
         ::
 
             sage: E = EllipticCurve('195a')
-            sage: G = E.isogeny_graph()                                                                     # needs sage.graphs
-            sage: for v in G: print("{} {}".format(v, G.get_vertex(v)))
+            sage: G = E.isogeny_graph()                                                 # needs sage.graphs
+            sage: for v in G: print("{} {}".format(v, G.get_vertex(v)))                 # needs sage.graphs
             1 Elliptic Curve defined by y^2 + x*y  = x^3 - 110*x + 435 over Rational Field
             2 Elliptic Curve defined by y^2 + x*y  = x^3 - 115*x + 392 over Rational Field
             3 Elliptic Curve defined by y^2 + x*y  = x^3 + 210*x + 2277 over Rational Field

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -171,7 +171,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         the large database was installed)::
 
             sage: E = EllipticCurve('389a1')
-            sage: [P.curve() is E for P in E.gens()]
+            sage: [P.curve() is E for P in E.gens()]            # needs eclib
             [True, True]
         """
         # Cached values for the generators, rank and regulator.
@@ -330,6 +330,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('5077a1')
             sage: E.rank()
             3
@@ -445,9 +446,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a1')
-            sage: E.mwrank() #random
+            sage: E.mwrank()  # random                          # needs eclib
             ...
-            sage: print(E.mwrank())
+            sage: print(E.mwrank())                             # needs eclib
             Curve [0,0,1,-1,0] :        Basic pair: I=48, J=-432
             disc=255744
             ...
@@ -465,14 +466,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Run mwrank with ``'verbose'`` flag set to 0 but list generators if
         found::
 
-            sage: print(E.mwrank('-v0 -l'))
+            sage: print(E.mwrank('-v0 -l'))                     # needs eclib
             Curve [0,0,0,877,0] :   0 <= rank <= 1
             Regulator = 1
 
         Run mwrank again, this time with a higher bound for point searching
         on homogeneous spaces::
 
-            sage: print(E.mwrank('-v0 -l -b11'))
+            sage: print(E.mwrank('-v0 -l -b11'))                # needs eclib
             Curve [0,0,0,877,0] :   Rank = 1
             Generator 1 is [29604565304828237474403861024284371796799791624792913256602210:-256256267988926809388776834045513089648669153204356603464786949:490078023219787588959802933995928925096061616470779979261000]; height 95.98037...
             Regulator = 95.98037...
@@ -519,7 +520,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             3006
             sage: E.conductor(algorithm='generic')
             3006
-            sage: E.conductor(algorithm='all')
+            sage: E.conductor(algorithm='all')                  # needs eclib
             3006
 
         .. NOTE::
@@ -775,6 +776,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a1')
             sage: EE = E.mwrank_curve()
             sage: EE
@@ -831,7 +833,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a1')
-            sage: E.two_descent(verbose=False)
+            sage: E.two_descent(verbose=False)                  # needs eclib
             True
         """
         verbose_verbose("Calling mwrank C++ library.")
@@ -1084,7 +1086,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         TESTS::
 
             sage: E = EllipticCurve('37a1')
-            sage: E.modular_symbol(implementation = 'eclib') is E.modular_symbol(implementation = 'eclib', normalize = 'L_ratio')
+            sage: E.modular_symbol(implementation = 'eclib') is E.modular_symbol(implementation = 'eclib', normalize = 'L_ratio')  # needs eclib
             True
         """
         if sign not in [1,-1]:
@@ -1179,6 +1181,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('37a1')
             sage: M = E.modular_symbol(); M
             Modular symbol with sign 1 over Rational Field attached to
@@ -1332,6 +1335,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('19a1')
             sage: f = E.modular_symbol_numerical(1)
             sage: g = E.modular_symbol(1)
@@ -1375,6 +1379,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('113a1')
             sage: symb = E.pollack_stevens_modular_symbol()
             sage: symb
@@ -1382,6 +1387,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: symb.values()
             [-1/2, 1, -1, 0, 0, 1, 1, -1, 0, -1, 0, 0, 0, 1, -1, 0, 0, 0, 1, 0, 0]
 
+            sage: # needs eclib
             sage: E = EllipticCurve([0,1])
             sage: symb = E.pollack_stevens_modular_symbol(+1)
             sage: symb.values()
@@ -1835,6 +1841,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a1')
             sage: E.simon_two_descent()
             doctest:warning
@@ -1863,7 +1870,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         ::
 
             sage: E = EllipticCurve([1, -1, 0, -751055859, -7922219731979])
-            sage: E.simon_two_descent()
+            sage: E.simon_two_descent()                                                 # needs eclib
             (1, 1, [])
 
         The rest of these entries were taken from Tom Womack's page
@@ -1871,6 +1878,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([1, -1, 0, -79, 289])
             sage: E.simon_two_descent()
             (4, 4, [(6 : -1 : 1), (4 : 3 : 1), (5 : -2 : 1), (8 : 7 : 1)])
@@ -1889,6 +1897,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         Example from :issue:`10832`::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([1,0,0,-6664,86543])
             sage: E.simon_two_descent()
             (2, 3, [(-1/4 : 2377/8 : 1), (323/4 : 1891/8 : 1)])
@@ -1901,6 +1910,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         despite that the algorithm has not found any
         points of infinite order ::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([1, 1, 0, -23611790086, 1396491910863060])
             sage: E.simon_two_descent()
             (1, 2, [])
@@ -1912,7 +1922,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Example for :issue:`5153`::
 
             sage: E = EllipticCurve([3,0])
-            sage: E.simon_two_descent()
+            sage: E.simon_two_descent()                                                 # needs eclib
             (1, 2, [(1 : 2 : 1)])
 
         The upper bound on the 2-Selmer rank returned by this method
@@ -1920,9 +1930,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         equals the actual 2-Selmer rank plus 2 (see :issue:`10735`)::
 
             sage: E = EllipticCurve('438e1')
-            sage: E.simon_two_descent()
+            sage: E.simon_two_descent()                                                 # needs eclib
             (0, 3, [])
-            sage: E.selmer_rank()  # uses mwrank
+            sage: E.selmer_rank()  # uses mwrank                                        # needs eclib
             1
         """
         from sage.misc.superseded import deprecation
@@ -2048,29 +2058,29 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             2
             sage: EllipticCurve('5077a').rank()
             3
-            sage: EllipticCurve([1, -1, 0, -79, 289]).rank()   # This will use the default proof behavior of True
+            sage: EllipticCurve([1, -1, 0, -79, 289]).rank()   # This will use the default proof behavior of True    # needs eclib
             4
-            sage: EllipticCurve([0, 0, 1, -79, 342]).rank(proof=False)
+            sage: EllipticCurve([0, 0, 1, -79, 342]).rank(proof=False)  # needs eclib
             5
             sage: EllipticCurve([0, 0, 1, -79, 342]).rank(algorithm='pari')
             5
 
         Examples with denominators in defining equations::
 
-            sage: E = EllipticCurve([0, 0, 0, 0, -675/4])
+            sage: E = EllipticCurve([0, 0, 0, 0, -675/4])               # needs eclib
             sage: E.rank()
             0
             sage: E = EllipticCurve([0, 0, 1/2, 0, -1/5])
-            sage: E.rank()
+            sage: E.rank()                                              # needs eclib
             1
-            sage: E.minimal_model().rank()
+            sage: E.minimal_model().rank()                              # needs eclib
             1
 
         A large example where mwrank doesn't determine the result with certainty, but pari does::
 
-            sage: EllipticCurve([1,0,0,0,37455]).rank(proof=False)
+            sage: EllipticCurve([1,0,0,0,37455]).rank(proof=False)      # needs eclib
             0
-            sage: EllipticCurve([1,0,0,0,37455]).rank(proof=True)
+            sage: EllipticCurve([1,0,0,0,37455]).rank(proof=True)       # needs eclib
             Traceback (most recent call last):
             ...
             RuntimeError: rank not provably correct (lower bound: 0)
@@ -2096,21 +2106,21 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         database. We also check that the result is cached correctly::
 
             sage: E = EllipticCurve([-517, -4528])  # 1888b1
-            sage: E.rank(use_database=False)
+            sage: E.rank(use_database=False)                            # needs eclib
             Traceback (most recent call last):
             ...
             RuntimeError: rank not provably correct (lower bound: 0)
-            sage: E._EllipticCurve_rational_field__rank
+            sage: E._EllipticCurve_rational_field__rank                 # needs eclib
             (0, False)
-            sage: E.rank()
+            sage: E.rank()                                              # needs eclib
             0
-            sage: E._EllipticCurve_rational_field__rank
+            sage: E._EllipticCurve_rational_field__rank                 # needs eclib
             (0, True)
 
         This example has Sha = Z/4 x Z/4 and the rank cannot be
         determined using pari only::
 
-            sage: E =EllipticCurve([-113^2,0])
+            sage: E = EllipticCurve([-113^2,0])
             sage: E.rank(use_database=False, verbose=False, algorithm='pari')
             Traceback (most recent call last):
             ...
@@ -2298,7 +2308,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('389a')
-            sage: E.gens()                 # random output
+            sage: E.gens()                 # random output              # needs eclib
             [(-1 : 1 : 1), (0 : 0 : 1)]
             sage: E.gens(algorithm='pari')    # random output
             [(5/4 : 5/8 : 1), (0 : 0 : 1)]
@@ -2309,7 +2319,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         A non-integral example::
 
             sage: E = EllipticCurve([-3/8,-2/3])
-            sage: E.gens() # random (up to sign)
+            sage: E.gens() # random (up to sign)                        # needs eclib
             [(10/9 : 29/54 : 1)]
 
         A non-minimal example::
@@ -2318,7 +2328,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E1 = E.change_weierstrass_model([1/20,0,0,0]); E1
             Elliptic Curve defined by y^2 + 8000*y = x^3 + 400*x^2 - 320000*x
              over Rational Field
-            sage: E1.gens() # random (if database not used)
+            sage: E1.gens()  # random (if database not used)            # needs eclib
             [(-400 : 8000 : 1), (0 : -8000 : 1)]
             sage: E1.gens(algorithm='pari')   #random
             [(-400 : 8000 : 1), (0 : -8000 : 1)]
@@ -2326,9 +2336,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         TESTS::
 
             sage: E = EllipticCurve('389a')
-            sage: len(E.gens())
+            sage: len(E.gens())                                         # needs eclib
             2
-            sage: E.saturation(E.gens())[1]
+            sage: E.saturation(E.gens())[1]                             # needs eclib
             1
             sage: len(E.gens(algorithm='pari'))
             2
@@ -2336,7 +2346,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             1
             sage: E = EllipticCurve([-3/8,-2/3])
             sage: P = E.lift_x(10/9)
-            sage: set(E.gens()) <= set([P,-P])
+            sage: set(E.gens()) <= set([P,-P])                          # needs eclib
             True
         """
         if proof is None:
@@ -2385,8 +2395,8 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve([-3/8, -2/3])
-            sage: gens, proved = E._compute_gens(proof=False)
-            sage: proved
+            sage: gens, proved = E._compute_gens(proof=False)           # needs eclib
+            sage: proved                                                # needs eclib
             True
 
             sage: E = EllipticCurve([-127^2,0])
@@ -2537,16 +2547,16 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a1')
-            sage: E.gens()                   # random (up to sign)
+            sage: E.gens()                   # random (up to sign)      # needs eclib
             [(0 : -1 : 1)]
-            sage: E.gens_certain()
+            sage: E.gens_certain()                                      # needs eclib
             True
 
         TESTS::
 
             sage: E = EllipticCurve('37a1')
             sage: P = E([0,-1])
-            sage: set(E.gens()) <= set([P,-P])
+            sage: set(E.gens()) <= set([P,-P])                          # needs eclib
             True
 
             sage: E = EllipticCurve([2, 4, 6, 8, 10])
@@ -2574,14 +2584,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a1')
-            sage: E.ngens()
+            sage: E.ngens()                                             # needs eclib
             1
 
             sage: E = EllipticCurve([0,0,0,877,0])
-            sage: E.ngens()
+            sage: E.ngens()                                             # needs eclib
             1
 
-            sage: print(E.mwrank('-v0 -b12 -l'))
+            sage: print(E.mwrank('-v0 -b12 -l'))                        # needs eclib
             Curve [0,0,0,877,0] :   Rank = 1
             Generator 1 is [29604565304828237474403861024284371796799791624792913256602210:-256256267988926809388776834045513089648669153204356603464786949:490078023219787588959802933995928925096061616470779979261000]; height 95.98037...
             Regulator = 95.980...
@@ -2605,6 +2615,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([0, 0, 1, -1, 0])
             sage: E.regulator()
             0.0511114082399688
@@ -2722,7 +2733,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: P=E(0,0)
             sage: Q=5*P; Q
             (1/4 : -5/8 : 1)
-            sage: E.saturation([Q])
+            sage: E.saturation([Q])                                                     # needs eclib
             ([(0 : 0 : 1)], 5, 0.0511114082399688)
 
         TESTS:
@@ -2731,6 +2742,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         ``v20190909``, this example would loop forever at default
         precision.  Since version ``v20210310`` it runs fine::
 
+            sage: # needs eclib
             sage: E = EllipticCurve([1, 0, 1, -977842, -372252745])
             sage: P = E([-192128125858676194585718821667542660822323528626273/336995568430319276695106602174283479617040716649, 70208213492933395764907328787228427430477177498927549075405076353624188436/195630373799784831667835900062564586429333568841391304129067339731164107, 1])
             sage: P.height()
@@ -2753,14 +2765,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: Q = E([-24108,-17791704])
             sage: R = E([-97104,-20391840])
             sage: S = E([-113288,-9969344])
-            sage: E.saturation([P,Q,R,S])
+            sage: E.saturation([P,Q,R,S])                                               # needs eclib
             ([(-19992 : 16313472 : 1), (-24108 : -17791704 : 1), (-97104 : -20391840 : 1), (-113288 : -9969344 : 1)], 1, 172.792031341679)
 
         See :issue:`34029`.  With eclib versions prior to 20220621 this failed to saturate::
 
             sage: E = EllipticCurve([0, 0, 0, -17607, -889490])
             sage: Q = E([-82,54])
-            sage: E.saturation([2*Q], max_prime=10)
+            sage: E.saturation([2*Q], max_prime=10)                                     # needs eclib
             ([(-82 : 54 : 1)], 2, 2.36570863272098)
         """
         if not isinstance(points, list):
@@ -2818,6 +2830,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve("11a")
             sage: E.CPS_height_bound()
             2.8774743273580445
@@ -2888,7 +2901,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             4.825400758180918
             sage: E.silverman_height_bound(algorithm='mwrank')  # needs eclib
             4.825400758180918
-            sage: E.CPS_height_bound()
+            sage: E.CPS_height_bound()                          # needs eclib
             0.16397076103046915
         """
         if algorithm == 'default':
@@ -2944,13 +2957,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('389a1')
-            sage: E.point_search(1, verbose=False)
+            sage: E.point_search(1, verbose=False)              # needs eclib
             [(-1 : 1 : 1), (0 : 0 : 1)]
 
         Increasing the height_limit takes longer, but finds no more
         points::
 
-            sage: E.point_search(10, verbose=False)  # long time
+            sage: E.point_search(10, verbose=False)  # long time    # needs eclib
             [(-1 : 1 : 1), (0 : 0 : 1)]
 
         In fact this curve has rank 2 so no more than 2 points will ever be
@@ -2958,7 +2971,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: E.saturation(_)
+            sage: E.saturation(_)                                   # needs eclib
             ([(-1 : 1 : 1), (0 : 0 : 1)], 1, 0.152460177943144)
 
         What this shows is that if the rank is 2 then the points listed do
@@ -2966,12 +2979,12 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: E.rank()
+            sage: E.rank()                                          # needs eclib
             2
 
         If we only need one independent generator::
 
-            sage: E.point_search(5, verbose=False, rank_bound=1)
+            sage: E.point_search(5, verbose=False, rank_bound=1)    # needs eclib
             [(-2 : 0 : 1)]
         """
         # Convert logarithmic height to height
@@ -3876,10 +3889,10 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([0, -1, 1, -10, -20])
             sage: E
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
-            sage: E.modular_degree()
+            sage: E.modular_degree()                            # needs sympow
             1
             sage: E = EllipticCurve('5077a')
-            sage: E.modular_degree()
+            sage: E.modular_degree()                            # needs sympow
             1984
             sage: factor(1984)
             2^6 * 31
@@ -4009,6 +4022,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sympow
             sage: E = EllipticCurve('37a')
             sage: E.congruence_number()
             2
@@ -5645,7 +5659,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: S
             Tate-Shafarevich group for the Elliptic Curve
              defined by y^2 + y = x^3 - x over Rational Field
-            sage: S.bound_kolyvagin()
+            sage: S.bound_kolyvagin()                                                   # needs eclib
             ([2], 1)
         """
         try:
@@ -5981,7 +5995,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         The bug reported on :issue:`22719` is now fixed::
 
             sage: E = EllipticCurve("141d1")
-            sage: E.integral_points()
+            sage: E.integral_points()                                                   # needs eclib
             [(0 : -1 : 1), (2 : -2 : 1)]
         """
         xmin = pari(xmin)

--- a/src/sage/schemes/elliptic_curves/ell_tate_curve.py
+++ b/src/sage/schemes/elliptic_curves/ell_tate_curve.py
@@ -588,13 +588,13 @@ class TateCurve(SageObject):
             sage: e = EllipticCurve('130a1')
             sage: eq = e.tate_curve(5)
             sage: h = eq.padic_height(prec=10)
-            sage: P = e.gens()[0]
-            sage: h(P)
+            sage: P = e.gens()[0]                                                       # needs eclib
+            sage: h(P)                                                                  # needs eclib
             2*5^-1 + 1 + 2*5 + 2*5^2 + 3*5^3 + 3*5^6 + 5^7 + O(5^9)
 
         Check that it is a quadratic function::
 
-            sage: h(3*P)-3^2*h(P)
+            sage: h(3*P) - 3^2*h(P)                                                     # needs eclib
             O(5^9)
         """
         if not self.is_split():
@@ -643,7 +643,7 @@ class TateCurve(SageObject):
         EXAMPLES::
 
             sage: eq = EllipticCurve('130a1').tate_curve(5)
-            sage: eq.padic_regulator()
+            sage: eq.padic_regulator()                                                  # needs eclib
             2*5^-1 + 1 + 2*5 + 2*5^2 + 3*5^3 + 3*5^6 + 5^7 + 3*5^9 + 3*5^10 + 3*5^12 + 4*5^13 + 3*5^15 + 2*5^16 + 3*5^18 + 4*5^19 +  4*5^20 + 3*5^21 + 4*5^22 + O(5^23)
         """
         prec = prec + 4

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -4415,6 +4415,7 @@ class KolyvaginPoint(HeegnerPoint):
         Here the Kolyvagin point is a torsion point (since `E` has
         rank 1), and we reduce it modulo several primes.::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve('11a1'); P = E.kolyvagin_point(-7)
             sage: P.mod(3,70)  # long time (4s on sage.math, 2013)
             (1 : 2 : 1)

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -2983,7 +2983,7 @@ class HeegnerPointOnX0N(HeegnerPoint):
 
         EXAMPLES::
 
-            sage: heegner_point(389,-7,1).plot(pointsize=50)
+            sage: heegner_point(389,-7,1).plot(pointsize=50)                            # needs sage.plot
             Graphics object consisting of 1 graphics primitive
         """
         from sage.plot.all import point
@@ -6547,18 +6547,18 @@ def heegner_point_height(self, D, prec=2, check_rank=True):
     EXAMPLES::
 
         sage: E = EllipticCurve('11a')
-        sage: E.heegner_point_height(-7)
+        sage: E.heegner_point_height(-7)                                                # needs sage.graphs
         0.22227?
 
     Some higher rank examples::
 
         sage: E = EllipticCurve('389a')
-        sage: E.heegner_point_height(-7)
+        sage: E.heegner_point_height(-7)                                                # needs sage.graphs
         0
         sage: E = EllipticCurve('5077a')
-        sage: E.heegner_point_height(-7)
+        sage: E.heegner_point_height(-7)                                                # needs sage.graphs
         0
-        sage: E.heegner_point_height(-7, check_rank=False)
+        sage: E.heegner_point_height(-7, check_rank=False)                              # needs sage.graphs
         0.0000?
     """
 
@@ -6653,7 +6653,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
         sage: E = EllipticCurve('11a')
         sage: E.heegner_discriminants(50)
         [-7, -8, -19, -24, -35, -39, -40, -43]
-        sage: E.heegner_index(-7)
+        sage: E.heegner_index(-7)                                                       # needs sage.graphs
         1.00000?
 
     ::
@@ -6661,19 +6661,19 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
         sage: E = EllipticCurve('37b')
         sage: E.heegner_discriminants(100)
         [-3, -4, -7, -11, -40, -47, -67, -71, -83, -84, -95]
-        sage: E.heegner_index(-95)          # long time (1 second)
+        sage: E.heegner_index(-95)          # long time (1 second)                      # needs sage.graphs
         2.00000?
 
     This tests doing direct computation of the Mordell-Weil group.
 
     ::
 
-        sage: EllipticCurve('675b').heegner_index(-11)
+        sage: EllipticCurve('675b').heegner_index(-11)                                  # needs sage.graphs
         3.0000?
 
     Currently discriminants -3 and -4 are not supported::
 
-        sage: E.heegner_index(-3)
+        sage: E.heegner_index(-3)                                                       # needs sage.graphs
         Traceback (most recent call last):
         ...
         ArithmeticError: Discriminant (=-3) must not be -3 or -4.
@@ -6681,7 +6681,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
     The curve 681b returns the true index, which is `3`::
 
         sage: E = EllipticCurve('681b')
-        sage: I = E.heegner_index(-8); I
+        sage: I = E.heegner_index(-8); I                                                # needs sage.graphs
         3.0000?
 
     In fact, whenever the returned index has a denominator of
@@ -6695,27 +6695,27 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
     the regulator of the twist::
 
         sage: E = EllipticCurve([1,-1,0,-1228,-16267])
-        sage: E.heegner_index(-8)
+        sage: E.heegner_index(-8)                                                       # needs sage.graphs
         Traceback (most recent call last):
         ...
         RuntimeError: ...
 
     However when we search higher, we find the points we need::
 
-        sage: E.heegner_index(-8, descent_second_limit=16, check_rank=False)  # long time
+        sage: E.heegner_index(-8, descent_second_limit=16, check_rank=False)  # long time, needs sage.graphs
         2.00000?
 
     Two higher rank examples (of ranks 2 and 3)::
 
         sage: E = EllipticCurve('389a')
-        sage: E.heegner_index(-7)
+        sage: E.heegner_index(-7)                                                       # needs sage.graphs
         +Infinity
         sage: E = EllipticCurve('5077a')
-        sage: E.heegner_index(-7)
+        sage: E.heegner_index(-7)                                                       # needs sage.graphs
         +Infinity
-        sage: E.heegner_index(-7, check_rank=False)
+        sage: E.heegner_index(-7, check_rank=False)                                     # needs sage.graphs
         0.001?
-        sage: E.heegner_index(-7, check_rank=False).lower() == 0
+        sage: E.heegner_index(-7, check_rank=False).lower() == 0                        # needs sage.graphs
         True
     """
     if not self.satisfies_heegner_hypothesis(D):
@@ -6866,7 +6866,7 @@ def heegner_index_bound(self, D=0, prec=5, max_height=None):
     EXAMPLES::
 
         sage: E = EllipticCurve('11a1')
-        sage: E.heegner_index_bound()
+        sage: E.heegner_index_bound()                                                   # needs sage.graphs
         ([2], -7, 2)
     """
     from .ell_rational_field import _MAX_HEIGHT

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -3788,7 +3788,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             0.150298370947295
             sage: P.height()
             0.0375745927368238
-            sage: E.heegner_index(-8)
+            sage: E.heegner_index(-8)                                                   # needs eclib
             2.0000?
             sage: E.torsion_order()
             1
@@ -4141,7 +4141,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
-            sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67); P.index()
+            sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67); P.index()      # needs eclib
             6
         """
         if self.conductor() == 1:
@@ -4191,6 +4191,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A rank 1 curve::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.point_exact()
             (6 : -15 : 1)
@@ -4203,12 +4204,14 @@ class KolyvaginPoint(HeegnerPoint):
 
         A rank 0 curve::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a1'); P = E.kolyvagin_point(-7)
             sage: P.point_exact()
             (-1/2*sqrt_minus_7 + 1/2 : -2*sqrt_minus_7 - 2 : 1)
 
         A rank 2 curve::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('389a1'); P = E.kolyvagin_point(-7)
             sage: P.point_exact()
             (0 : 1 : 0)
@@ -4334,6 +4337,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A Kolyvagin point on a rank 1 curve::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.trace_to_real_numerical()
             (1.61355529131986 : -2.18446840788880 : 1.00000000000000)
@@ -4360,6 +4364,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('43a'); P = E.heegner_point(-20).kolyvagin_point()
             sage: PP = P.numerical_approx(); PP
             (0.000000000000000 : -1.00000000000000 : 1.00000000000000)
@@ -4396,6 +4401,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A Kolyvagin point on a rank 1 curve::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.mod(2)
             (1 : 1 : 1)
@@ -5684,11 +5690,12 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     A rank 1 example::
 
-        sage: kolyvagin_reduction_data(EllipticCurve('37a1'), 3)
+        sage: kolyvagin_reduction_data(EllipticCurve('37a1'), 3)                        # needs eclib
         (17, -7, 1, 52)
 
     A rank 3 example::
 
+        sage: # needs eclib
         sage: kolyvagin_reduction_data(EllipticCurve('5077a1'), 3)
         (11, -47, 5, 4234)
         sage: H = heegner_points(5077, -47)
@@ -5703,6 +5710,7 @@ def kolyvagin_reduction_data(E, q, first_only=True):
     working in a space of dimension 293060 (so prohibitive at
     present)::
 
+        sage: # needs eclib
         sage: E = elliptic_curves.rank(4)[0]
         sage: kolyvagin_reduction_data(E,3)              # long time
         (11, -71, 7, 293060)
@@ -5712,19 +5720,19 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     The first rank 2 example::
 
-        sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3)
+        sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3)                        # needs eclib
         (5, -7, 1, 130)
-        sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3, first_only=False)
+        sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3, first_only=False)      # needs eclib
         (5, 17, -7, 1, 130, 520)
 
     A large `q = 7`::
 
-        sage: kolyvagin_reduction_data(EllipticCurve('1143c1'), 7, first_only=False)
+        sage: kolyvagin_reduction_data(EllipticCurve('1143c1'), 7, first_only=False)    # needs eclib
         (13, 83, -59, 3, 1536, 10496)
 
     Additive reduction::
 
-        sage: kolyvagin_reduction_data(EllipticCurve('2350g1'), 5, first_only=False)
+        sage: kolyvagin_reduction_data(EllipticCurve('2350g1'), 5, first_only=False)    # needs eclib
         (19, 239, -311, 19, 6480, 85680)
     """
     from .ell_generic import EllipticCurve_generic
@@ -6457,6 +6465,7 @@ def kolyvagin_point(self, D, c=ZZ(1), check=True):
 
     EXAMPLES::
 
+        sage: # needs eclib
         sage: E = EllipticCurve('37a1')
         sage: P = E.kolyvagin_point(-67); P
         Kolyvagin point of discriminant -67 on elliptic curve of conductor 37
@@ -6970,7 +6979,7 @@ def _heegner_index_in_EK(self, D):
     We compute the index for a rank 2 curve and found that it is 2::
 
         sage: E = EllipticCurve('389a')
-        sage: E._heegner_index_in_EK(-7)
+        sage: E._heegner_index_in_EK(-7)                                                # needs eclib
         2
 
     We explicitly verify in the above example that indeed that

--- a/src/sage/schemes/elliptic_curves/isogeny_class.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_class.py
@@ -102,6 +102,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.groups
             sage: E = EllipticCurve('990j1')
             sage: iso = E.isogeny_class(order='lmfdb') # orders lexicographically on a-invariants
             sage: iso[2] == E # indirect doctest
@@ -124,6 +125,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.groups
             sage: E = EllipticCurve('990j1')
             sage: iso = E.isogeny_class(order='lmfdb') # orders lexicographically on a-invariants
             sage: iso.index(E.short_weierstrass_model())
@@ -396,6 +398,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: isocls = EllipticCurve('15a3').isogeny_class()
             sage: G = isocls.graph()
             sage: sorted(G._pos.items())
@@ -512,6 +515,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.groups
             sage: isocls = EllipticCurve('15a1').isogeny_class()
             sage: print("\n".join(repr(C) for C in isocls.curves))
             Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 - 10*x - 10 over Rational Field
@@ -965,6 +969,7 @@ class IsogenyClass_EC_NumberField(IsogenyClass_EC):
 
         EXAMPLES::
 
+            sage: # needs sage.groups
             sage: isocls = EllipticCurve('1225h1').isogeny_class('database')
             sage: isocls._mat
             sage: isocls._compute_matrix(); isocls._mat

--- a/src/sage/schemes/elliptic_curves/isogeny_class.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_class.py
@@ -774,6 +774,7 @@ class IsogenyClass_EC_NumberField(IsogenyClass_EC):
 
         Check that :issue:`19030` is fixed (codomains of reverse isogenies were wrong)::
 
+            sage: x = polygen(QQ, 'x')
             sage: K.<i> = NumberField(x^2 + 1)
             sage: E = EllipticCurve([1, i + 1, 1, -72*i + 8, 95*i + 146])
             sage: C = E.isogeny_class()
@@ -1195,8 +1196,9 @@ def isogeny_degrees_cm(E, verbose=False):
 
     Check that :issue:`36780` is fixed::
 
-        sage: L5.<r5> = NumberField(x^2-5)
-        sage: E = EllipticCurve(L5,[0,-4325477943600 *r5-4195572876000])
+        sage: x = polygen(QQ)
+        sage: L5.<r5> = NumberField(x^2 - 5)
+        sage: E = EllipticCurve(L5, [0, -4325477943600*r5 - 4195572876000])
         sage: from sage.schemes.elliptic_curves.isogeny_class import isogeny_degrees_cm
         sage: isogeny_degrees_cm(E)
         [3, 5]
@@ -1404,6 +1406,7 @@ def possible_isogeny_degrees(E, algorithm='Billerey', max_l=None,
 
     A higher degree example (LMFDB curve 5.5.170701.1-4.1-b1)::
 
+        sage: x = polygen(QQ)
         sage: K.<a> = NumberField(x^5 - x^4 - 6*x^3 + 4*x + 1)
         sage: E = EllipticCurve(K, [a^3 - a^2 - 5*a + 1, a^4 - a^3 - 5*a^2 - a + 1,
         ....:                       -a^4 + 2*a^3 + 5*a^2 - 5*a - 3, a^4 - a^3 - 5*a^2 - a,
@@ -1417,6 +1420,7 @@ def possible_isogeny_degrees(E, algorithm='Billerey', max_l=None,
 
     LMFDB curve 4.4.8112.1-108.1-a5::
 
+        sage: x = polygen(QQ)
         sage: K.<a> = NumberField(x^4 - 5*x^2 + 3)
         sage: E = EllipticCurve(K, [a^2 - 2, -a^2 + 3, a^2 - 2, -50*a^2 + 35, 95*a^2 - 67])
         sage: possible_isogeny_degrees(E, exact=False, algorithm='Billerey')            # long time (6.5s)

--- a/src/sage/schemes/elliptic_curves/kraus.py
+++ b/src/sage/schemes/elliptic_curves/kraus.py
@@ -794,7 +794,7 @@ def check_Kraus_global(c4, c6, assume_nonsingular=False, debug=False):
 
     TESTS (see :issue:`17295`)::
 
-        sage: # needs sage.rings.number_field
+        sage: # needs sage.groups sage.rings.number_field
         sage: K.<a> = NumberField(x^3 - 7*x - 5)
         sage: E = EllipticCurve([a, 0, 1, 2*a^2 + 5*a + 3, -a^2 - 3*a - 2])
         sage: assert E.conductor().norm() == 8

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -289,11 +289,11 @@ class Lseries_ell(SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a')
-            sage: E.lseries().zeros(2)
+            sage: E.lseries().zeros(2)                                  # needs lcalc
             [0.000000000, 5.00317001]
 
-            sage: a = E.lseries().zeros(20)             # long time
-            sage: point([(1,x) for x in a])             # graph  (long time)
+            sage: a = E.lseries().zeros(20)             # long time     # needs lcalc
+            sage: point([(1,x) for x in a])             # long time     # needs lcalc sage.plot
             Graphics object consisting of 1 graphics primitive
 
         AUTHORS: Uses Rubinstein's L-functions calculator.
@@ -326,7 +326,7 @@ class Lseries_ell(SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a')
-            sage: E.lseries().zeros_in_interval(6, 10, 0.1)      # long time
+            sage: E.lseries().zeros_in_interval(6, 10, 0.1)      # long time, needs lcalc
             [(6.87039122, 0.248922780), (8.01433081, -0.140168533), (9.93309835, -0.129943029)]
         """
         from sage.lfunctions.lcalc import lcalc
@@ -357,7 +357,7 @@ class Lseries_ell(SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a')
-            sage: E.lseries().values_along_line(1, 0.5 + 20*I, 5)
+            sage: E.lseries().values_along_line(1, 0.5 + 20*I, 5)       # needs lcalc
             [(0.500000000, ...),
              (0.400000000 + 4.00000000*I, 3.31920245 - 2.60028054*I),
              (0.300000000 + 8.00000000*I, -0.886341185 - 0.422640337*I),
@@ -393,6 +393,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs lcalc
             sage: E = EllipticCurve('37a')
             sage: vals = E.lseries().twist_values(1, -12, -4)
             sage: vals[0][0]
@@ -448,7 +449,7 @@ class Lseries_ell(SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a')
-            sage: E.lseries().twist_zeros(3, -4, -3)         # long time
+            sage: E.lseries().twist_zeros(3, -4, -3)         # long time, needs lcalc
             {-4: [1.60813783, 2.96144840, 3.89751747], -3: [2.06170900, 3.48216881, 4.45853219]}
         """
         from sage.lfunctions.lcalc import lcalc
@@ -782,6 +783,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve([0, -1, 1, -10, -20])   # 11A  = X_0(11)
             sage: E.lseries().L1_vanishes()
             False

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -818,6 +818,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.graphs
             sage: E = EllipticCurve([0, -1, 1, -10, -20])   # 11A  = X_0(11)
             sage: E.lseries().L_ratio()
             1/5
@@ -842,6 +843,7 @@ class Lseries_ell(SageObject):
 
         See :issue:`3651` and :issue:`15299`::
 
+            sage: # needs sage.graphs
             sage: EllipticCurve([0,0,0,-193^2,0]).sha().an()
             4
             sage: EllipticCurve([1, 0, 1, -131, 558]).sha().an()  # long time

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -173,7 +173,7 @@ class Lseries_ell(SageObject):
             return L
 
         if algorithm == 'gp':
-            from sage.lfunctions.all import Dokchitser
+            from sage.lfunctions.dokchitser import Dokchitser
             key = (prec, max_imaginary_part, max_asymp_coeffs)
             try:
                 return self.__dokchitser[key]

--- a/src/sage/schemes/elliptic_curves/saturation.py
+++ b/src/sage/schemes/elliptic_curves/saturation.py
@@ -375,6 +375,7 @@ class EllipticCurveSaturator(SageObject):
 
         See :issue:`27387`::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - x - 26)
             sage: E = EllipticCurve([a, 1 - a, 0, 93 - 16*a, 3150 - 560*a])
             sage: P = E([65 - 35*a/3, (959*a-5377)/9])
@@ -390,6 +391,7 @@ class EllipticCurveSaturator(SageObject):
         A CM example where large sieving primes are needed (LMFDB
         label 2.0.3.1-50625.1-CMb2)::
 
+            sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - x + 1)
             sage: E = EllipticCurve(K, [0, 0, 1, -750, 7906])
             sage: E.has_rational_cm()

--- a/src/sage/schemes/elliptic_curves/sha_tate.py
+++ b/src/sage/schemes/elliptic_curves/sha_tate.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
+# sage.doctest: needs sage.graphs
 r"""
 Tate-Shafarevich group
 

--- a/src/sage/schemes/plane_conics/con_number_field.py
+++ b/src/sage/schemes/plane_conics/con_number_field.py
@@ -34,6 +34,7 @@ class ProjectiveConic_number_field(ProjectiveConic_field):
 
     EXAMPLES::
 
+        sage: x = polygen(QQ, 'x')
         sage: K.<a> = NumberField(x^3 - 2, 'a')
         sage: P.<X, Y, Z> = K[]
         sage: Conic(X^2 + Y^2 - a*Z^2)


### PR DESCRIPTION
- **src/sage/schemes/elliptic_curves: Define x in some doctests**
- **src/sage/rings/finite_rings/element_pari_ffelt.pyx: Use try..except for import from sage.libs.gap**
- **src/sage/schemes/elliptic_curves: Add # needs**
- **pkgs/sagemath-schemes: Add sage.lfunctions**
- **src/sage/features/sympow.py: Make sympow a JoinFeature**
- **src/sage/schemes: Remove import from sage.lfunctions.all**
- **src/.relint.yml (namespace_pkg_all_import), src/sage/misc/replace_dot_all.py: Add sage.lfunctions**
- **src/sage/schemes/elliptic_curves: Add # needs**
- **pkgs/sagemath-modules/pyproject.toml.m4: Declare extra fpylll**
- **pkgs/sagemath-schemes/pyproject.toml.m4: Declare extras eclib, fpylll, sympow**
- **pkgs/sagemath-eclib/known-test-failures.json: New**
