### PR TITLE
pkgs/sagemath-polyhedra: Modularization fixes

### DIFF
--- a/pkgs/sagemath-graphs/setup.py
+++ b/pkgs/sagemath-graphs/setup.py
@@ -9,4 +9,5 @@ from sage_setup import sage_setup
 
 sage_setup(['sagemath-graphs'],
            spkgs=['boost_cropped', 'planarity', 'rw'],
-           package_data={'sage.ext_data.graphs': ['**']})
+           package_data={'sage.ext_data.graphs': ['**'],
+                         'sage.ext_data.kenzo': ['**']})

--- a/pkgs/sagemath-polyhedra/known-test-failures--standard.json
+++ b/pkgs/sagemath-polyhedra/known-test-failures--standard.json
@@ -90,6 +90,9 @@
     "sage.arith.srange": {
         "ntests": 77
     },
+    "sage.calculus.functional": {
+        "ntests": 1
+    },
     "sage.calculus.interpolation": {
         "ntests": 67
     },
@@ -280,8 +283,7 @@
         "ntests": 17
     },
     "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 96
+        "ntests": 1
     },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
@@ -341,12 +343,10 @@
         "ntests": 141
     },
     "sage.categories.filtered_algebras": {
-        "failed": true,
         "ntests": 5
     },
     "sage.categories.filtered_algebras_with_basis": {
-        "failed": true,
-        "ntests": 63
+        "ntests": 53
     },
     "sage.categories.filtered_hopf_algebras_with_basis": {
         "ntests": 17
@@ -366,7 +366,7 @@
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "failed": true,
-        "ntests": 234
+        "ntests": 203
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -382,7 +382,7 @@
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
         "failed": true,
-        "ntests": 178
+        "ntests": 43
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "failed": true,
@@ -550,11 +550,9 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 118
+        "ntests": 110
     },
     "sage.categories.lie_algebras_with_basis": {
-        "failed": true,
         "ntests": 19
     },
     "sage.categories.lie_conformal_algebras": {
@@ -851,7 +849,8 @@
         "ntests": 45
     },
     "sage.coding.linear_code": {
-        "ntests": 404
+        "failed": true,
+        "ntests": 0
     },
     "sage.coding.linear_code_no_metric": {
         "ntests": 249
@@ -1382,7 +1381,7 @@
         "ntests": 1
     },
     "sage.doctest.external": {
-        "ntests": 42
+        "ntests": 46
     },
     "sage.doctest.fixtures": {
         "ntests": 59
@@ -1453,6 +1452,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
     "sage.features.ecm": {
         "ntests": 4
     },
@@ -1488,6 +1490,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -1603,14 +1608,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 156
+        "ntests": 158
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 141
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "ntests": 81
@@ -1636,7 +1641,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 244
+        "ntests": 245
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1718,14 +1723,12 @@
         "ntests": 57
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "failed": true,
-        "ntests": 59
+        "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
-        "failed": true,
         "ntests": 659
     },
     "sage.geometry.linear_expression": {
@@ -1735,7 +1738,7 @@
         "ntests": 110
     },
     "sage.geometry.palp_normal_form": {
-        "ntests": 15
+        "ntests": 22
     },
     "sage.geometry.point_collection": {
         "ntests": 111
@@ -1774,7 +1777,6 @@
         "ntests": 144
     },
     "sage.geometry.polyhedron.base2": {
-        "failed": true,
         "ntests": 96
     },
     "sage.geometry.polyhedron.base3": {
@@ -1854,7 +1856,7 @@
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
-        "ntests": 6
+        "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
         "failed": true,
@@ -1919,7 +1921,7 @@
         "ntests": 86
     },
     "sage.graphs.base.graph_backends": {
-        "ntests": 85
+        "ntests": 87
     },
     "sage.graphs.base.overview": {
         "ntests": 1
@@ -1990,7 +1992,7 @@
     },
     "sage.graphs.generators.distance_regular": {
         "failed": true,
-        "ntests": 166
+        "ntests": 165
     },
     "sage.graphs.generators.families": {
         "failed": true,
@@ -2003,8 +2005,7 @@
         "ntests": 26
     },
     "sage.graphs.generators.random": {
-        "failed": true,
-        "ntests": 195
+        "ntests": 193
     },
     "sage.graphs.generators.smallgraphs": {
         "failed": true,
@@ -2015,7 +2016,7 @@
     },
     "sage.graphs.generic_graph": {
         "failed": true,
-        "ntests": 3862
+        "ntests": 3826
     },
     "sage.graphs.generic_graph_pyx": {
         "ntests": 139
@@ -2025,13 +2026,13 @@
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1185
+        "ntests": 1186
     },
     "sage.graphs.graph_coloring": {
         "ntests": 160
     },
     "sage.graphs.graph_database": {
-        "ntests": 3
+        "ntests": 50
     },
     "sage.graphs.graph_decompositions.bandwidth": {
         "ntests": 14
@@ -2077,7 +2078,7 @@
         "ntests": 198
     },
     "sage.graphs.graph_list": {
-        "ntests": 54
+        "ntests": 58
     },
     "sage.graphs.graph_plot": {
         "ntests": 161
@@ -2094,6 +2095,9 @@
     "sage.graphs.independent_sets": {
         "ntests": 56
     },
+    "sage.graphs.isgci": {
+        "ntests": 83
+    },
     "sage.graphs.isoperimetric_inequalities": {
         "ntests": 25
     },
@@ -2105,7 +2109,7 @@
     },
     "sage.graphs.matching": {
         "failed": true,
-        "ntests": 197
+        "ntests": 184
     },
     "sage.graphs.matchpoly": {
         "ntests": 57
@@ -2130,7 +2134,7 @@
     },
     "sage.graphs.strongly_regular_db": {
         "failed": true,
-        "ntests": 305
+        "ntests": 312
     },
     "sage.graphs.traversals": {
         "ntests": 222
@@ -2151,7 +2155,7 @@
         "ntests": 123
     },
     "sage.groups.abelian_gps.abelian_group": {
-        "ntests": 341
+        "ntests": 343
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 32
@@ -2217,7 +2221,6 @@
         "ntests": 192
     },
     "sage.groups.finitely_presented": {
-        "failed": true,
         "ntests": 380
     },
     "sage.groups.finitely_presented_named": {
@@ -2387,7 +2390,7 @@
     },
     "sage.groups.perm_gps.permgroup": {
         "failed": true,
-        "ntests": 1008
+        "ntests": 1005
     },
     "sage.groups.perm_gps.permgroup_element": {
         "ntests": 402
@@ -2396,7 +2399,6 @@
         "ntests": 90
     },
     "sage.groups.perm_gps.permgroup_named": {
-        "failed": true,
         "ntests": 553
     },
     "sage.groups.perm_gps.symgp_conjugacy_class": {
@@ -2459,7 +2461,7 @@
     },
     "sage.interfaces.gap": {
         "failed": true,
-        "ntests": 204
+        "ntests": 201
     },
     "sage.interfaces.gap3": {
         "ntests": 35
@@ -2468,6 +2470,9 @@
         "failed": true,
         "ntests": 15
     },
+    "sage.interfaces.genus2reduction": {
+        "ntests": 23
+    },
     "sage.interfaces.gnuplot": {
         "ntests": 1
     },
@@ -2475,7 +2480,7 @@
         "ntests": 142
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.jmoldata": {
         "ntests": 26
@@ -2519,7 +2524,7 @@
     },
     "sage.knots.link": {
         "failed": true,
-        "ntests": 582
+        "ntests": 562
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2583,7 +2588,6 @@
         "ntests": 22
     },
     "sage.libs.mpmath.utils": {
-        "failed": true,
         "ntests": 57
     },
     "sage.libs.ntl.error": {
@@ -2709,7 +2713,6 @@
         "ntests": 873
     },
     "sage.matrix.matrix1": {
-        "failed": true,
         "ntests": 457
     },
     "sage.matrix.matrix2": {
@@ -2752,7 +2755,7 @@
     },
     "sage.matrix.matrix_integer_dense": {
         "failed": true,
-        "ntests": 675
+        "ntests": 667
     },
     "sage.matrix.matrix_integer_dense_hnf": {
         "ntests": 125
@@ -2877,7 +2880,7 @@
         "ntests": 677
     },
     "sage.matroids.matroid": {
-        "ntests": 1003
+        "ntests": 1007
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2982,8 +2985,7 @@
         "ntests": 32
     },
     "sage.misc.functional": {
-        "failed": true,
-        "ntests": 319
+        "ntests": 315
     },
     "sage.misc.gperftools": {
         "ntests": 17
@@ -3121,7 +3123,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
-        "ntests": 330
+        "ntests": 326
     },
     "sage.misc.search": {
         "ntests": 4
@@ -3174,10 +3176,6 @@
     },
     "sage.modular.modsym.apply": {
         "ntests": 6
-    },
-    "sage.modular.pollack_stevens.dist": {
-        "failed": true,
-        "ntests": 168
     },
     "sage.modules.complex_double_vector": {
         "ntests": 2
@@ -3277,7 +3275,7 @@
         "ntests": 45
     },
     "sage.modules.vector_numpy_integer_dense": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.modules.vector_rational_dense": {
         "ntests": 45
@@ -3292,8 +3290,7 @@
         "ntests": 184
     },
     "sage.modules.with_basis.indexed_element": {
-        "failed": true,
-        "ntests": 174
+        "ntests": 168
     },
     "sage.modules.with_basis.invariant": {
         "failed": true,
@@ -3799,11 +3796,9 @@
         "ntests": 300
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "failed": true,
         "ntests": 344
     },
     "sage.rings.finite_rings.finite_field_constructor": {
-        "failed": true,
         "ntests": 126
     },
     "sage.rings.finite_rings.finite_field_givaro": {
@@ -3888,8 +3883,7 @@
         "ntests": 7
     },
     "sage.rings.function_field.function_field": {
-        "failed": true,
-        "ntests": 184
+        "ntests": 168
     },
     "sage.rings.function_field.function_field_rational": {
         "failed": true,
@@ -3942,7 +3936,6 @@
         "ntests": 313
     },
     "sage.rings.integer": {
-        "failed": true,
         "ntests": 1169
     },
     "sage.rings.integer_fake.pxd": {
@@ -3972,7 +3965,6 @@
         "ntests": 5
     },
     "sage.rings.morphism": {
-        "failed": true,
         "ntests": 599
     },
     "sage.rings.multi_power_series_ring": {
@@ -4226,11 +4218,11 @@
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 583
+        "ntests": 580
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 515
+        "ntests": 511
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "ntests": 15
@@ -4246,10 +4238,6 @@
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
         "ntests": 142
-    },
-    "sage.rings.polynomial.omega": {
-        "failed": true,
-        "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
         "failed": true,
@@ -4279,7 +4267,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2619
+        "ntests": 2614
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 219
@@ -4302,7 +4290,7 @@
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
         "failed": true,
-        "ntests": 503
+        "ntests": 499
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
         "ntests": 151
@@ -4383,11 +4371,10 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1334
+        "ntests": 1346
     },
     "sage.rings.qqbar_decorators": {
-        "failed": true,
-        "ntests": 14
+        "ntests": 7
     },
     "sage.rings.quotient_ring": {
         "ntests": 204
@@ -4410,7 +4397,6 @@
         "ntests": 299
     },
     "sage.rings.real_double_element_gsl": {
-        "failed": true,
         "ntests": 145
     },
     "sage.rings.real_field": {
@@ -4424,7 +4410,7 @@
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 907
+        "ntests": 899
     },
     "sage.rings.real_mpfr": {
         "failed": true,
@@ -4435,7 +4421,6 @@
         "ntests": 192
     },
     "sage.rings.ring_extension": {
-        "failed": true,
         "ntests": 442
     },
     "sage.rings.ring_extension_conversion": {
@@ -4520,7 +4505,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 382
+        "ntests": 374
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
@@ -4610,11 +4595,9 @@
         "ntests": 199
     },
     "sage.schemes.toric.divisor": {
-        "failed": true,
         "ntests": 366
     },
     "sage.schemes.toric.divisor_class": {
-        "failed": true,
         "ntests": 62
     },
     "sage.schemes.toric.fano_variety": {
@@ -4622,7 +4605,6 @@
         "ntests": 175
     },
     "sage.schemes.toric.homset": {
-        "failed": true,
         "ntests": 94
     },
     "sage.schemes.toric.library": {
@@ -4632,7 +4614,6 @@
         "ntests": 340
     },
     "sage.schemes.toric.points": {
-        "failed": true,
         "ntests": 195
     },
     "sage.schemes.toric.sheaf.constructor": {
@@ -4647,7 +4628,6 @@
         "ntests": 89
     },
     "sage.schemes.toric.variety": {
-        "failed": true,
         "ntests": 418
     },
     "sage.schemes.toric.weierstrass": {
@@ -4843,8 +4823,7 @@
         "ntests": 24
     },
     "sage.structure.sage_object": {
-        "failed": true,
-        "ntests": 88
+        "ntests": 84
     },
     "sage.structure.sequence": {
         "ntests": 183
@@ -4980,7 +4959,6 @@
         "ntests": 6
     },
     "sage.topology.simplicial_complex_examples": {
-        "failed": true,
         "ntests": 137
     },
     "sage.topology.simplicial_complex_homset": {

--- a/pkgs/sagemath-polyhedra/known-test-failures.json
+++ b/pkgs/sagemath-polyhedra/known-test-failures.json
@@ -69,7 +69,7 @@
         "ntests": 77
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.calculus.interpolation": {
         "ntests": 67
@@ -214,7 +214,6 @@
         "ntests": 2
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
         "ntests": 368
     },
     "sage.categories.crystals": {
@@ -266,8 +265,7 @@
         "ntests": 17
     },
     "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 96
+        "ntests": 1
     },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
@@ -321,12 +319,10 @@
         "ntests": 113
     },
     "sage.categories.filtered_algebras": {
-        "failed": true,
         "ntests": 5
     },
     "sage.categories.filtered_algebras_with_basis": {
-        "failed": true,
-        "ntests": 63
+        "ntests": 53
     },
     "sage.categories.filtered_hopf_algebras_with_basis": {
         "ntests": 17
@@ -345,8 +341,7 @@
         "ntests": 6
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "failed": true,
-        "ntests": 103
+        "ntests": 72
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -361,8 +356,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 172
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "failed": true,
@@ -525,11 +519,9 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
-        "failed": true,
         "ntests": 19
     },
     "sage.categories.lie_conformal_algebras": {
@@ -1153,6 +1145,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
     "sage.features.ecm": {
         "ntests": 4
     },
@@ -1188,6 +1183,9 @@
     },
     "sage.features.imagemagick": {
         "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
     },
     "sage.features.interfaces": {
         "ntests": 34
@@ -1262,7 +1260,8 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "ntests": 181
+        "failed": true,
+        "ntests": 0
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1304,14 +1303,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 154
+        "ntests": 156
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 136
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "ntests": 81
@@ -1336,7 +1335,7 @@
         "ntests": 236
     },
     "sage.functions.other": {
-        "ntests": 245
+        "ntests": 246
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1424,7 +1423,7 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "ntests": 51
+        "ntests": 7
     },
     "sage.geometry.lattice_polytope": {
         "failed": true,
@@ -1488,7 +1487,7 @@
         "ntests": 351
     },
     "sage.geometry.polyhedron.base6": {
-        "ntests": 162
+        "ntests": 163
     },
     "sage.geometry.polyhedron.base7": {
         "ntests": 122
@@ -1558,7 +1557,7 @@
         "ntests": 44
     },
     "sage.geometry.polyhedron.palp_database": {
-        "ntests": 6
+        "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
         "ntests": 187
@@ -1609,7 +1608,7 @@
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 238
+        "ntests": 240
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 26
@@ -1734,7 +1733,7 @@
         "ntests": 8
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.polymake": {
         "ntests": 187
@@ -1758,7 +1757,6 @@
         "ntests": 22
     },
     "sage.libs.mpmath.utils": {
-        "failed": true,
         "ntests": 57
     },
     "sage.matrix.action": {
@@ -1894,7 +1892,7 @@
         "ntests": 621
     },
     "sage.matroids.matroid": {
-        "ntests": 930
+        "ntests": 925
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 22
@@ -2132,7 +2130,7 @@
     },
     "sage.misc.sageinspect": {
         "failed": true,
-        "ntests": 330
+        "ntests": 326
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2213,7 +2211,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 8
+        "ntests": 11
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -2289,8 +2287,7 @@
         "ntests": 151
     },
     "sage.modules.with_basis.indexed_element": {
-        "failed": true,
-        "ntests": 166
+        "ntests": 160
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353
@@ -2388,6 +2385,7 @@
         "ntests": 19
     },
     "sage.quadratic_forms.binary_qf": {
+        "failed": true,
         "ntests": 299
     },
     "sage.quadratic_forms.constructions": {
@@ -2599,10 +2597,10 @@
         "ntests": 11
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "ntests": 15
+        "ntests": 21
     },
     "sage.rings.finite_rings.finite_field_constructor": {
-        "ntests": 17
+        "ntests": 21
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
         "ntests": 28
@@ -2617,8 +2615,7 @@
         "ntests": 539
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "failed": true,
-        "ntests": 346
+        "ntests": 326
     },
     "sage.rings.finite_rings.residue_field": {
         "ntests": 39
@@ -2652,7 +2649,7 @@
         "ntests": 7
     },
     "sage.rings.function_field.function_field": {
-        "ntests": 154
+        "ntests": 156
     },
     "sage.rings.function_field.function_field_rational": {
         "ntests": 135
@@ -2703,7 +2700,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1084
+        "ntests": 1085
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -2730,7 +2727,7 @@
     },
     "sage.rings.morphism": {
         "failed": true,
-        "ntests": 467
+        "ntests": 469
     },
     "sage.rings.multi_power_series_ring": {
         "ntests": 218
@@ -2803,7 +2800,7 @@
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 516
+        "ntests": 513
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "ntests": 275
@@ -2823,10 +2820,6 @@
         "failed": true,
         "ntests": 138
     },
-    "sage.rings.polynomial.omega": {
-        "failed": true,
-        "ntests": 121
-    },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 56
     },
@@ -2845,7 +2838,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1907
+        "ntests": 1897
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 198
@@ -2975,7 +2968,7 @@
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
@@ -2988,7 +2981,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 304
+        "ntests": 303
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,

--- a/src/sage/geometry/cone_critical_angles.py
+++ b/src/sage/geometry/cone_critical_angles.py
@@ -34,12 +34,14 @@ methods have been prefixed with an underscore.
 
 from sage.functions.trig import arccos, cos
 from sage.matrix.constructor import matrix
+from sage.misc.lazy_import import lazy_import
 from sage.misc.misc import powerset
 from sage.rings.integer_ring import ZZ
 from sage.rings.qqbar import AA
 from sage.rings.rational_field import QQ
 from sage.rings.real_double import RDF
-from sage.symbolic.constants import pi
+
+lazy_import('sage.symbolic.constants', 'pi')
 
 
 def _normalize_gevp_solution(gevp_solution):

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -679,7 +679,7 @@ class HyperplaneArrangementElement(Element):
         EXAMPLES::
 
             sage: L.<x, y> = HyperplaneArrangements(QQ)
-            sage: L(x, y, x+y-2).plot()                                                 # needs sage.plot
+            sage: L(x, y, x + y - 2).plot()                                             # needs sage.plot sage.symbolic
             Graphics object consisting of 3 graphics primitives
         """
         from sage.geometry.hyperplane_arrangement.plot import plot

--- a/src/sage/geometry/hyperplane_arrangement/plot.py
+++ b/src/sage/geometry/hyperplane_arrangement/plot.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-polyhedra
+# sage.doctest: needs sage.plot sage.symbolic
 """
 Plotting of Hyperplane Arrangements
 
@@ -57,7 +58,7 @@ EXAMPLES::
 
     sage: H3.<x,y,z> = HyperplaneArrangements(QQ)
     sage: A = H3([(1,0,0), 0], [(0,0,1), 5])
-    sage: A.plot(hyperplane_opacities=0.5, hyperplane_labels=True,                      # needs sage.plot
+    sage: A.plot(hyperplane_opacities=0.5, hyperplane_labels=True,
     ....:        hyperplane_legend=False)
     Graphics3d Object
 

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -370,7 +370,7 @@ class Polyhedron_base6(Polyhedron_base5):
             <class 'sage.plot.plot3d.base.Graphics3dGroup'>
             sage: type(Polyhedron([(0,0,0,0), (1,1,1,1)]).plot())
             <class 'sage.plot.graphics.Graphics'>
-            sage: type(Polyhedron([(0,0,0,0,0), (1,1,1,1,1)]).plot())
+            sage: type(Polyhedron([(0,0,0,0,0), (1,1,1,1,1)]).plot())                   # needs sage.symbolic
             <class 'sage.plot.graphics.Graphics'>
             sage: type(Polyhedron([(0,0,0,0), (1,1,1,1), (1,0,0,0)]).plot())
             <class 'sage.plot.graphics.Graphics'>

--- a/src/sage/geometry/toric_plotter.py
+++ b/src/sage/geometry/toric_plotter.py
@@ -16,7 +16,7 @@ EXAMPLES:
 In most cases, this module is used indirectly, e.g. ::
 
     sage: fan = toric_varieties.dP6().fan()                                             # needs palp sage.graphs
-    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot
+    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot sage.symbolic
     Graphics object consisting of 31 graphics primitives
 
 You may change default plotting options as follows::
@@ -26,12 +26,12 @@ You may change default plotting options as follows::
     sage: toric_plotter.options(show_rays=False)
     sage: toric_plotter.options("show_rays")
     False
-    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot
+    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot sage.symbolic
     Graphics object consisting of 19 graphics primitives
     sage: toric_plotter.reset_options()
     sage: toric_plotter.options("show_rays")
     True
-    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot
+    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot sage.symbolic
     Graphics object consisting of 31 graphics primitives
 """
 
@@ -134,9 +134,9 @@ class ToricPlotter(SageObject):
     plot, e.g. ::
 
         sage: fan = toric_varieties.dP6().fan()                                         # needs palp sage.graphs
-        sage: fan.plot()                                                                # needs palp sage.graphs sage.plot
+        sage: fan.plot()                                                                # needs palp sage.graphs sage.plot sage.symbolic
         Graphics object consisting of 31 graphics primitives
-        sage: print(fan.plot())                                                         # needs palp sage.graphs sage.plot
+        sage: print(fan.plot())                                                         # needs palp sage.graphs sage.plot sage.symbolic
         Graphics object consisting of 31 graphics primitives
 
     If you do want to create your own plotting function for some toric
@@ -583,14 +583,14 @@ class ToricPlotter(SageObject):
             sage: quadrant = Cone([(1,0), (0,1)])
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2, quadrant.rays())
-            sage: tp.plot_walls([quadrant])                                             # needs sage.plot
+            sage: tp.plot_walls([quadrant])                                             # needs sage.plot sage.symbolic
             Graphics object consisting of 2 graphics primitives
 
         Let's also check that the truncating polyhedron is functioning
         correctly::
 
             sage: tp = ToricPlotter({"mode": "box"}, 2, quadrant.rays())
-            sage: tp.plot_walls([quadrant])                                             # needs sage.plot
+            sage: tp.plot_walls([quadrant])                                             # needs sage.plot sage.symbolic
             Graphics object consisting of 2 graphics primitives
         """
         result = Graphics()

--- a/src/sage/graphs/generators/random.py
+++ b/src/sage/graphs/generators/random.py
@@ -2296,6 +2296,7 @@ def RandomTriangulation(n, set_position=False, k=3, seed=None):
         ...
         ValueError: The size 'k' of the outer face must be at least 3.
 
+        sage: # needs planarity
         sage: for i in range(10):
         ....:     g = graphs.RandomTriangulation(30) # random
         ....:     assert g.is_planar()

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -5724,7 +5724,7 @@ class GenericGraph(GenericGraph_pyx):
         Multi-edged and looped graphs are partially supported::
 
             sage: G = Graph({0: [1, 1]}, multiedges=True)
-            sage: G.is_planar()
+            sage: G.is_planar()                                                         # needs planarity
             True
             sage: G.is_planar(on_embedding={})
             Traceback (most recent call last):
@@ -5736,22 +5736,22 @@ class GenericGraph(GenericGraph_pyx):
             ...
             NotImplementedError: cannot compute with embeddings of
              multiple-edged or looped graphs
-            sage: G.is_planar(kuratowski=True)
+            sage: G.is_planar(kuratowski=True)                                          # needs planarity
             (True, None)
-            sage: G.is_planar(set_pos=True)
+            sage: G.is_planar(set_pos=True)                                             # needs planarity
             True
-            sage: sorted(G.get_pos().items())
+            sage: sorted(G.get_pos().items())                                           # needs planarity
             [(0, [0, 0]), (1, [0, 1])]
 
         Digraphs with multiple edges or loops or pairs of opposite arcs are
         partially supported (:issue:`35152`)::
 
             sage: D = digraphs.Complete(3)
-            sage: D.is_planar()
+            sage: D.is_planar()                                                         # needs planarity
             True
-            sage: D.is_planar(set_pos=True)
+            sage: D.is_planar(set_pos=True)                                             # needs planarity
             True
-            sage: sorted(D.get_pos().items())
+            sage: sorted(D.get_pos().items())                                           # needs planarity
             [(0, [0, 1]), (1, [1, 1]), (2, [1, 0])]
             sage: D.is_planar(on_embedding={})
             Traceback (most recent call last):
@@ -5763,17 +5763,17 @@ class GenericGraph(GenericGraph_pyx):
             ...
             NotImplementedError: cannot compute with embeddings of
              digraphs with pairs of opposite arcs
-            sage: D.is_planar(kuratowski=True)
+            sage: D.is_planar(kuratowski=True)                                          # needs planarity
             (True, None)
             sage: D.allow_multiple_edges(True)
             sage: D.add_edges(D.edges(sort=False))
             sage: D.allow_loops(True)
             sage: D.add_edges((u, u) for u in D)
-            sage: D.is_planar()
+            sage: D.is_planar()                                                         # needs planarity
             True
-            sage: D.is_planar(kuratowski=True)
+            sage: D.is_planar(kuratowski=True)                                          # needs planarity
             (True, None)
-            sage: D.is_planar(set_pos=True)
+            sage: D.is_planar(set_pos=True)                                             # needs planarity
             True
             sage: D.is_planar(set_embedding=True)
             Traceback (most recent call last):
@@ -5791,12 +5791,12 @@ class GenericGraph(GenericGraph_pyx):
             sage: G = graphs.CompleteGraph(5)
             sage: G = Graph(G, multiedges=True)
             sage: G.add_edge(0, 1)
-            sage: G.is_planar()
+            sage: G.is_planar()                                                         # needs planarity
             False
-            sage: b,k = G.is_planar(kuratowski=True)
-            sage: b
+            sage: b,k = G.is_planar(kuratowski=True)                                    # needs planarity
+            sage: b                                                                     # needs planarity
             False
-            sage: k.vertices(sort=True)
+            sage: k.vertices(sort=True)                                                 # needs planarity
             [0, 1, 2, 3, 4]
 
         TESTS:
@@ -5804,21 +5804,21 @@ class GenericGraph(GenericGraph_pyx):
         :issue:`18045`::
 
             sage: g = graphs.CompleteGraph(4)
-            sage: g.is_planar(set_embedding=True)
+            sage: g.is_planar(set_embedding=True)                                       # needs planarity
             True
             sage: emb = {0 : [2,3,1], 1: [2,3,0], 2: [1,3,0], 3:[0,1,2]}
-            sage: g.is_planar(on_embedding=emb)
+            sage: g.is_planar(on_embedding=emb)                                         # needs planarity
             False
 
         :issue:`19193`::
 
-            sage: posets.BooleanLattice(3).cover_relations_graph().is_planar()
+            sage: posets.BooleanLattice(3).cover_relations_graph().is_planar()          # needs planarity
             True
 
         :issue:`33759`::
 
             sage: G = Graph([(1, 2)])
-            sage: for set_embedding, set_pos in ((True,True), (True,False), (False, True), (False, False)):
+            sage: for set_embedding, set_pos in ((True,True), (True,False), (False, True), (False, False)):     # needs planarity
             ....:     G = Graph([(1, 2)])
             ....:     assert G.is_planar(set_embedding=set_embedding, set_pos=set_pos)
             ....:     assert (hasattr(G, '_embedding') and G._embedding is not None) == set_embedding, (set_embedding, set_pos)
@@ -5828,7 +5828,7 @@ class GenericGraph(GenericGraph_pyx):
 
             sage: G = DiGraph([[1, 2], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5],
             ....:              [3, 4], [3, 5], [4, 5], [5, 1]])
-            sage: G.is_planar()
+            sage: G.is_planar()                                 # needs planarity
             True
 
         Corner cases::
@@ -6000,7 +6000,7 @@ class GenericGraph(GenericGraph_pyx):
 
         Corner cases::
 
-            sage: graphs.EmptyGraph().is_circular_planar()
+            sage: graphs.EmptyGraph().is_circular_planar()                                                      # needs planarity
             True
             sage: Graph(1).is_circular_planar()
             True
@@ -6512,9 +6512,9 @@ class GenericGraph(GenericGraph_pyx):
             Traceback (most recent call last):
             ...
             NotImplementedError: cannot work with embeddings of non-simple graphs
-            sage: G.to_simple().genus()
+            sage: G.to_simple().genus()                                                 # needs planarity
             0
-            sage: G.genus(set_embedding=False)
+            sage: G.genus(set_embedding=False)                                          # needs planarity
             0
             sage: G.genus(maximal=True, set_embedding=False)
             Traceback (most recent call last):

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -7486,8 +7486,8 @@ class Graph(GenericGraph):
 
         Stellating in a face of the octahedral graph is not circumscribable::
 
-            sage: f = set(flatten(choice(O.faces())))
-            sage: O.add_edges([[6, i] for i in f])
+            sage: f = set(flatten(choice(O.faces())))                                   # needs planarity
+            sage: O.add_edges([[6, i] for i in f])                                      # needs planarity
             sage: O.is_circumscribable()                                                # needs planarity sage.numerical.mip
             False
 
@@ -7595,7 +7595,7 @@ class Graph(GenericGraph):
             True
 
             sage: C = graphs.CubeGraph(3)
-            sage: C.is_inscribable()                                                    # needs sage.numerical.mip
+            sage: C.is_inscribable()                                                    # needs planarity sage.numerical.mip
             True
 
         Cutting off a vertex from the cube yields an uninscribable graph::
@@ -7606,7 +7606,7 @@ class Graph(GenericGraph):
             sage: C.add_edges(Combinations(triangle, 2))
             sage: C.add_edges(zip(triangle, C.neighbors(v)))
             sage: C.delete_vertex(v)
-            sage: C.is_inscribable()                                                    # needs sage.numerical.mip
+            sage: C.is_inscribable()                                                    # needs planarity sage.numerical.mip
             False
 
         Breaking a face of the cube yields an uninscribable graph::
@@ -7614,7 +7614,7 @@ class Graph(GenericGraph):
             sage: C = graphs.CubeGraph(3)
             sage: face = choice(C.faces())
             sage: C.add_edge([face[0][0], face[2][0]])
-            sage: C.is_inscribable()                                                    # needs sage.numerical.mip
+            sage: C.is_inscribable()                                                    # needs planarity sage.numerical.mip
             False
 
 

--- a/src/sage/graphs/isgci.py
+++ b/src/sage/graphs/isgci.py
@@ -584,7 +584,7 @@ class GraphClass(SageObject, CachedRepresentation):
             True
             sage: graphs.CompleteGraph(4) in graph_classes.Perfect
             True
-            sage: graphs.CompleteGraph(4) in graph_classes.Planar
+            sage: graphs.CompleteGraph(4) in graph_classes.Planar                       # needs planarity
             True
             sage: graphs.CompleteGraph(4) in graph_classes.Split
             True

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -912,6 +912,7 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
 
     Providing with a wrong matching::
 
+        sage: # needs networkx
         sage: G = graphs.CompleteGraph(6)
         sage: M = Graph(G.matching())
         sage: M.add_edges([(0, 1), (0, 2)])

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -1774,18 +1774,18 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
              3: [(f1 - 1, f2 - 1, f3 - 1)],
              4: []}
             sage: G = FreeGroup(2)/[2*(1,2,-1,-2)]
-            sage: G.characteristic_varieties()
+            sage: G.characteristic_varieties()                                          # needs sage.libs.singular
             {0: Ideal (0) of Multivariate Laurent Polynomial Ring in f1, f2 over Rational Field,
              1: Ideal (f2 - 1, f1 - 1) of Multivariate Laurent Polynomial Ring in f1, f2 over Rational Field,
              2: Ideal (f2 - 1, f1 - 1) of Multivariate Laurent Polynomial Ring in f1, f2 over Rational Field,
              3: Ideal (1) of Multivariate Laurent Polynomial Ring in f1, f2 over Rational Field}
-            sage: G.characteristic_varieties(ring=ZZ)
+            sage: G.characteristic_varieties(ring=ZZ)                                   # needs sage.libs.singular
             {0: Ideal (0) of Multivariate Laurent Polynomial Ring in f1, f2 over Integer Ring,
              1: Ideal (2*f2 - 2, 2*f1 - 2) of Multivariate Laurent Polynomial Ring in f1, f2 over Integer Ring,
              2: Ideal (f2 - 1, f1 - 1) of Multivariate Laurent Polynomial Ring in f1, f2 over Integer Ring,
              3: Ideal (1) of Multivariate Laurent Polynomial Ring in f1, f2 over Integer Ring}
             sage: G = FreeGroup(2)/[(1,2,1,-2,-1,-2)]
-            sage: G.characteristic_varieties()
+            sage: G.characteristic_varieties()                                          # needs sage.libs.singular
             {0: Ideal (0) of Univariate Laurent Polynomial Ring in f1 over Rational Field,
              1: Ideal (-1 + 2*f1 - 2*f1^2 + f1^3) of Univariate Laurent Polynomial Ring in f1 over Rational Field,
              2: Ideal (1) of Univariate Laurent Polynomial Ring in f1 over Rational Field}
@@ -1795,10 +1795,10 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular
             {0: [-1 + F1, 1 + F1, 1 - F1 + F1^2, 1 + F1 + F1^2], 1: [1 - F1 + F1^2],  2: []}
             sage: G = FreeGroup(2)/[2 * (2, )]
-            sage: G.characteristic_varieties(groebner=True)
+            sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular
             {0: [(f1 + 1,), (f1 - 1,)], 1: [(f1 + 1,), (f1 - 1, f2 - 1)], 2: []}
             sage: G = (FreeGroup(0) / [])
-            sage: G.characteristic_varieties()
+            sage: G.characteristic_varieties()                                          # needs sage.libs.singular
             {0: Principal ideal (0) of Rational Field,
              1: Principal ideal (1) of Rational Field}
             sage: G.characteristic_varieties(groebner=True)                             # needs sage.libs.singular

--- a/src/sage/groups/matrix_gps/finitely_generated_gap.py
+++ b/src/sage/groups/matrix_gps/finitely_generated_gap.py
@@ -472,9 +472,9 @@ class FinitelyGeneratedMatrixGroup_gap(MatrixGroup_gap):
             1 + t + 2*t^2 + 3*t^3 + 4*t^4 + 5*t^5 + 7*t^6 + 8*t^7 + 10*t^8 + 12*t^9 + O(t^10)
             sage: mol.parent()
             Power Series Ring in t over Integer Ring
-            sage: mol = S3.molien_series(prec=oo); mol
+            sage: mol = S3.molien_series(prec=oo); mol                                  # needs sage.combinat
             1 + t + 2*t^2 + 3*t^3 + 4*t^4 + 5*t^5 + 7*t^6 + O(t^7)
-            sage: mol.parent()
+            sage: mol.parent()                                                          # needs sage.combinat
             Lazy Taylor Series Ring in t over Integer Ring
 
         Octahedral Group::

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -3257,8 +3257,8 @@ class ComplexReflectionGroup(PermutationGroup_unique):
 
             sage: groups.permutation.ComplexReflection(4, 1, 3).cardinality()
             384
-            sage: CP = ColoredPermutations(4, 3)
-            sage: CP.cardinality()
+            sage: CP = ColoredPermutations(4, 3)                                        # needs sage.combinat
+            sage: CP.cardinality()                                                      # needs sage.combinat
             384
         """
         if p is None:

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -245,7 +245,7 @@ class Link(SageObject):
 
         sage: L.alexander_polynomial()
         t^-3 - t^-2 + t^-1 - 1 + t - t^2 + t^3
-        sage: L.jones_polynomial()
+        sage: L.jones_polynomial()                                                      # needs sage.symbolic
         -t^10 + t^9 - t^8 + t^7 - t^6 + t^5 + t^3
         sage: L.determinant()
         7
@@ -584,7 +584,7 @@ class Link(SageObject):
 
             sage: B = BraidGroup(8)
             sage: L1 = Link(B([-1, -1, -1, -2, 1, -2, 3, -2, 5, 4]))
-            sage: H = hash(L1)
+            sage: H = hash(L1)                                                          # needs sage.libs.braiding
         """
         return hash(self.braid())
 
@@ -2589,11 +2589,13 @@ class Link(SageObject):
             s0^2*s1^-1*(s1^-1*s0)^2*s1^-1
             sage: br = K8_17r.braid(); br
             s0^-1*s1*s0^-2*s1^2*s0^-1*s1
-            sage: b.is_conjugated(br)                                                   # needs sage.libs.braiding
+
+            sage: # needs sage.libs.braiding
+            sage: b.is_conjugated(br)
             False
             sage: b == br.reverse()
             False
-            sage: b.is_conjugated(br.reverse())                                         # needs sage.libs.braiding
+            sage: b.is_conjugated(br.reverse())
             True
             sage: K8_17b = Link(b)
             sage: K8_17br = K8_17b.reverse()
@@ -4250,6 +4252,7 @@ class Link(SageObject):
         the same unoriented name (according to the note above) the option can be
         used to achieve more detailed information::
 
+            sage: # needs sage.libs.homfly
             sage: L2a1 = Link(b**2)
             sage: L2a1.get_knotinfo()
             (Series of links L2a1, <SymmetryMutant.mixed: 'x'>)

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -5661,6 +5661,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.singular
             sage: A = matrix(ZZ, 3, 3, [-8, 2, 0, 0, 1, -1, 2, 1, -95])
             sage: As = singular(A); As
             -8     2     0

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8083,8 +8083,8 @@ cdef class Matroid(SageObject):
             5 bases over Integer Ring
             sage: A.defining_ideal()._gens_constructor(A.defining_ideal().ring())
             [A0*A1, A0*A23, A1*A23, A0 + A0123, A1 + A0123, A23 + A0123]
-            sage: A23 = A.gen(0)
-            sage: A23*A23
+            sage: A23 = A.gen(0)                                                        # needs sage.libs.singular
+            sage: A23*A23                                                               # needs sage.libs.singular
             0
 
         We construct a more interesting example using the Fano matroid::

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -225,7 +225,7 @@ def decomposition(x):
         (Ambient free module of rank 2 over the principal ideal domain Integer Ring, True)
         ]
 
-        sage: # needs sage.groups
+        sage: # needs sage.schemes
         sage: G.<a,b> = DirichletGroup(20)
         sage: c = a * b
         sage: d = c.decomposition(); d

--- a/src/sage/modules/free_module_integer.py
+++ b/src/sage/modules/free_module_integer.py
@@ -409,7 +409,7 @@ class FreeModule_submodule_with_basis_integer(FreeModule_submodule_with_basis_pi
             sage: from sage.modules.free_module_integer import IntegerLattice
             sage: A = sage.crypto.gen_lattice(type='random', n=1, m=60, q=2^60, seed=42)
             sage: L = IntegerLattice(A, lll_reduce=False)
-            sage: min(v.norm().n() for v in L.reduced_basis)
+            sage: min(v.norm().n() for v in L.reduced_basis)                            # needs sage.symbolic
             4.17330740711759e15
             sage: L.LLL()
             60 x 60 dense matrix over Integer Ring (use the '.str()' method to see the entries)
@@ -417,7 +417,7 @@ class FreeModule_submodule_with_basis_integer(FreeModule_submodule_with_basis_pi
             5.19615242270663
             sage: L.BKZ(block_size=10)
             60 x 60 dense matrix over Integer Ring (use the '.str()' method to see the entries)
-            sage: min(v.norm().n() for v in L.reduced_basis)
+            sage: min(v.norm().n() for v in L.reduced_basis)                            # needs sage.symbolic
             4.12310562561766
 
         .. NOTE::
@@ -610,7 +610,7 @@ class FreeModule_submodule_with_basis_integer(FreeModule_submodule_with_basis_pi
             sage: B = L.reduced_basis
             sage: v = L.shortest_vector(update_reduced_basis=False)
             sage: L.update_reduced_basis(v)
-            sage: bool(L.reduced_basis[0].norm() < B[0].norm())
+            sage: bool(L.reduced_basis[0].norm() < B[0].norm())                         # needs sage.symbolic
             True
         """
         w = matrix(ZZ, w)

--- a/src/sage/modules/free_module_integer.py
+++ b/src/sage/modules/free_module_integer.py
@@ -430,7 +430,7 @@ class FreeModule_submodule_with_basis_integer(FreeModule_submodule_with_basis_pi
         basis = matrix(ZZ, len(basis), len(basis[0]), basis)
         basis.set_immutable()
 
-        if self.reduced_basis[0].norm() > basis[0].norm():
+        if self.reduced_basis[0].dot_product(self.reduced_basis[0]) > basis[0].dot_product(basis[0]):
             self._reduced_basis = basis
         return basis
 

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -1093,7 +1093,7 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
         Note, though, that proper handling of the ``analytic`` flag is required
         even when the path does not touch the branch cut::
 
-            sage: correct = CBF.integral(my_sqrt, 1, 2); correct
+            sage: correct = CBF.integral(my_sqrt, 1, 2); correct                        # needs sage.symbolic
             [1.21895141649746 +/- ...e-15]
             sage: RBF(integral(sqrt(x), x, 1, 2))       # long time                     # needs sage.symbolic
             [1.21895141649746 +/- ...e-15]

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1018,15 +1018,15 @@ cdef class FiniteField(Field):
             x + 1
             sage: GF(2, impl='ntl').modulus()                                           # needs sage.libs.ntl
             x + 1
-            sage: GF(2, impl='modn', modulus=x).modulus()
+            sage: GF(2, impl='modn', modulus=x).modulus()                               # needs sage.symbolics
             x
-            sage: GF(2, impl='givaro', modulus=x).modulus()                             # needs sage.libs.linbox
+            sage: GF(2, impl='givaro', modulus=x).modulus()                             # needs sage.libs.linbox sage.symbolics
             x
-            sage: GF(2, impl='ntl', modulus=x).modulus()                                # needs sage.libs.ntl
+            sage: GF(2, impl='ntl', modulus=x).modulus()                                # needs sage.libs.ntl sage.symbolics
             x
-            sage: GF(13^2, 'a', impl='givaro', modulus=x^2 + 2).modulus()               # needs sage.libs.linbox
+            sage: GF(13^2, 'a', impl='givaro', modulus=x^2 + 2).modulus()               # needs sage.libs.linbox sage.symbolics
             x^2 + 2
-            sage: GF(13^2, 'a', impl='pari_ffelt', modulus=x^2 + 2).modulus()           # needs sage.libs.pari
+            sage: GF(13^2, 'a', impl='pari_ffelt', modulus=x^2 + 2).modulus()           # needs sage.libs.pari sage.symbolics
             x^2 + 2
         """
         # Normally, this is set by the constructor of the implementation

--- a/src/sage/rings/function_field/function_field.py
+++ b/src/sage/rings/function_field/function_field.py
@@ -1264,7 +1264,7 @@ class FunctionField(Field):
             Place (1/x)
             sage: a = (5*x + 6)/(x + 15)
             sage: b = 7/x
-            sage: K.hilbert_symbol(a, b, P)
+            sage: K.hilbert_symbol(a, b, P)                                             # needs sage.libs.singular
             -1
             sage: Q = K.places()[7]; Q
             Place (x + 6)

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -1543,7 +1543,7 @@ cdef class RingHomomorphism(RingMap):
 
             sage: R.<x,y> = QQbar[]                                                     # needs sage.rings.number_field
             sage: f = R.hom([x + QQbar(I)*y^2, -y], R)                                  # needs sage.rings.number_field
-            sage: (f.inverse() * f).is_identity()                                       # needs sage.rings.number_field
+            sage: (f.inverse() * f).is_identity()                                       # needs sage.libs.singular sage.rings.number_field
             True
 
         Check that results are cached::

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -2446,12 +2446,12 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         ::
 
             sage: f = 3*x                                                               # needs sage.rings.number_field
-            sage: f.reduce([2*x, y])                                                    # needs sage.rings.number_field
+            sage: f.reduce([2*x, y])                                                    # needs sage.libs.singular sage.rings.number_field
             0
 
         ::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs sage.libs.singular sage.rings.number_field
             sage: k.<w> = CyclotomicField(3)
             sage: A.<y9,y12,y13,y15> = PolynomialRing(k)
             sage: J = [y9 + y12]
@@ -2466,7 +2466,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
 
             sage: R.<y1,y2> = PolynomialRing(Qp(5), 2, order='lex')                     # needs sage.rings.padics
             sage: G = [y1^2 + y2^2, y1*y2 + y2^2, y2^3]                                 # needs sage.rings.padics
-            sage: type((y2^3).reduce(G))                                                # needs sage.rings.padics
+            sage: type((y2^3).reduce(G))                                                # needs sage.libs.singular sage.rings.padics
             <class 'sage.rings.polynomial.multi_polynomial_element.MPolynomial_polydict'>
 
         TESTS:
@@ -2474,7 +2474,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         Verify that :issue:`34105` is fixed::
 
             sage: R.<x,y> = AA[]                                                        # needs sage.rings.number_field
-            sage: x.reduce(R.zero_ideal())                                              # needs sage.rings.number_field
+            sage: x.reduce(R.zero_ideal())                                              # needs sage.libs.singular sage.rings.number_field
             x
         """
         from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal

--- a/src/sage/rings/polynomial/omega.py
+++ b/src/sage/rings/polynomial/omega.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-polyhedra
+# sage.doctest: needs sage.libs.singular
 r"""
 MacMahon's Partition Analysis Omega Operator
 

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -7465,7 +7465,7 @@ cdef class Polynomial(CommutativePolynomial):
         This function works over any field. However for base rings other than
         `\ZZ` and `\QQ` only the resultant algorithm is available::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs sage.libs.singular sage.rings.number_field
             sage: x = polygen(QQbar)
             sage: p1 = x**2 - AA(2).sqrt()
             sage: p2 = x**3 - AA(3).sqrt()

--- a/src/sage/rings/qqbar_decorators.py
+++ b/src/sage/rings/qqbar_decorators.py
@@ -69,6 +69,7 @@ def handle_AA_and_QQbar(func):
 
         ::
 
+            sage: # needs sage.symbolic
             sage: @handle_AA_and_QQbar
             ....: def f(x):
             ....:     print(x.ring().base_ring())

--- a/src/sage/rings/real_double_element_gsl.pyx
+++ b/src/sage/rings/real_double_element_gsl.pyx
@@ -686,9 +686,9 @@ cdef class RealDoubleElement_gsl(RealDoubleElement):
 
         EXAMPLES::
 
-            sage: RDF(pi).sech()
+            sage: RDF(pi).sech()                                                        # needs sage.symbolic
             0.08626673833405443
-            sage: CDF(pi).sech()
+            sage: CDF(pi).sech()                                                        # needs sage.symbolic
             0.08626673833405443
         """
         return 1/self.cosh()
@@ -699,9 +699,9 @@ cdef class RealDoubleElement_gsl(RealDoubleElement):
 
         EXAMPLES::
 
-            sage: RDF(pi).csch()
+            sage: RDF(pi).csch()                                                        # needs sage.symbolic
             0.08658953753004694
-            sage: CDF(pi).csch()  # rel tol 1e-15
+            sage: CDF(pi).csch()  # rel tol 1e-15                                       # needs sage.symbolic
             0.08658953753004696
         """
         return 1/self.sinh()
@@ -712,9 +712,9 @@ cdef class RealDoubleElement_gsl(RealDoubleElement):
 
         EXAMPLES::
 
-            sage: RDF(pi).coth()
+            sage: RDF(pi).coth()                                                        # needs sage.symbolic
             1.003741873197321
-            sage: CDF(pi).coth()
+            sage: CDF(pi).coth()                                                        # needs sage.symbolic
             1.0037418731973213
         """
         return self.cosh() / self.sinh()

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -1831,13 +1831,13 @@ cdef class RealIntervalFieldElement(RingElement):
             5559060566555523
             sage: RIF(3^33 * 2)
             1.1118121133111046?e16
-            sage: RIF(-pi^-512, 0)
+            sage: RIF(-pi^-512, 0)                                                      # needs sage.symbolic
             -1.?e-254
             sage: RealIntervalField(2)(3 * 2^18)
             786432
             sage: RealIntervalField(2)(3 * 2^19)
             1.6?e6
-            sage: v = RIF(AA(2-sqrt(3)))
+            sage: v = RIF(AA(2-sqrt(3)))                                                # needs sage.symbolic
             sage: v
             0.2679491924311227?
             sage: v.str(error_digits=1)

--- a/src/sage/rings/ring_extension_element.pyx
+++ b/src/sage/rings/ring_extension_element.pyx
@@ -1529,7 +1529,7 @@ cdef class RingExtensionWithBasisElement(RingExtensionElement):
         If ``base`` is omitted, it is set to its default which is the
         base of the extension::
 
-            sage: u.minpoly()                                                           # needs sage.rings.finite_rings
+            sage: u.minpoly()                                                           # needs sage.libs.singular sage.rings.finite_rings
             x^2 + (2*a + a^2)*x - 1 + a
 
         Note that ``base`` must be an explicit base over which the

--- a/src/sage/rings/valuation/inductive_valuation.py
+++ b/src/sage/rings/valuation/inductive_valuation.py
@@ -1254,9 +1254,9 @@ class NonFinalInductiveValuation(FiniteInductiveValuation, DiscreteValuation):
             sage: v1 = v0.mac_lane_step(G)[0]
             sage: V = v1.mac_lane_step(G)
             sage: v2 = V[0]
-            sage: F = v2.equivalence_decomposition(G); F
+            sage: F = v2.equivalence_decomposition(G); F                                # needs sage.libs.singular
             (x^4 + 2*alpha + 1)^3 * (x^4 + 1/2*alpha^4 + alpha + 1)^3 * (x^4 + 1/2*alpha^4 + 3*alpha + 1)^3
-            sage: v2.is_equivalent(F.prod(), G)
+            sage: v2.is_equivalent(F.prod(), G)                                         # needs sage.libs.singular
             True
 
         Check that :issue:`33422` is fixed::
@@ -1267,9 +1267,9 @@ class NonFinalInductiveValuation(FiniteInductiveValuation, DiscreteValuation):
             sage: v1 = v0.augmentation(x, 3/2)
             sage: v2 = v1.augmentation(x^2-686, 7/2)
             sage: f = x^4 - 8001504*x^2 - 592815428352
-            sage: F = v2.equivalence_decomposition(f); F
+            sage: F = v2.equivalence_decomposition(f); F                                # needs sage.libs.singular
             x^4 - 343/2*x^2 + 1294139
-            sage: v2.is_equivalent(F.prod(), f)
+            sage: v2.is_equivalent(F.prod(), f)                                         # needs sage.libs.singular
             True
         """
         f = self.domain().coerce(f)

--- a/src/sage/schemes/affine/affine_morphism.py
+++ b/src/sage/schemes/affine/affine_morphism.py
@@ -1064,7 +1064,7 @@ class SchemeMorphism_polynomial_affine_space_field(SchemeMorphism_polynomial_aff
 
         ::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs sage.libs.singular sage.rings.number_field
             sage: K.<v> = QuadraticField(5)
             sage: PS.<x,y> = AffineSpace(K, 2)
             sage: H = Hom(PS, PS)
@@ -1072,7 +1072,7 @@ class SchemeMorphism_polynomial_affine_space_field(SchemeMorphism_polynomial_aff
             sage: F = f.weil_restriction()
             sage: P = PS(2, 1)
             sage: Q = P.weil_restriction()
-            sage: f(P).weil_restriction() == F(Q)                                       # needs sage.libs.singular
+            sage: f(P).weil_restriction() == F(Q)
             True
         """
         if any(isinstance(f, FractionFieldElement) for f in self):

--- a/src/sage/schemes/toric/variety.py
+++ b/src/sage/schemes/toric/variety.py
@@ -3277,16 +3277,16 @@ def is_CohomologyClass(x):
         sage: P2 = toric_varieties.P2()
         sage: HH = P2.cohomology_ring()
         sage: from sage.schemes.toric.variety import is_CohomologyClass
-        sage: is_CohomologyClass( HH.one() )                                            # needs sage.libs.singular
+        sage: is_CohomologyClass('z')
         doctest:warning...
         DeprecationWarning: The function is_CohomologyClass is deprecated;
         use 'isinstance(..., CohomologyClass)' instead.
         See https://github.com/sagemath/sage/issues/38277 for details.
+        False
+        sage: is_CohomologyClass( HH.one() )                                            # needs sage.libs.singular
         True
         sage: is_CohomologyClass( HH(P2.fan(1)[0]) )                                    # needs sage.libs.singular
         True
-        sage: is_CohomologyClass('z')
-        False
     """
     from sage.misc.superseded import deprecation
     deprecation(38277,

--- a/src/sage/structure/sage_object.pyx
+++ b/src/sage/structure/sage_object.pyx
@@ -348,7 +348,7 @@ cdef class SageObject:
 
         Check that breakpoints and baseline are preserved (:issue:`29202`)::
 
-            sage: # needs sage.groups
+            sage: # needs sage.combinat
             sage: F = FreeAbelianMonoid(index_set=ZZ)
             sage: f = prod(F.gen(i) for i in range(5))
             sage: s, t = ascii_art(f), unicode_art(f)

--- a/src/sage/topology/simplicial_complex_examples.py
+++ b/src/sage/topology/simplicial_complex_examples.py
@@ -1431,7 +1431,7 @@ def RandomTwoSphere(n):
         True
         sage: fg = G.flip_graph(); fg
         Graph on 8 vertices
-        sage: fg.is_planar() and fg.is_regular(3)
+        sage: fg.is_planar() and fg.is_regular(3)               # needs planarity
         True
     """
     from sage.graphs.generators.random import RandomTriangulation


### PR DESCRIPTION
- **pkgs/sagemath-graphs/setup.py: Add sage.ext_data.kenzo**
- **src/sage/geometry/cone_critical_angles.py: Use lazy_import**
- **src/sage/geometry: Add # needs**
- **src/sage/graphs: Add # needs**
- **src/sage/groups: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/schemes: Add # needs**
- **src/sage/modules/free_module_integer.py: Avoid use of norm**
- **src/sage/knots/link.py: Add # needs**
- **src/sage/matrix/matrix_integer_dense.pyx: Add # needs**
- **src/sage/matroids/matroid.pyx: Add # needs**
- **src/sage/misc/functional.py: Add # needs**
- **src/sage/structure/sage_object.pyx: Add # needs**
- **src/sage/topology/simplicial_complex_examples.py: Add # needs**
- **src/sage/modules/free_module_integer.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-polyhedra[standard]' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-polyhedra' --update-known-test-failures**
