### PR TITLE
pkgs/sagemath-schemes: Modularization fixes

### DIFF
--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -393,7 +393,7 @@
     },
     "sage.categories.filtered_modules_with_basis": {
         "failed": true,
-        "ntests": 99
+        "ntests": 97
     },
     "sage.categories.finite_complex_reflection_groups": {
         "ntests": 172
@@ -872,7 +872,6 @@
         "ntests": 172
     },
     "sage.coding.kasami_codes": {
-        "failed": true,
         "ntests": 45
     },
     "sage.coding.linear_code": {
@@ -1250,7 +1249,6 @@
         "ntests": 343
     },
     "sage.doctest.test": {
-        "failed": true,
         "ntests": 23
     },
     "sage.doctest.util": {
@@ -1573,8 +1571,7 @@
         "ntests": 101
     },
     "sage.geometry.cone_critical_angles": {
-        "failed": true,
-        "ntests": 125
+        "ntests": 112
     },
     "sage.geometry.convex_set": {
         "ntests": 148
@@ -1609,7 +1606,7 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "ntests": 51
+        "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
         "ntests": 171
@@ -1676,7 +1673,7 @@
     },
     "sage.geometry.polyhedron.base6": {
         "failed": true,
-        "ntests": 202
+        "ntests": 203
     },
     "sage.geometry.polyhedron.base7": {
         "ntests": 128
@@ -1968,10 +1965,6 @@
     "sage.lfunctions.pari": {
         "failed": true,
         "ntests": 182
-    },
-    "sage.lfunctions.zero_sums": {
-        "failed": true,
-        "ntests": 132
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2304,14 +2297,6 @@
     "sage.matroids.basis_matroid": {
         "ntests": 150
     },
-    "sage.matroids.chow_ring": {
-        "failed": true,
-        "ntests": 40
-    },
-    "sage.matroids.chow_ring_ideal": {
-        "failed": true,
-        "ntests": 81
-    },
     "sage.matroids.circuit_closures_matroid": {
         "ntests": 86
     },
@@ -2343,8 +2328,7 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "failed": true,
-        "ntests": 941
+        "ntests": 936
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2446,7 +2430,7 @@
     },
     "sage.misc.functional": {
         "failed": true,
-        "ntests": 315
+        "ntests": 319
     },
     "sage.misc.gperftools": {
         "ntests": 17
@@ -2884,10 +2868,6 @@
     "sage.modular.modform.weight1": {
         "ntests": 10
     },
-    "sage.modular.modform_hecketriangle.abstract_ring": {
-        "failed": true,
-        "ntests": 523
-    },
     "sage.modular.modform_hecketriangle.analytic_type": {
         "ntests": 6
     },
@@ -2957,7 +2937,6 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3008,8 +2987,7 @@
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "failed": true,
-        "ntests": 174
+        "ntests": 169
     },
     "sage.modules.finite_submodule_iter": {
         "failed": true,
@@ -3027,7 +3005,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 8
+        "ntests": 11
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3493,7 +3471,6 @@
         "ntests": 283
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "failed": true,
         "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
@@ -4132,8 +4109,7 @@
         "ntests": 1370
     },
     "sage.rings.qqbar_decorators": {
-        "failed": true,
-        "ntests": 17
+        "ntests": 10
     },
     "sage.rings.quotient_ring": {
         "ntests": 257
@@ -4370,7 +4346,7 @@
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
         "failed": true,
-        "ntests": 76
+        "ntests": 43
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
@@ -4382,7 +4358,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 786
+        "ntests": 776
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4549,11 +4525,9 @@
         "ntests": 75
     },
     "sage.schemes.hyperelliptic_curves.jacobian_endomorphism_utils": {
-        "failed": true,
         "ntests": 39
     },
     "sage.schemes.hyperelliptic_curves.jacobian_generic": {
-        "failed": true,
         "ntests": 106
     },
     "sage.schemes.hyperelliptic_curves.jacobian_homset": {

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -393,7 +393,7 @@
     },
     "sage.categories.filtered_modules_with_basis": {
         "failed": true,
-        "ntests": 99
+        "ntests": 97
     },
     "sage.categories.finite_complex_reflection_groups": {
         "ntests": 172
@@ -872,7 +872,6 @@
         "ntests": 172
     },
     "sage.coding.kasami_codes": {
-        "failed": true,
         "ntests": 45
     },
     "sage.coding.linear_code": {
@@ -1250,7 +1249,6 @@
         "ntests": 343
     },
     "sage.doctest.test": {
-        "failed": true,
         "ntests": 23
     },
     "sage.doctest.util": {
@@ -1573,8 +1571,7 @@
         "ntests": 101
     },
     "sage.geometry.cone_critical_angles": {
-        "failed": true,
-        "ntests": 125
+        "ntests": 112
     },
     "sage.geometry.convex_set": {
         "ntests": 148
@@ -1609,7 +1606,7 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "ntests": 51
+        "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
         "ntests": 171
@@ -1676,7 +1673,7 @@
     },
     "sage.geometry.polyhedron.base6": {
         "failed": true,
-        "ntests": 202
+        "ntests": 203
     },
     "sage.geometry.polyhedron.base7": {
         "ntests": 128
@@ -1968,10 +1965,6 @@
     "sage.lfunctions.pari": {
         "failed": true,
         "ntests": 182
-    },
-    "sage.lfunctions.zero_sums": {
-        "failed": true,
-        "ntests": 132
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2304,14 +2297,6 @@
     "sage.matroids.basis_matroid": {
         "ntests": 150
     },
-    "sage.matroids.chow_ring": {
-        "failed": true,
-        "ntests": 40
-    },
-    "sage.matroids.chow_ring_ideal": {
-        "failed": true,
-        "ntests": 81
-    },
     "sage.matroids.circuit_closures_matroid": {
         "ntests": 86
     },
@@ -2343,8 +2328,7 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "failed": true,
-        "ntests": 941
+        "ntests": 936
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2446,7 +2430,7 @@
     },
     "sage.misc.functional": {
         "failed": true,
-        "ntests": 315
+        "ntests": 319
     },
     "sage.misc.gperftools": {
         "ntests": 17
@@ -2884,10 +2868,6 @@
     "sage.modular.modform.weight1": {
         "ntests": 10
     },
-    "sage.modular.modform_hecketriangle.abstract_ring": {
-        "failed": true,
-        "ntests": 523
-    },
     "sage.modular.modform_hecketriangle.analytic_type": {
         "ntests": 6
     },
@@ -3008,8 +2988,7 @@
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "failed": true,
-        "ntests": 174
+        "ntests": 169
     },
     "sage.modules.finite_submodule_iter": {
         "failed": true,
@@ -3027,7 +3006,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 8
+        "ntests": 11
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3493,7 +3472,6 @@
         "ntests": 283
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "failed": true,
         "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
@@ -4132,8 +4110,7 @@
         "ntests": 1370
     },
     "sage.rings.qqbar_decorators": {
-        "failed": true,
-        "ntests": 17
+        "ntests": 10
     },
     "sage.rings.quotient_ring": {
         "ntests": 257
@@ -4370,7 +4347,7 @@
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
         "failed": true,
-        "ntests": 76
+        "ntests": 43
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
@@ -4382,7 +4359,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 786
+        "ntests": 776
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4549,11 +4526,9 @@
         "ntests": 75
     },
     "sage.schemes.hyperelliptic_curves.jacobian_endomorphism_utils": {
-        "failed": true,
         "ntests": 39
     },
     "sage.schemes.hyperelliptic_curves.jacobian_generic": {
-        "failed": true,
         "ntests": 106
     },
     "sage.schemes.hyperelliptic_curves.jacobian_homset": {

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -393,7 +393,7 @@
     },
     "sage.categories.filtered_modules_with_basis": {
         "failed": true,
-        "ntests": 99
+        "ntests": 97
     },
     "sage.categories.finite_complex_reflection_groups": {
         "ntests": 172
@@ -872,7 +872,6 @@
         "ntests": 172
     },
     "sage.coding.kasami_codes": {
-        "failed": true,
         "ntests": 45
     },
     "sage.coding.linear_code": {
@@ -1250,7 +1249,6 @@
         "ntests": 343
     },
     "sage.doctest.test": {
-        "failed": true,
         "ntests": 23
     },
     "sage.doctest.util": {
@@ -1573,8 +1571,7 @@
         "ntests": 101
     },
     "sage.geometry.cone_critical_angles": {
-        "failed": true,
-        "ntests": 125
+        "ntests": 112
     },
     "sage.geometry.convex_set": {
         "ntests": 148
@@ -1609,7 +1606,7 @@
         "ntests": 38
     },
     "sage.geometry.hyperplane_arrangement.plot": {
-        "ntests": 51
+        "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
         "ntests": 171
@@ -1676,7 +1673,7 @@
     },
     "sage.geometry.polyhedron.base6": {
         "failed": true,
-        "ntests": 202
+        "ntests": 203
     },
     "sage.geometry.polyhedron.base7": {
         "ntests": 128
@@ -1968,10 +1965,6 @@
     "sage.lfunctions.pari": {
         "failed": true,
         "ntests": 182
-    },
-    "sage.lfunctions.zero_sums": {
-        "failed": true,
-        "ntests": 132
     },
     "sage.libs.arb.arith": {
         "ntests": 8
@@ -2304,14 +2297,6 @@
     "sage.matroids.basis_matroid": {
         "ntests": 150
     },
-    "sage.matroids.chow_ring": {
-        "failed": true,
-        "ntests": 40
-    },
-    "sage.matroids.chow_ring_ideal": {
-        "failed": true,
-        "ntests": 81
-    },
     "sage.matroids.circuit_closures_matroid": {
         "ntests": 86
     },
@@ -2343,8 +2328,7 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "failed": true,
-        "ntests": 941
+        "ntests": 936
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 73
@@ -2446,7 +2430,7 @@
     },
     "sage.misc.functional": {
         "failed": true,
-        "ntests": 315
+        "ntests": 319
     },
     "sage.misc.gperftools": {
         "ntests": 17
@@ -2884,10 +2868,6 @@
     "sage.modular.modform.weight1": {
         "ntests": 10
     },
-    "sage.modular.modform_hecketriangle.abstract_ring": {
-        "failed": true,
-        "ntests": 523
-    },
     "sage.modular.modform_hecketriangle.analytic_type": {
         "ntests": 6
     },
@@ -3008,8 +2988,7 @@
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "failed": true,
-        "ntests": 174
+        "ntests": 169
     },
     "sage.modules.finite_submodule_iter": {
         "failed": true,
@@ -3027,7 +3006,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 8
+        "ntests": 11
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3493,7 +3472,6 @@
         "ntests": 283
     },
     "sage.rings.finite_rings.finite_field_base": {
-        "failed": true,
         "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
@@ -4132,8 +4110,7 @@
         "ntests": 1370
     },
     "sage.rings.qqbar_decorators": {
-        "failed": true,
-        "ntests": 17
+        "ntests": 10
     },
     "sage.rings.quotient_ring": {
         "ntests": 257
@@ -4370,7 +4347,7 @@
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
         "failed": true,
-        "ntests": 76
+        "ntests": 43
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
@@ -4382,7 +4359,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 786
+        "ntests": 776
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4549,11 +4526,9 @@
         "ntests": 75
     },
     "sage.schemes.hyperelliptic_curves.jacobian_endomorphism_utils": {
-        "failed": true,
         "ntests": 39
     },
     "sage.schemes.hyperelliptic_curves.jacobian_generic": {
-        "failed": true,
         "ntests": 106
     },
     "sage.schemes.hyperelliptic_curves.jacobian_homset": {

--- a/src/sage/categories/filtered_modules_with_basis.py
+++ b/src/sage/categories/filtered_modules_with_basis.py
@@ -1182,7 +1182,7 @@ class FilteredModulesWithBasis(FilteredModulesCategory):
 
                 EXAMPLES::
 
-                    sage: # needs sage.geometry.polyhedron
+                    sage: # needs sage.geometry.polyhedron sage.graphs
                     sage: OS = hyperplane_arrangements.braid(3).orlik_solomon_algebra(QQ)
                     sage: OS.hilbert_series()
                     2*t^2 + 3*t + 1

--- a/src/sage/coding/kasami_codes.pyx
+++ b/src/sage/coding/kasami_codes.pyx
@@ -309,18 +309,18 @@ class KasamiCode(AbstractLinearCode):
             sage: C = codes.KasamiCode(8,2)
             sage: C.generator_matrix()
             [1 1 1 1 1 1 1 1]
-            sage: C.minimum_distance()
+            sage: C.minimum_distance()                                                  # needs sage.libs.gap
             8
             sage: C = codes.KasamiCode(8, 2, extended=False)
             sage: C.generator_matrix()
             [1 1 1 1 1 1 1]
-            sage: C.minimum_distance()
+            sage: C.minimum_distance()                                                  # needs sage.libs.gap
             7
             sage: C = codes.KasamiCode(4, 2, extended=False)
             sage: C.generator_matrix()
             []
             sage: C = codes.KasamiCode(16, 4, extended=False)
-            sage: C.minimum_distance()
+            sage: C.minimum_distance()                                                  # needs sage.libs.gap
             3
         """
         from sage.misc.functional import log

--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
@@ -7823,14 +7823,14 @@ class DynamicalSystem_projective_field(DynamicalSystem_projective,
 
             sage: PS.<x,y> = ProjectiveSpace(1,QQ)
             sage: f = DynamicalSystem_projective([7*x^2 - 28*y^2, 24*x*y])
-            sage: f.rational_preperiodic_graph()                                        # needs sage.rings.function_field
+            sage: f.rational_preperiodic_graph()                                        # needs sage.graphs sage.rings.function_field
             Looped digraph on 12 vertices
 
         ::
 
             sage: PS.<x,y> = ProjectiveSpace(1,QQ)
             sage: f = DynamicalSystem_projective([-3/2*x^3 + 19/6*x*y^2, y^3])
-            sage: f.rational_preperiodic_graph(prime_bound=[1,8])                       # needs sage.rings.function_field
+            sage: f.rational_preperiodic_graph(prime_bound=[1,8])                       # needs sage.graphs sage.rings.function_field
             Looped digraph on 12 vertices
 
         ::
@@ -7838,7 +7838,7 @@ class DynamicalSystem_projective_field(DynamicalSystem_projective,
             sage: PS.<x,y,z> = ProjectiveSpace(2,QQ)
             sage: f = DynamicalSystem_projective([2*x^3 - 50*x*z^2 + 24*z^3,
             ....:                                 5*y^3 - 53*y*z^2 + 24*z^3, 24*z^3])
-            sage: f.rational_preperiodic_graph(prime_bound=[1,11],  # long time
+            sage: f.rational_preperiodic_graph(prime_bound=[1,11],  # long time         # needs sage.graphs
             ....:                              lifting_prime=13)
             Looped digraph on 30 vertices
 
@@ -7848,7 +7848,7 @@ class DynamicalSystem_projective_field(DynamicalSystem_projective,
             sage: K.<w> = QuadraticField(-3)
             sage: P.<x,y> = ProjectiveSpace(K,1)
             sage: f = DynamicalSystem_projective([x^2 + y^2, y^2])
-            sage: f.rational_preperiodic_graph()        # long time
+            sage: f.rational_preperiodic_graph()        # long time                     # needs sage.graphs
             Looped digraph on 5 vertices
         """
         #input checking done in .rational_preperiodic_points()

--- a/src/sage/geometry/cone_critical_angles.py
+++ b/src/sage/geometry/cone_critical_angles.py
@@ -300,6 +300,7 @@ def _solve_gevp_naive(GG, HH, M, I, J):
     eigenspaces of dimension `n=2` corresponding to the eigenvalues
     `\cos\theta = -1` and `\cos\theta = 1`::
 
+        sage: # needs sage.symbolic
         sage: from sage.geometry.cone_critical_angles import _solve_gevp_naive
         sage: g11,g12,g21,g22 = SR.var('g11,g12,g21,g22', domain='real')
         sage: h11,h12,h21,h22 = SR.var('h11,h12,h21,h22', domain='real')
@@ -790,7 +791,7 @@ def check_gevp_feasibility(cos_theta, xi, eta, G_I, G_I_c_T,
         sage: eta = xi
         sage: G_I = matrix.identity(QQ,2)
         sage: H_J = 2*G_I
-        sage: check_gevp_feasibility(0,xi,eta,G_I,None,H_J,None,0)
+        sage: check_gevp_feasibility(0,xi,eta,G_I,None,H_J,None,0)                      # needs sage.symbolic
         (False, (0, 0), (0, 0))
 
     When `\cos\theta` is zero, the inequality (42) in Theorem 7.3
@@ -806,7 +807,7 @@ def check_gevp_feasibility(cos_theta, xi, eta, G_I, G_I_c_T,
         sage: G_I = matrix.identity(QQ,4)
         sage: G_I_c_T = matrix(QQ, [[0,-1,0,0]])
         sage: H_J = G_I
-        sage: check_gevp_feasibility(0,xi,eta,G_I,G_I_c_T,H_J,None,0)
+        sage: check_gevp_feasibility(0,xi,eta,G_I,G_I_c_T,H_J,None,0)                   # needs sage.symbolic
         (False, (0, 0, 0, 0), (0, 0, 0, 0))
 
     Likewise we can make (43) fail in exactly the same way::
@@ -819,7 +820,7 @@ def check_gevp_feasibility(cos_theta, xi, eta, G_I, G_I_c_T,
         sage: G_I_c_T = matrix(QQ, [[0,1,0,0]])
         sage: H_J = G_I
         sage: H_J_c_T = matrix(QQ, [[0,-1,0,0]])
-        sage: check_gevp_feasibility(0,xi,eta,G_I,G_I_c_T,H_J,H_J_c_T,0)
+        sage: check_gevp_feasibility(0,xi,eta,G_I,G_I_c_T,H_J,H_J_c_T,0)                # needs sage.symbolic
         (False, (0, 0, 0, 0), (0, 0, 0, 0))
 
     Finally, if we ensure that everything works, we get back a feasible
@@ -833,7 +834,7 @@ def check_gevp_feasibility(cos_theta, xi, eta, G_I, G_I_c_T,
         sage: G_I_c_T = matrix(QQ, [[0,1,0,0]])
         sage: H_J = G_I
         sage: H_J_c_T = matrix(QQ, [[0,1,0,0]])
-        sage: check_gevp_feasibility(0,xi,eta,G_I,G_I_c_T,H_J,H_J_c_T,0)
+        sage: check_gevp_feasibility(0,xi,eta,G_I,G_I_c_T,H_J,H_J_c_T,0)                # needs sage.symbolic
         (True, (1/2, 1/2, 1/2, 1/2), (1/2, 1/2, 1/2, 1/2))
     """
     infeasible_result = (False, 0*xi, 0*eta)

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -270,7 +270,7 @@ For finer invariants derived from the intersection poset, see
 Miscellaneous methods (see documentation for an explanation)::
 
     sage: a = hyperplane_arrangements.semiorder(3)
-    sage: a.has_good_reduction(5)                                                       # needs sage.rings.finite_rings
+    sage: a.has_good_reduction(5)                                                       # needs sage.graphs sage.rings.finite_rings
     True
     sage: b = a.change_ring(GF(5))
     sage: pa = a.intersection_poset()                                                   # needs sage.graphs
@@ -1054,7 +1054,7 @@ class HyperplaneArrangementElement(Element):
             sage: H.primitive_eulerian_polynomial()                                     # needs sage.graphs
             z^3 + 11*z^2 + 4*z
 
-            sage: H = hyperplane_arrangements.graphical(graphs.CycleGraph(4))
+            sage: H = hyperplane_arrangements.graphical(graphs.CycleGraph(4))           # needs sage.graphs
             sage: H.primitive_eulerian_polynomial()                                     # needs sage.graphs
             z^3 + 3*z^2 - z
 
@@ -3617,7 +3617,7 @@ class HyperplaneArrangements(Parent, UniqueRepresentation):
             True
             sage: type(K)
             <class 'sage.geometry.hyperplane_arrangement.arrangement.HyperplaneArrangements_with_category'>
-            sage: K.change_ring(RR).gen(0)
+            sage: K.change_ring(RR).gen(0)                                              # needs sage.rings.real_mpfr
             Hyperplane 1.00000000000000*x + 0.000000000000000*y + 0.000000000000000
 
         TESTS::
@@ -3871,11 +3871,11 @@ class HyperplaneArrangements(Parent, UniqueRepresentation):
 
         TESTS::
 
+            sage: # needs sage.rings.real_mpfr
             sage: L.<x> = HyperplaneArrangements(QQ);  L
             Hyperplane arrangements in 1-dimensional linear space over Rational Field with coordinate x
             sage: M.<y> = HyperplaneArrangements(RR);  M
             Hyperplane arrangements in 1-dimensional linear space over Real Field with 53 bits of precision with coordinate y
-
             sage: L.coerce_map_from(ZZ)
             Coercion map:
               From: Integer Ring

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -1318,7 +1318,10 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
                 if self.is_reflexive():
                     parts[1] = "reflexive"
                     if self.dim() == 2 or self.index.is_in_cache():
-                        parts.insert(-1, "#%d" % self.index())
+                        try:
+                            parts.insert(-1, "#%d" % self.index())
+                        except ImportError:
+                            pass
             except (ValueError, FileNotFoundError):
                 pass
             if isinstance(self.lattice(), ToricLattice_generic):

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -2468,7 +2468,7 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
         database::
 
             sage: d = lattice_polytope.cross_polytope(2)
-            sage: d.index()                                                             # needs palp
+            sage: d.index()                                                             # needs palp sage.groups
             3
 
         Note that polytopes with the same index are not necessarily the
@@ -2947,9 +2947,9 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
 
         The diamond is the 3rd polytope in the internal database::
 
-            sage: d.index()                                                             # needs palp
+            sage: d.index()                                                             # needs palp sage.groups
             3
-            sage: d                                                                     # needs palp
+            sage: d                                                                     # needs palp sage.groups
             2-d reflexive polytope #3 in 2-d lattice M
 
         You can get it in its normal form (in the default lattice) as ::
@@ -3331,7 +3331,7 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
         Check that a bug introduced in :issue:`35997` is fixed::
 
             sage: P = LatticePolytope([(-4,-6),(-4,-5),(0,0),(1,0),(5,6)])
-            sage: P._palp_PM_max()
+            sage: P._palp_PM_max()                                                      # needs sage.groups
             [9 5 4 0 0]
             [6 0 6 5 0]
             [1 5 0 0 4]
@@ -5679,7 +5679,7 @@ def read_all_polytopes(file_name):
            1  -1  -1
           -1   1  -1
            1   1  -1
-        sage: lattice_polytope.read_all_polytopes(result_name)
+        sage: lattice_polytope.read_all_polytopes(result_name)                          # needs sage.groups
         [2-d reflexive polytope #14 in 2-d lattice M,
          3-d reflexive polytope in 3-d lattice M]
         sage: os.remove(result_name)

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -1518,8 +1518,8 @@ class Polyhedron_base6(Polyhedron_base5):
 
         TESTS::
 
-            sage: D = polytopes.dodecahedron()                                          # needs sage.rings.number_field
-            sage: D.facets()[0].as_polyhedron()._test_affine_hull_projection()          # needs sage.rings.number_field
+            sage: D = polytopes.dodecahedron()                                          # needs sage.groups sage.rings.number_field
+            sage: D.facets()[0].as_polyhedron()._test_affine_hull_projection()          # needs sage.groups sage.rings.number_field
         """
         if tester is None:
             tester = self._tester(**options)

--- a/src/sage/lfunctions/zero_sums.pyx
+++ b/src/sage/lfunctions/zero_sums.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
+# sage.doctest: needs sage.symbolic
 r"""
 Class for computing sums over zeros of motivic `L`-functions
 

--- a/src/sage/matroids/chow_ring.py
+++ b/src/sage/matroids/chow_ring.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-modules
-# sage.doctest: needs sage.libs.singular
+# sage.doctest: needs sage.graphs sage.libs.singular
 r"""
 Chow rings of matroids
 

--- a/src/sage/matroids/chow_ring_ideal.py
+++ b/src/sage/matroids/chow_ring_ideal.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-modules
-# sage.doctest: needs sage.libs.singular
+# sage.doctest: needs sage.graphs sage.libs.singular
 r"""
 Chow ring ideals of matroids
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8097,7 +8097,7 @@ cdef class Matroid(SageObject):
 
         Next we get the non-trivial generators and do some computations::
 
-            sage: # needs sage.libs.singular sage.rings.finite_rings
+            sage: # needs sage.graphs sage.libs.singular sage.rings.finite_rings
             sage: G = A.gens()[7:]; G
             (Aabf, Aace, Aadg, Abcd, Abeg, Acfg, Adef, Aabcdefg)
             sage: Aabf, Aace, Aadg, Abcd, Abeg, Acfg, Adef, Aabcdefg = G

--- a/src/sage/modular/modform_hecketriangle/abstract_ring.py
+++ b/src/sage/modular/modform_hecketriangle/abstract_ring.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
+# sage.doctest: needs sage.graphs
 r"""
 Graded rings of modular forms for Hecke triangle groups
 

--- a/src/sage/modular/modform_hecketriangle/abstract_ring.py
+++ b/src/sage/modular/modform_hecketriangle/abstract_ring.py
@@ -16,9 +16,8 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.algebras.free_algebra import FreeAlgebra
-
 from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_import import lazy_import
 from sage.rings.fraction_field import FractionField
 from sage.rings.infinity import infinity
 from sage.rings.integer_ring import ZZ
@@ -29,6 +28,8 @@ from sage.structure.parent import Parent
 
 from .constructor import FormsRing, FormsSpace
 from .series_constructor import MFSeriesConstructor
+
+lazy_import('sage.algebras.free_algebra', 'FreeAlgebra')
 
 
 class FormsRing_abstract(Parent):

--- a/src/sage/modular/modform_hecketriangle/graded_ring_element.py
+++ b/src/sage/modular/modform_hecketriangle/graded_ring_element.py
@@ -17,7 +17,6 @@ AUTHORS:
 # ****************************************************************************
 
 from sage.functions.log import exp
-from sage.geometry.hyperbolic_space.hyperbolic_interface import HyperbolicPlane
 from sage.misc.cachefunc import cached_method
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
 from sage.misc.lazy_import import lazy_import
@@ -37,6 +36,14 @@ lazy_import("sage.symbolic.constants", "pi")
 
 from .constructor import rational_type, FormsSpace, FormsRing
 from .series_constructor import MFSeriesConstructor
+
+
+def _in_HyperbolicPlane(x):
+    try:
+        from sage.geometry.hyperbolic_space.hyperbolic_interface import HyperbolicPlane
+    except ImportError:
+        return False
+    return x in HyperbolicPlane()
 
 
 # Warning: We choose CommutativeAlgebraElement because we want the
@@ -1335,7 +1342,7 @@ class FormsRingElement(CommutativeAlgebraElement, UniqueRepresentation,
         i = QuadraticField(-1, 'I').gen()
 
         # if tau is a point of HyperbolicPlane then we use it's coordinates in the UHP model
-        if (tau in HyperbolicPlane()):
+        if _in_HyperbolicPlane(tau):
             tau = tau.to_model('UHP').coordinates()
 
         if self.is_zero():
@@ -2138,7 +2145,7 @@ class FormsRingElement(CommutativeAlgebraElement, UniqueRepresentation,
         i = QuadraticField(-1, 'I').gen()
 
         # if tau is a point of HyperbolicPlane then we use it's coordinates in the UHP model
-        if (tau in HyperbolicPlane()):
+        if _in_HyperbolicPlane(tau):
             tau = tau.to_model('UHP').coordinates()
 
         if (prec is None):

--- a/src/sage/modules/filtered_vector_space.py
+++ b/src/sage/modules/filtered_vector_space.py
@@ -911,7 +911,7 @@ class FilteredVectorSpace_class(FreeModule_ambient_field):
 
         TESTS::
 
-            sage: # needs sage.geometry.polyhedron sage.schemes
+            sage: # needs sage.geometry.polyhedron sage.graphs sage.schemes
             sage: P = toric_varieties.P2()
             sage: T_P = P.sheaves.tangent_bundle()
             sage: O_P = P.sheaves.trivial_bundle(1)

--- a/src/sage/schemes/curves/affine_curve.py
+++ b/src/sage/schemes/curves/affine_curve.py
@@ -1916,7 +1916,7 @@ class AffinePlaneCurve_field(AffinePlaneCurve, AffineCurve_field):
             sage: T.<t> = QQ[]
             sage: K.<a> = NumberField(t^3 + 2, 'a')
             sage: A.<x, y> = AffineSpace(K, 2)
-            sage: Curve(y^2 + a * x).braid_monodromy()
+            sage: Curve(y^2 + a * x).braid_monodromy()                  # needs sage.graphs
             Traceback (most recent call last):
             ...
             NotImplementedError: the base field must have an embedding to the algebraic field
@@ -1940,7 +1940,7 @@ class AffinePlaneCurve_field(AffinePlaneCurve, AffineCurve_field):
 
             sage: R.<x,y> = QQ[]
             sage: C = Curve(x^3 + 3*y^3 + 5)
-            sage: C.riemann_surface()
+            sage: C.riemann_surface()                                   # needs sage.graphs
             Riemann surface defined by polynomial f = x^3 + 3*y^3 + 5 = 0,
              with 53 bits of precision
         """

--- a/src/sage/schemes/curves/plane_curve_arrangement.py
+++ b/src/sage/schemes/curves/plane_curve_arrangement.py
@@ -49,9 +49,9 @@ AUTHORS:
 
 from itertools import combinations
 from sage.categories.sets_cat import Sets
-from sage.groups.free_group import FreeGroup
 from sage.misc.abstract_method import abstract_method
 from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_import import lazy_import
 from sage.misc.misc_c import prod
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.qqbar import QQbar
@@ -66,6 +66,8 @@ from sage.structure.parent import Parent
 from sage.structure.element import Element
 from sage.structure.richcmp import richcmp
 from sage.structure.unique_representation import UniqueRepresentation
+
+lazy_import('sage.groups.free_group', 'FreeGroup')
 
 
 class PlaneCurveArrangementElement(Element):

--- a/src/sage/schemes/curves/plane_curve_arrangement.py
+++ b/src/sage/schemes/curves/plane_curve_arrangement.py
@@ -60,7 +60,6 @@ from sage.schemes.affine.affine_space import AffineSpace
 from sage.schemes.curves.affine_curve import AffinePlaneCurve
 from sage.schemes.curves.constructor import Curve
 from sage.schemes.curves.projective_curve import ProjectiveSpace, ProjectivePlaneCurve
-from sage.schemes.curves.zariski_vankampen import braid_monodromy, fundamental_group_arrangement
 from sage.structure.category_object import normalize_names
 from sage.structure.parent import Parent
 from sage.structure.element import Element
@@ -68,6 +67,7 @@ from sage.structure.richcmp import richcmp
 from sage.structure.unique_representation import UniqueRepresentation
 
 lazy_import('sage.groups.free_group', 'FreeGroup')
+lazy_import('sage.schemes.curves.zariski_vankampen', ['braid_monodromy', 'fundamental_group_arrangement'])
 
 
 class PlaneCurveArrangementElement(Element):

--- a/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
+++ b/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
@@ -34,6 +34,7 @@ Modular symbols are used to compute `p`-adic `L`-functions.
 
 EXAMPLES::
 
+    sage: # needs eclib
     sage: E = EllipticCurve("19a1")
     sage: m = E.modular_symbol()
     sage: m(0)
@@ -173,8 +174,8 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
-            sage: m = EllipticCurve('11a1').modular_symbol()
-            sage: m.sign()
+            sage: m = EllipticCurve('11a1').modular_symbol()                            # needs eclib
+            sage: m.sign()                                                              # needs eclib
             1
 
             sage: # needs sage.graphs
@@ -190,8 +191,8 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
-            sage: m = EllipticCurve('11a1').modular_symbol()
-            sage: m.elliptic_curve()
+            sage: m = EllipticCurve('11a1').modular_symbol()                            # needs eclib
+            sage: m.elliptic_curve()                                                    # needs eclib
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
         """
         return self._E
@@ -202,8 +203,8 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
-            sage: m = EllipticCurve('11a1').modular_symbol()
-            sage: m.base_ring()
+            sage: m = EllipticCurve('11a1').modular_symbol()                            # needs eclib
+            sage: m.base_ring()                                                         # needs eclib
             Rational Field
         """
         return self._base_ring
@@ -214,8 +215,8 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
-            sage: m = EllipticCurve('11a1').modular_symbol()
-            sage: m
+            sage: m = EllipticCurve('11a1').modular_symbol()                            # needs eclib
+            sage: m                                                                     # needs eclib
             Modular symbol with sign 1 over Rational Field attached to
              Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
 
@@ -252,6 +253,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolECLIB
             sage: E = EllipticCurve('11a1')
             sage: M = ModularSymbolECLIB(E,+1)
@@ -267,6 +269,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         This is a rank 1 case with vanishing positive twists::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('121b1')
             sage: M = ModularSymbolECLIB(E,+1)
             sage: M(0)
@@ -274,16 +277,17 @@ class ModularSymbolECLIB(ModularSymbol):
             sage: M(1/7)
             1/2
 
-            sage: M = EllipticCurve('121d1').modular_symbol(implementation='eclib')
-            sage: M(0)
+            sage: M = EllipticCurve('121d1').modular_symbol(implementation='eclib')     # needs eclib
+            sage: M(0)                                                                  # needs eclib
             2
 
-            sage: E = EllipticCurve('15a1')
-            sage: [C.modular_symbol(implementation='eclib')(0) for C in E.isogeny_class()]
+            sage: E = EllipticCurve('15a1')                                             # needs eclib
+            sage: [C.modular_symbol(implementation='eclib')(0) for C in E.isogeny_class()]  # needs eclib
             [1/4, 1/8, 1/4, 1/2, 1/8, 1/16, 1/2, 1]
 
         Since :issue:`10256`, the interface for negative modular symbols in eclib is available::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a1')
             sage: Mplus = E.modular_symbol(+1); Mplus
             Modular symbol with sign 1 over Rational Field attached to
@@ -298,13 +302,14 @@ class ModularSymbolECLIB(ModularSymbol):
 
         The scaling factor relative to eclib's normalization is 1/2 for curves of negative discriminant::
 
-            sage: [E.discriminant() for E in cremona_curves([14])]
+            sage: [E.discriminant() for E in cremona_curves([14])]                      # needs eclib
             [-21952, 941192, -1835008, -28, 25088, 98]
-            sage: [E.modular_symbol()._scaling for E in cremona_curves([14])]
+            sage: [E.modular_symbol()._scaling for E in cremona_curves([14])]           # needs eclib
             [1/2, 1, 1/2, 1/2, 1, 1]
 
         TESTS (for :issue:`10236`)::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a1')
             sage: m = E.modular_symbol(implementation='eclib')
             sage: m(1/7)
@@ -317,6 +322,7 @@ class ModularSymbolECLIB(ModularSymbol):
         v20210310 the value of ``nap`` is increased automatically by
         ``eclib``::
 
+            sage: # needs eclib
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolECLIB
             sage: E = EllipticCurve('1590g1')
             sage: m = ModularSymbolECLIB(E, sign=+1, nap=300)
@@ -327,6 +333,7 @@ class ModularSymbolECLIB(ModularSymbol):
         effect.  The correct values may verified by the numerical
         implementation::
 
+            sage: # needs eclib
             sage: m = ModularSymbolECLIB(E, sign=+1, nap=400)
             sage: [m(a/5) for a in [1..4]]
             [13/2, -13/2, -13/2, 13/2]
@@ -353,8 +360,8 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
-            sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')
-            sage: m._call_with_caching(0)
+            sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')      # needs eclib
+            sage: m._call_with_caching(0)                                               # needs eclib
             1/5
         """
         cache = self.cache[base_at_infinity]
@@ -372,8 +379,8 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
-            sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')
-            sage: m(0)
+            sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')      # needs eclib
+            sage: m(0)                                                                  # needs eclib
             1/5
         """
         from sage.rings.rational import Rational

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1213,6 +1213,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Different curves in an isogeny class have modular symbols
         which differ by a nonzero rational factor::
 
+            sage: # needs eclib
             sage: E1 = EllipticCurve('11a1')
             sage: M1 = E1.modular_symbol()
             sage: M1(0)
@@ -2062,7 +2063,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             4
             sage: EllipticCurve([0, 0, 1, -79, 342]).rank(proof=False)  # needs eclib
             5
-            sage: EllipticCurve([0, 0, 1, -79, 342]).rank(algorithm='pari')
+            sage: EllipticCurve([0, 0, 1, -79, 342]).rank(algorithm='pari')     # needs eclib
             5
 
         Examples with denominators in defining equations::
@@ -2310,7 +2311,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve('389a')
             sage: E.gens()                 # random output              # needs eclib
             [(-1 : 1 : 1), (0 : 0 : 1)]
-            sage: E.gens(algorithm='pari')    # random output
+            sage: E.gens(algorithm='pari')    # random output           # needs eclib
             [(5/4 : 5/8 : 1), (0 : 0 : 1)]
             sage: E = EllipticCurve([0,2429469980725060,0,275130703388172136833647756388,0])
             sage: len(E.gens(algorithm='pari'))  # not tested (takes too long)
@@ -2400,7 +2401,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             True
 
             sage: E = EllipticCurve([-127^2,0])
-            sage: E.gens(use_database=False, algorithm='pari',pari_effort=4)   # random
+            sage: E.gens(use_database=False, algorithm='pari',pari_effort=4)   # random, needs eclib
             [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
 
         TESTS::
@@ -3899,7 +3900,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree()
+            sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree()  # needs sympow
             1984
             sage: EllipticCurve([0, 0, 1, -7, 6]).modular_degree(algorithm='sympow')    # needs sympow
             1984
@@ -4061,7 +4062,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         TESTS::
 
             sage: E = EllipticCurve('11a')
-            sage: E.congruence_number()
+            sage: E.congruence_number()                                                 # needs sympow
             1
         """
         # Case 1: M==1

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -3235,7 +3235,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             sage: P = E.heegner_point(-19); y = P._trace_numerical_conductor_1()
             sage: [c.real() for c in y]
             [-1.2...e-16, -1.00000000000000, 1.00000000000000]
-            sage: -2*E.gens()[0]
+            sage: -2*E.gens()[0]                                                        # needs eclib
             (0 : -1 : 1)
             sage: P._trace_index()
             2

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
@@ -60,7 +60,7 @@ the LMFDB label of the curve is 169.a.169.1::
     sage: f = x^6 + 4*x^5 + 6*x^4 + 2*x^3 + x^2 + 2*x + 1
     sage: C = HyperellipticCurve(f)
     sage: A = C.jacobian()
-    sage: A.geometric_endomorphism_algebra_is_field()
+    sage: A.geometric_endomorphism_algebra_is_field()                                   # needs sage.groups
     False
 
 .. WARNING:
@@ -177,21 +177,21 @@ def get_is_geom_field(f, C, bad_primes, B=200):
         sage: R.<x> = QQ[]
         sage: f = 4*x^6 - 12*x^5 + 20*x^3 - 8*x^2 - 4*x + 1
         sage: C = HyperellipticCurve(f)
-        sage: get_is_geom_field(f,C,[13,269])
+        sage: get_is_geom_field(f,C,[13,269])                                           # needs sage.groups
         (False, False)
 
     This is LMFDB curve 3125.a.3125.1::
 
         sage: f = 4*x^5 + 1
         sage: C = HyperellipticCurve(f)
-        sage: get_is_geom_field(f,C,[5])
+        sage: get_is_geom_field(f,C,[5])                                                # needs sage.groups
         (True, False)
 
     This is LMFDB curve 277.a.277.2::
 
         sage: f = 4*x^6 - 36*x^4 + 56*x^3 - 76*x^2 + 44*x - 23
         sage: C = HyperellipticCurve(f)
-        sage: get_is_geom_field(f,C,[277])
+        sage: get_is_geom_field(f,C,[277])                                              # needs sage.groups
         (True, True)
     """
 

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
@@ -377,7 +377,7 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             sage: f = x^6 + 2*x^4 + 2*x^3 + 5*x^2 + 6*x + 1
             sage: C = HyperellipticCurve(f)
             sage: J = C.jacobian()
-            sage: J.geometric_endomorphism_ring_is_ZZ()
+            sage: J.geometric_endomorphism_ring_is_ZZ()                                 # needs sage.groups
             False
 
         This is LMFDB curve 160000.c.800000.1 whose geometric endomorphism ring
@@ -386,7 +386,7 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             sage: f = x^5 - 1
             sage: C = HyperellipticCurve(f)
             sage: J = C.jacobian()
-            sage: J.geometric_endomorphism_ring_is_ZZ()
+            sage: J.geometric_endomorphism_ring_is_ZZ()                                 # needs sage.groups
             False
 
         This is LMFDB curve 262144.d.524288.2 whose geometric endomorphism ring
@@ -395,7 +395,7 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             sage: f = x^5 + x^4 + 4*x^3 + 8*x^2 + 5*x + 1
             sage: C = HyperellipticCurve(f)
             sage: J = C.jacobian()
-            sage: J.geometric_endomorphism_ring_is_ZZ()
+            sage: J.geometric_endomorphism_ring_is_ZZ()                                 # needs sage.groups
             False
 
         This is LMFDB curve 578.a.2312.1 whose geometric endomorphism ring
@@ -404,7 +404,7 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             sage: f = 4*x^5 - 7*x^4 + 10*x^3 - 7*x^2 + 4*x
             sage: C = HyperellipticCurve(f)
             sage: J = C.jacobian()
-            sage: J.geometric_endomorphism_ring_is_ZZ()
+            sage: J.geometric_endomorphism_ring_is_ZZ()                                 # needs sage.groups
             False
         """
         if self._have_established_geometrically_trivial:


### PR DESCRIPTION
- **src/sage/modular/modform_hecketriangle/graded_ring_element.py: Modularization fix for import of HyperbolicPlane**
- **src/sage/modular/modform_hecketriangle/abstract_ring.py: Use lazy_import**
- **src/sage/schemes/curves/plane_curve_arrangement.py: Use lazy_import**
- **src/sage/schemes: Add # needs**
- **src/sage/modules/filtered_vector_space.py: Add # needs**
- **src/sage/categories/filtered_modules_with_basis.py: Add # needs**
- **src/sage/coding/kasami_codes.pyx: Add # needs**
- **src/sage/dynamics/arithmetic_dynamics/projective_ds.py: Add # needs**
- **src/sage/geometry/cone_critical_angles.py: Add # needs**
- **src/sage/geometry/hyperplane_arrangement/arrangement.py: Add # needs**
- **src/sage/geometry/lattice_polytope.py: Do not fail in repr when polytope index cannot be determined**
- **src/sage/geometry/lattice_polytope.py: Add # needs**
- **src/sage/geometry/polyhedron/base6.py: Add # needs**
- **src/sage/lfunctions/zero_sums.pyx: Add # needs**
- **src/sage/matroids/chow_ring*.py: Add # needs**
- **src/sage/modular/modform_hecketriangle/abstract_ring.py: Add # needs**
- **src/sage/matroids/matroid.pyx: Add # needs**
- **src/sage/schemes/curves/plane_curve_arrangement.py: Use lazy_import**
- **./sage --fixdoctests --distribution 'sagemath-schemes*' --update-known-test-failures**
