### PR TITLE
Revert "src/pyproject.toml: Pin cypari2 to a version for which PyPI wheels exist"

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -6,9 +6,7 @@ requires = [
     'setuptools >= 68.1.1',
     # version constraint for macOS Big Sur support (see https://github.com/sagemath/sage/issues/31050)
     'wheel >=0.36.2',
-    # Pin version for which wheels are available on PyPI - https://github.com/passagemath/passagemath/issues/347
-    'cypari2 == 2.1.5; sys_platform == "darwin" and platform_machine != "arm64"',
-    'cypari2 == 2.2.0; sys_platform != "darwin" or platform_machine == "arm64"',
+    'cypari2 >=2.1.1',
     'cysignals >=1.10.2',
     # per https://github.com/scipy/scipy/blob/maintenance/1.13.x/pyproject.toml
     'cython >=3.0.8,<3.1.0',


### PR DESCRIPTION
This reverts commit fb1c6bf5c3e069a1380410f12fffc35a9745e4fb.
