### PR TITLE
pkgs/sagemath-graphs: Doctest fixes

### DIFF
--- a/pkgs/sagemath-graphs/known-test-failures--modules--pari.json
+++ b/pkgs/sagemath-graphs/known-test-failures--modules--pari.json
@@ -32,7 +32,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "ntests": 117
+        "ntests": 119
     },
     "sage.algebras.orlik_terao": {
         "failed": true,
@@ -171,6 +171,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 35
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -223,7 +226,7 @@
         "ntests": 391
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -351,7 +354,7 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "ntests": 135
@@ -397,7 +400,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -687,7 +690,7 @@
     },
     "sage.categories.simplicial_sets": {
         "failed": true,
-        "ntests": 133
+        "ntests": 125
     },
     "sage.categories.subobjects": {
         "ntests": 2
@@ -945,7 +948,7 @@
     },
     "sage.combinat.designs.incidence_structures": {
         "failed": true,
-        "ntests": 287
+        "ntests": 283
     },
     "sage.combinat.designs.latin_squares": {
         "ntests": 36
@@ -1197,7 +1200,6 @@
         "ntests": 162
     },
     "sage.combinat.shard_order": {
-        "failed": true,
         "ntests": 40
     },
     "sage.combinat.subset": {
@@ -1666,13 +1668,10 @@
     },
     "sage.graphs.bipartite_graph": {
         "failed": true,
-        "ntests": 431
+        "ntests": 434
     },
     "sage.graphs.centrality": {
         "ntests": 31
-    },
-    "sage.graphs.cliquer": {
-        "ntests": 34
     },
     "sage.graphs.comparability": {
         "ntests": 52
@@ -1718,11 +1717,11 @@
     },
     "sage.graphs.generators.distance_regular": {
         "failed": true,
-        "ntests": 151
+        "ntests": 143
     },
     "sage.graphs.generators.families": {
         "failed": true,
-        "ntests": 382
+        "ntests": 383
     },
     "sage.graphs.generators.intersection": {
         "ntests": 72
@@ -1731,11 +1730,11 @@
         "ntests": 6
     },
     "sage.graphs.generators.random": {
-        "ntests": 181
+        "ntests": 182
     },
     "sage.graphs.generators.smallgraphs": {
         "failed": true,
-        "ntests": 444
+        "ntests": 445
     },
     "sage.graphs.generators.world_map": {
         "ntests": 20
@@ -1752,10 +1751,10 @@
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1136
+        "ntests": 1117
     },
     "sage.graphs.graph_coloring": {
-        "ntests": 151
+        "ntests": 153
     },
     "sage.graphs.graph_database": {
         "ntests": 4
@@ -1782,7 +1781,7 @@
         "ntests": 131
     },
     "sage.graphs.graph_decompositions.tree_decomposition": {
-        "ntests": 273
+        "ntests": 223
     },
     "sage.graphs.graph_decompositions.vertex_separation": {
         "ntests": 176
@@ -1791,7 +1790,7 @@
         "ntests": 8
     },
     "sage.graphs.graph_generators": {
-        "ntests": 174
+        "ntests": 179
     },
     "sage.graphs.graph_generators_pyx": {
         "ntests": 7
@@ -1958,7 +1957,7 @@
         "ntests": 75
     },
     "sage.groups.perm_gps.partn_ref.refinement_graphs": {
-        "ntests": 110
+        "ntests": 103
     },
     "sage.groups.perm_gps.partn_ref.refinement_lists": {
         "ntests": 3
@@ -2046,19 +2045,19 @@
     },
     "sage.knots.free_knotinfo_monoid": {
         "failed": true,
-        "ntests": 66
+        "ntests": 58
     },
     "sage.knots.gauss_code": {
         "ntests": 18
     },
     "sage.knots.knot": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.knots.knotinfo": {
         "ntests": 50
     },
     "sage.knots.link": {
-        "ntests": 50
+        "ntests": 51
     },
     "sage.libs.gsl.array": {
         "ntests": 22
@@ -2564,7 +2563,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -3275,7 +3274,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 142
+        "ntests": 138
     },
     "sage.rings.polynomial.ore_function_element": {
         "failed": true,

--- a/pkgs/sagemath-graphs/known-test-failures--modules.json
+++ b/pkgs/sagemath-graphs/known-test-failures--modules.json
@@ -29,7 +29,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "ntests": 117
+        "ntests": 119
     },
     "sage.algebras.orlik_terao": {
         "failed": true,
@@ -165,6 +165,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 35
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -217,7 +220,7 @@
         "ntests": 391
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -338,7 +341,7 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "ntests": 115
@@ -384,7 +387,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -673,7 +676,7 @@
     },
     "sage.categories.simplicial_sets": {
         "failed": true,
-        "ntests": 133
+        "ntests": 125
     },
     "sage.categories.subobjects": {
         "ntests": 2
@@ -773,7 +776,7 @@
         "ntests": 2
     },
     "sage.coding.kasami_codes": {
-        "ntests": 2
+        "ntests": 5
     },
     "sage.coding.linear_code": {
         "failed": true,
@@ -863,7 +866,7 @@
         "ntests": 0
     },
     "sage.combinat.designs.incidence_structures": {
-        "ntests": 276
+        "ntests": 272
     },
     "sage.combinat.designs.latin_squares": {
         "ntests": 36
@@ -1114,7 +1117,6 @@
         "ntests": 162
     },
     "sage.combinat.shard_order": {
-        "failed": true,
         "ntests": 40
     },
     "sage.combinat.subset": {
@@ -1503,8 +1505,7 @@
         "ntests": 4
     },
     "sage.functions.special": {
-        "failed": true,
-        "ntests": 121
+        "ntests": 120
     },
     "sage.functions.spike_function": {
         "ntests": 32
@@ -1565,13 +1566,10 @@
         "ntests": 91
     },
     "sage.graphs.bipartite_graph": {
-        "ntests": 411
+        "ntests": 414
     },
     "sage.graphs.centrality": {
         "ntests": 31
-    },
-    "sage.graphs.cliquer": {
-        "ntests": 34
     },
     "sage.graphs.comparability": {
         "ntests": 52
@@ -1616,11 +1614,11 @@
         "ntests": 13
     },
     "sage.graphs.generators.distance_regular": {
-        "ntests": 144
+        "ntests": 136
     },
     "sage.graphs.generators.families": {
         "failed": true,
-        "ntests": 382
+        "ntests": 383
     },
     "sage.graphs.generators.intersection": {
         "ntests": 72
@@ -1629,11 +1627,11 @@
         "ntests": 6
     },
     "sage.graphs.generators.random": {
-        "ntests": 181
+        "ntests": 182
     },
     "sage.graphs.generators.smallgraphs": {
         "failed": true,
-        "ntests": 444
+        "ntests": 445
     },
     "sage.graphs.generators.world_map": {
         "ntests": 20
@@ -1650,10 +1648,10 @@
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1136
+        "ntests": 1117
     },
     "sage.graphs.graph_coloring": {
-        "ntests": 151
+        "ntests": 153
     },
     "sage.graphs.graph_database": {
         "ntests": 4
@@ -1680,7 +1678,7 @@
         "ntests": 131
     },
     "sage.graphs.graph_decompositions.tree_decomposition": {
-        "ntests": 273
+        "ntests": 223
     },
     "sage.graphs.graph_decompositions.vertex_separation": {
         "ntests": 176
@@ -1690,7 +1688,7 @@
     },
     "sage.graphs.graph_generators": {
         "failed": true,
-        "ntests": 174
+        "ntests": 179
     },
     "sage.graphs.graph_generators_pyx": {
         "ntests": 7
@@ -1853,7 +1851,7 @@
         "ntests": 4
     },
     "sage.groups.perm_gps.partn_ref.refinement_graphs": {
-        "ntests": 110
+        "ntests": 103
     },
     "sage.groups.perm_gps.partn_ref.refinement_lists": {
         "ntests": 3
@@ -1909,6 +1907,7 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
+        "failed": true,
         "ntests": 5
     },
     "sage.interfaces.abc": {
@@ -1934,19 +1933,19 @@
     },
     "sage.knots.free_knotinfo_monoid": {
         "failed": true,
-        "ntests": 66
+        "ntests": 58
     },
     "sage.knots.gauss_code": {
         "ntests": 18
     },
     "sage.knots.knot": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.knots.knotinfo": {
         "ntests": 50
     },
     "sage.knots.link": {
-        "ntests": 54
+        "ntests": 55
     },
     "sage.libs.gsl.array": {
         "ntests": 22
@@ -1982,7 +1981,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2065
+        "ntests": 2048
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -2416,7 +2415,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -2976,7 +2975,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 138
+        "ntests": 134
     },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 56

--- a/pkgs/sagemath-graphs/known-test-failures.json
+++ b/pkgs/sagemath-graphs/known-test-failures.json
@@ -95,6 +95,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 22
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -146,7 +149,7 @@
         "ntests": 391
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -272,7 +275,7 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "ntests": 71
@@ -317,7 +320,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_posets": {
         "ntests": 19
@@ -609,8 +612,7 @@
         "ntests": 17
     },
     "sage.categories.simplicial_sets": {
-        "failed": true,
-        "ntests": 135
+        "ntests": 109
     },
     "sage.categories.subobjects": {
         "ntests": 2
@@ -735,7 +737,7 @@
         "ntests": 0
     },
     "sage.combinat.designs.incidence_structures": {
-        "ntests": 276
+        "ntests": 272
     },
     "sage.combinat.designs.latin_squares": {
         "ntests": 12
@@ -830,7 +832,7 @@
         "ntests": 12
     },
     "sage.combinat.posets.posets": {
-        "ntests": 83
+        "ntests": 86
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -839,7 +841,6 @@
         "ntests": 162
     },
     "sage.combinat.shard_order": {
-        "failed": true,
         "ntests": 40
     },
     "sage.combinat.subset": {
@@ -1225,13 +1226,10 @@
         "ntests": 84
     },
     "sage.graphs.bipartite_graph": {
-        "ntests": 372
+        "ntests": 375
     },
     "sage.graphs.centrality": {
         "ntests": 31
-    },
-    "sage.graphs.cliquer": {
-        "ntests": 34
     },
     "sage.graphs.comparability": {
         "ntests": 52
@@ -1277,10 +1275,10 @@
         "ntests": 13
     },
     "sage.graphs.generators.distance_regular": {
-        "ntests": 130
+        "ntests": 122
     },
     "sage.graphs.generators.families": {
-        "ntests": 354
+        "ntests": 355
     },
     "sage.graphs.generators.intersection": {
         "ntests": 63
@@ -1289,11 +1287,11 @@
         "ntests": 6
     },
     "sage.graphs.generators.random": {
-        "ntests": 181
+        "ntests": 182
     },
     "sage.graphs.generators.smallgraphs": {
         "failed": true,
-        "ntests": 444
+        "ntests": 445
     },
     "sage.graphs.generators.world_map": {
         "ntests": 20
@@ -1310,10 +1308,10 @@
     },
     "sage.graphs.graph": {
         "failed": true,
-        "ntests": 1056
+        "ntests": 1037
     },
     "sage.graphs.graph_coloring": {
-        "ntests": 151
+        "ntests": 153
     },
     "sage.graphs.graph_database": {
         "ntests": 4
@@ -1340,7 +1338,7 @@
         "ntests": 131
     },
     "sage.graphs.graph_decompositions.tree_decomposition": {
-        "ntests": 273
+        "ntests": 223
     },
     "sage.graphs.graph_decompositions.vertex_separation": {
         "ntests": 176
@@ -1349,7 +1347,7 @@
         "ntests": 8
     },
     "sage.graphs.graph_generators": {
-        "ntests": 166
+        "ntests": 171
     },
     "sage.graphs.graph_generators_pyx": {
         "ntests": 7
@@ -1446,7 +1444,7 @@
         "ntests": 4
     },
     "sage.groups.perm_gps.partn_ref.refinement_graphs": {
-        "ntests": 110
+        "ntests": 103
     },
     "sage.groups.perm_gps.partn_ref.refinement_lists": {
         "ntests": 3
@@ -1479,20 +1477,19 @@
         "ntests": 13
     },
     "sage.knots.free_knotinfo_monoid": {
-        "failed": true,
-        "ntests": 66
+        "ntests": 58
     },
     "sage.knots.gauss_code": {
         "ntests": 18
     },
     "sage.knots.knot": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.knots.knotinfo": {
         "ntests": 50
     },
     "sage.knots.link": {
-        "ntests": 63
+        "ntests": 64
     },
     "sage.misc.abstract_method": {
         "ntests": 33
@@ -2106,7 +2103,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 133
+        "ntests": 129
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 396

--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -597,7 +597,7 @@ class SimplicialSets(Category_singleton):
 
                 EXAMPLES::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.combinat sage.graphs
                     sage: X = simplicial_sets.Torus()
                     sage: d = X._canonical_twisting_operator()
                     sage: d
@@ -664,7 +664,7 @@ class SimplicialSets(Category_singleton):
 
                 EXAMPLES::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.graphs sage.modules
                     sage: W = simplicial_sets.Sphere(1).wedge(simplicial_sets.Sphere(2))
                     sage: W.nondegenerate_simplices()
                     [*, sigma_1, sigma_2]
@@ -679,7 +679,7 @@ class SimplicialSets(Category_singleton):
 
                 ::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.graphs sage.modules
                     sage: X = simplicial_sets.Torus()
                     sage: C = X.twisted_chain_complex()
                     sage: C.differential(1)
@@ -693,7 +693,7 @@ class SimplicialSets(Category_singleton):
 
                 ::
 
-                    sage: # needs sage.graphs
+                    sage: # needs sage.graphs sage.modules
                     sage: Y = simplicial_sets.RealProjectiveSpace(2)
                     sage: C = Y.twisted_chain_complex()
                     sage: C.differential(1)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -8684,7 +8684,7 @@ class StandardPermutations_recoilsfiner(Permutations):
         TESTS::
 
             sage: P = Permutations(recoils_finer=[2,2])
-            sage: TestSuite(P).run()                                                    # needs sage.graphs
+            sage: TestSuite(P).run()                                                    # needs sage.graphs sage.modules
         """
         Permutations.__init__(self, category=FiniteEnumeratedSets())
         self.recoils = recoils

--- a/src/sage/combinat/shard_order.py
+++ b/src/sage/combinat/shard_order.py
@@ -229,7 +229,7 @@ def shard_poset(n):
         34*q^4 + 90*q^3 + 79*q^2 + 24*q + 1
         sage: P.characteristic_polynomial()
         q^3 - 11*q^2 + 23*q - 13
-        sage: P.zeta_polynomial()
+        sage: P.zeta_polynomial()                                                       # needs sage.libs.flint
         17/3*q^3 - 6*q^2 + 4/3*q
         sage: P.is_self_dual()
         False

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -497,7 +497,7 @@ class DocTestController(SageObject):
                         if pkg.name in options.hide:
                             continue
                         # Skip features for which we have a more specific runtime feature test.
-                        if pkg.name in ['bliss', 'coxeter3', 'database_graphs', 'eclib', 'ecm', 'fricas', 'frobby', 'gfan', 'giac', 'jmol', 'latte_int', 'macaulay2', 'mcqd', 'meataxe', 'msolve', 'palp', 'plantri', 'qepcad', 'rubiks', 'sirocco', 'sympow', 'tdlib', 'topcom']:
+                        if pkg.name in ['bliss', 'buckygen', 'coxeter3', 'database_graphs', 'eclib', 'ecm', 'fricas', 'frobby', 'gfan', 'giac', 'jmol', 'latte_int', 'macaulay2', 'mcqd', 'meataxe', 'msolve', 'palp', 'plantri', 'qepcad', 'rubiks', 'sirocco', 'sympow', 'tdlib', 'topcom']:
                             continue
                         if pkg.is_installed() and pkg.installed_version == pkg.remote_version:
                             options.optional.add(pkg.name)

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -327,7 +327,7 @@ set of parameters, including number of vertices and edges, density, maximum and
 minimum degree, diameter, radius, and connectivity. To see a list of all search
 parameter keywords broken down by their designated table names, type ::
 
-    sage: graph_db_info()
+    sage: graph_db_info()                                                               # needs database_graphs
     {...}
 
 For more details on data types or keyword input, enter ::
@@ -337,8 +337,8 @@ For more details on data types or keyword input, enter ::
 The results of a query can be viewed with the show method, or can be viewed
 individually by iterating through the results ::
 
-    sage: Q = GraphQuery(display_cols=['graph6'],num_vertices=7, diameter=5)
-    sage: Q.show()
+    sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=7, diameter=5)           # needs database_graphs
+    sage: Q.show()                                                                      # needs database_graphs
     Graph6
     --------------------
     F?`po
@@ -353,7 +353,7 @@ individually by iterating through the results ::
 
 Show each graph as you iterate through the results::
 
-    sage: for g in Q:                                                                   # needs sage.plot
+    sage: for g in Q:                                                                   # needs database_graphs sage.plot
     ....:     show(g)
 
 Visualization
@@ -3373,7 +3373,7 @@ class Graph(GenericGraph):
 
         TESTS::
 
-            sage: G.coloring(algorithm='foo')
+            sage: G.coloring(algorithm='foo')                                           # needs cliquer
             Traceback (most recent call last):
             ...
             ValueError: The 'algorithm' keyword must be set to either 'DLX' or 'MILP'.
@@ -6406,7 +6406,7 @@ class Graph(GenericGraph):
         The cardinality of the vertex cover is unchanged when reduction rules
         are used. First for trees::
 
-           sage: for i in range(20):
+           sage: for i in range(20):                                                    # needs cliquer
            ....:     g = graphs.RandomTree(20)
            ....:     vc1_set = g.vertex_cover()
            ....:     vc1 = len(vc1_set)
@@ -6422,7 +6422,7 @@ class Graph(GenericGraph):
 
         Then for random GNP graphs::
 
-           sage: for i in range(20):
+           sage: for i in range(20):                                                    # needs cliquer
            ....:     g = graphs.RandomGNP(50, 0.08)
            ....:     vc1_set = g.vertex_cover()
            ....:     vc1 = len(vc1_set)
@@ -7631,7 +7631,7 @@ class Graph(GenericGraph):
         TESTS::
 
             sage: G = graphs.CompleteBipartiteGraph(3,3)
-            sage: G.is_inscribable()
+            sage: G.is_inscribable()                                                    # needs planarity
             Traceback (most recent call last):
             ...
             NotImplementedError: this method only works for polyhedral graphs

--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -1628,7 +1628,7 @@ class GraphGenerators:
              18: [12, 20, 13],
              19: [14, 20, 15],
              20: [17, 19, 18]}
-            sage: g.plot3d(layout='spring')
+            sage: g.plot3d(layout='spring')                                             # needs sage.plot
             Graphics3d Object
         """
         # number of vertices should be positive

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -310,11 +310,11 @@ def is_bicritical(G, matching=None, algorithm='Edmonds', coNP_certificate=False,
     One may specify a matching::
 
         sage: G = graphs.WheelGraph(10)
-        sage: M = G.matching()
+        sage: M = G.matching()                                                      # needs networkx
         sage: G.is_bicritical(matching=M)                                           # needs networkx
         True
         sage: H = graphs.HexahedralGraph()
-        sage: N = H.matching()
+        sage: N = H.matching()                                                      # needs networkx
         sage: H.is_bicritical(matching=N)                                           # needs networkx
         False
 
@@ -324,7 +324,7 @@ def is_bicritical(G, matching=None, algorithm='Edmonds', coNP_certificate=False,
         sage: G.is_bicritical(coNP_certificate=True)                                # needs networkx
         (True, None)
         sage: H = graphs.CircularLadderGraph(20)
-        sage: M = H.matching()
+        sage: M = H.matching()                                                      # needs networkx
         sage: H.is_bicritical(matching=M, coNP_certificate=True)                    # needs networkx
         (False, {0, 2})
 

--- a/src/sage/graphs/strongly_regular_db.pyx
+++ b/src/sage/graphs/strongly_regular_db.pyx
@@ -2816,9 +2816,9 @@ def strongly_regular_graph(int v, int k, int l, int mu=-1, bint existence=False,
 
     An obviously infeasible set of parameters::
 
-        sage: graphs.strongly_regular_graph(5,5,5,5,existence=True)
+        sage: graphs.strongly_regular_graph(5,5,5,5, existence=True)    # needs database_graphs
         False
-        sage: graphs.strongly_regular_graph(5,5,5,5)
+        sage: graphs.strongly_regular_graph(5,5,5,5)                    # needs database_graphs
         Traceback (most recent call last):
         ...
         ValueError: There exists no (5, 5, 5, 5)-strongly regular graph

--- a/src/sage/knots/free_knotinfo_monoid.py
+++ b/src/sage/knots/free_knotinfo_monoid.py
@@ -264,6 +264,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
+            sage: # needs sage.groups
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: FKIM.inject_variables(select=3)
@@ -271,7 +272,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
             Defining K3_1m
             sage: elems = (K3_1, K3_1m)
             sage: K = Knots().from_table(3, 1)
-            sage: FKIM._check_elements(K, elems)                                        # needs sage.modules
+            sage: FKIM._check_elements(K, elems)
             KnotInfo['K3_1m']
             sage: K = Knots().from_table(4, 1)
             sage: FKIM._check_elements(K, elems) is None

--- a/src/sage/misc/classgraph.py
+++ b/src/sage/misc/classgraph.py
@@ -37,6 +37,7 @@ def class_graph(top, depth=5, name_filter=None, classes=None, as_graph=True):
 
     We construct the inheritance graph of the classes within a given module::
 
+        sage: # needs sage.rings.padics
         sage: from sage.rings.polynomial.padics import polynomial_padic_capped_relative_dense, polynomial_padic_flat
         sage: G = class_graph(sage.rings.polynomial.padics); G
         Digraph on 6 vertices

--- a/src/sage/misc/rest_index_of_methods.py
+++ b/src/sage/misc/rest_index_of_methods.py
@@ -148,14 +148,14 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
     A function that is imported into a class under a different name is listed
     under its 'new' name::
 
-        sage: 'cliques_maximum' in gen_rest_table_index(Graph)                          # needs sage.graphs
+        sage: 'cliques_maximum' in gen_rest_table_index(Graph)                          # needs cliquer sage.graphs
         True
-        sage: 'all_max_cliques`' in gen_rest_table_index(Graph)                         # needs sage.graphs
+        sage: 'all_max_cliques`' in gen_rest_table_index(Graph)                         # needs cliquer sage.graphs
         False
 
     Check that :issue:`36178` is fixed::
 
-        sage: print(gen_rest_table_index(Graph))                                        # needs sage.graphs
+        sage: print(gen_rest_table_index(Graph))                                        # needs cliquer sage.graphs
         ...
            :meth:`~sage.graphs.graph.Graph.independent_set` @ Return a maximum independent set.
         ...


### PR DESCRIPTION
- **src/sage/doctest/control.py: Override spkg feature buckygen**
- **src/sage/graphs: Add # needs**
- **src/sage/categories/simplicial_sets.py: Add # needs**
- **src/sage/combinat: Add # needs**
- **src/sage/graphs: Add # needs**
- **src/sage/knots/free_knotinfo_monoid.py: Add # needs**
- **src/sage/misc/classgraph.py: Add # needs**
- **src/sage/misc/rest_index_of_methods.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-graphs*' --update-known-test-failures**
