### PR TITLE
pkgs/sagemath-modules: Modularization fixes

### DIFF
--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -1259,7 +1259,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "ntests": 181
+        "ntests": 182
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1489,7 +1489,6 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
-        "failed": true,
         "ntests": 5
     },
     "sage.interfaces.abc": {
@@ -1708,6 +1707,9 @@
     },
     "sage.misc.classcall_metaclass": {
         "ntests": 78
+    },
+    "sage.misc.classgraph": {
+        "ntests": 1
     },
     "sage.misc.compat": {
         "ntests": 2
@@ -2841,7 +2843,7 @@
     },
     "sage.stats.distributions.discrete_gaussian_lattice": {
         "failed": true,
-        "ntests": 150
+        "ntests": 114
     },
     "sage.stats.distributions.discrete_gaussian_polynomial": {
         "ntests": 24
@@ -3041,7 +3043,7 @@
         "ntests": 8
     },
     "sage.tests.cmdline": {
-        "ntests": 133
+        "ntests": 108
     },
     "sage.tests.finite_poset": {
         "ntests": 1

--- a/src/sage/functions/gamma.py
+++ b/src/sage/functions/gamma.py
@@ -442,16 +442,16 @@ class Function_gamma_inc(BuiltinFunction):
         Check that :issue:`7099` is fixed::
 
             sage: R = RealField(1024)                                                   # needs sage.rings.real_mpfr
-            sage: gamma(R(9), R(10^-3))  # rel tol 1e-308                               # needs sage.rings.real_mpfr
+            sage: gamma(R(9), R(10^-3))  # rel tol 1e-308                               # needs sage.libs.pari sage.rings.real_mpfr
             40319.99999999999999999999999999988898884344822911869926361916294165058203634104838326009191542490601781777105678829520585311300510347676330951251563007679436243294653538925717144381702105700908686088851362675381239820118402497959018315224423868693918493033078310647199219674433536605771315869983788442389633
             sage: numerical_approx(gamma(9, 10^(-3)) - gamma(9), digits=40)  # abs tol 1e-36        # needs sage.symbolic
             -1.110111598370794007949063502542063148294e-28
 
         Check that :issue:`17328` is fixed::
 
-            sage: gamma_inc(float(-1), float(-1))                                       # needs sage.rings.real_mpfr
+            sage: gamma_inc(float(-1), float(-1))                                       # needs sage.libs.pari sage.rings.real_mpfr
             (-0.8231640121031085+3.141592653589793j)
-            sage: gamma_inc(RR(-1), RR(-1))                                             # needs sage.rings.complex_double
+            sage: gamma_inc(RR(-1), RR(-1))                                             # needs sage.rings.complex_double sage.rings.real_mpfr
             -0.823164012103109 + 3.14159265358979*I
             sage: gamma_inc(-1, float(-log(3))) - gamma_inc(-1, float(-log(2)))  # abs tol 1e-15    # needs sage.symbolic
             (1.2730972164471142+0j)

--- a/src/sage/misc/sage_eval.py
+++ b/src/sage/misc/sage_eval.py
@@ -179,9 +179,12 @@ def sage_eval(source, locals=None, cmds='', preparse=True):
             import sage.all__sagemath_polyhedra as toplevel
         except ImportError:
             try:
-                import sage.all__sagemath_categories as toplevel
+                import sage.all__sagemath_modules as toplevel
             except ImportError:
-                import sage.all__sagemath_objects as toplevel
+                try:
+                    import sage.all__sagemath_categories as toplevel
+                except ImportError:
+                    import sage.all__sagemath_objects as toplevel
     if cmds:
         cmd_seq = cmds + '\n_sage_eval_returnval_ = ' + source
         if preparse:

--- a/src/sage/stats/distributions/discrete_gaussian_lattice.py
+++ b/src/sage/stats/distributions/discrete_gaussian_lattice.py
@@ -207,12 +207,12 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: n = 3; sigma = 1.0
             sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(ZZ^n, sigma)
             sage: f = D.f
             sage: nf = D._normalisation_factor_zz(); nf
             15.7496...
-
             sage: from collections import defaultdict
             sage: counter = defaultdict(Integer)
             sage: m = 0
@@ -221,23 +221,18 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             ....:     for _ in range(i):
             ....:         counter[D()] += 1
             ....:         m += 1
-
             sage: v = vector(ZZ, n, (0, 0, 0))
             sage: v.set_immutable()
             sage: while v not in counter:
             ....:     add_samples(1000)
-
             sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:
             ....:     add_samples(1000)
-
             sage: v = vector(ZZ, n, (-1, 2, 3))
             sage: v.set_immutable()
             sage: while v not in counter:
             ....:     add_samples(1000)
-
             sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.2:  # long time
             ....:     add_samples(1000)
-
             sage: DGL = distributions.DiscreteGaussianDistributionLatticeSampler
             sage: D = DGL(ZZ^8, 0.5)
             sage: D._normalisation_factor_zz(tau=3)
@@ -247,32 +242,27 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: D = DGL(ZZ^8, 1000)
             sage: round(D._normalisation_factor_zz(prec=100))
             1558545456544038969634991553
-
             sage: M = Matrix(ZZ, [[1, 3, 0], [-2, 5, 1], [3, -4, 2]])
             sage: D = DGL(M, 1.7)
             sage: D._normalisation_factor_zz()  # long time
             Traceback (most recent call last):
             ...
             NotImplementedError: center must be at zero and basis must be trivial
-
             sage: Sigma = Matrix(ZZ, [[5, -2, 4], [-2, 10, -5], [4, -5, 5]])
             sage: D = DGL(ZZ^3, Sigma, [7, 2, 5])
             sage: D._normalisation_factor_zz()
             78.6804...
-
             sage: M = Matrix(ZZ, [[1, 3, 0], [-2, 5, 1]])
             sage: D = DGL(M, 3)
             sage: D._normalisation_factor_zz()
             Traceback (most recent call last):
             ...
             NotImplementedError: basis must be a square matrix
-
             sage: D = DGL(ZZ^3, c=(1/2, 0, 0))
             sage: D._normalisation_factor_zz()
             Traceback (most recent call last):
             ...
             NotImplementedError: center must be at zero and basis must be trivial
-
             sage: D = DGL(Matrix(3, 3, 1/2))
             sage: D._normalisation_factor_zz()
             Traceback (most recent call last):
@@ -374,8 +364,8 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(ZZ^n, Sigma, c)
             sage: r = D._maximal_r(); r
             0.58402...
-            sage: e_vals = (D.sigma() - r^2 * D.Q).eigenvalues()
-            sage: assert all(e_val >= -1e-12 for e_val in e_vals)
+            sage: e_vals = (D.sigma() - r^2 * D.Q).eigenvalues()                        # needs sage.libs.pari
+            sage: assert all(e_val >= -1e-12 for e_val in e_vals)                       # needs sage.libs.pari
         """
         assert not self.is_spherical
 
@@ -404,7 +394,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
 
             sage: Sigma = Matrix(ZZ, [[5, -2, 4], [-2, 10, -5], [4, -5, 5]])
             sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(ZZ^3, Sigma)
-            sage: all(D._randomise([0, 0, 0]).norm() <= 16 for _ in range(100))
+            sage: all(D._randomise([0, 0, 0]).norm() <= 16 for _ in range(100))         # needs sage.symbolic
             True
         """
         return vector(ZZ, [DiscreteGaussianDistributionIntegerSampler(self.r, c=vi)() for vi in v])
@@ -679,6 +669,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: norm(mean_L.n() - D.c()) < 0.25   # long time
             True
 
+            sage: # needs numpy
             sage: import numpy
             sage: M = matrix(ZZ, [[1,2],[0,1]])
             sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(M, 20.0)

--- a/src/sage/stats/distributions/discrete_gaussian_lattice.py
+++ b/src/sage/stats/distributions/discrete_gaussian_lattice.py
@@ -68,12 +68,14 @@ from sage.stats.distributions.discrete_gaussian_integer import DiscreteGaussianD
 from sage.structure.sage_object import SageObject
 from sage.misc.cachefunc import cached_method
 from sage.misc.functional import sqrt
+from sage.misc.lazy_import import lazy_import
 from sage.misc.prandom import normalvariate
 from sage.misc.verbose import verbose
-from sage.symbolic.constants import pi
 from sage.matrix.constructor import matrix
 from sage.modules.free_module import FreeModule
 from sage.modules.free_module_element import vector
+
+lazy_import('sage.symbolic.constants', 'pi')
 
 
 def _iter_vectors(n, lower, upper, step=None):


### PR DESCRIPTION
- **src/sage/stats/distributions/discrete_gaussian_lattice.py: Use lazy_import**
- **src/sage/misc/sage_eval.py: Try sage.all__sagemath_modules as toplevel**
- **src/sage/stats/distributions/discrete_gaussian_lattice.py: Add # needs**
- **src/sage/functions/gamma.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-modules' --update-known-test-failures**
