### PR TITLE
pkgs/sagemath-categories: Move sage.combinat.q_analogues here from sagemath-combinat

### DIFF
--- a/pkgs/sagemath-categories/MANIFEST.in
+++ b/pkgs/sagemath-categories/MANIFEST.in
@@ -225,6 +225,7 @@ include sage/combinat/partition.p*
 include sage/combinat/partitions.p*
 include sage/combinat/permutation.p*
 include sage/combinat/permutation_cython.p*
+include sage/combinat/q_analogues.p*
 include sage/combinat/ranker.py                                         # for sage.sets.finite_set_map_cy
 include sage/combinat/subset.p*
 include sage/combinat/tools.p*

--- a/pkgs/sagemath-categories/known-test-failures.json
+++ b/pkgs/sagemath-categories/known-test-failures.json
@@ -704,11 +704,21 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 9
     },
+    "sage.combinat.partition": {
+        "ntests": 1194
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
     "sage.combinat.permutation": {
         "ntests": 1184
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "failed": true,
+        "ntests": 113
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -920,7 +930,7 @@
         "ntests": 4
     },
     "sage.features.mip_backends": {
-        "ntests": 7
+        "ntests": 9
     },
     "sage.features.msolve": {
         "ntests": 6
@@ -1990,7 +2000,7 @@
     },
     "sage.structure.element": {
         "failed": true,
-        "ntests": 562
+        "ntests": 565
     },
     "sage.structure.element.pxd": {
         "ntests": 18

--- a/pkgs/sagemath-combinat/MANIFEST.in
+++ b/pkgs/sagemath-combinat/MANIFEST.in
@@ -36,6 +36,7 @@ exclude sage/combinat/partition.p*                                      # for jo
 exclude sage/combinat/partitions.p*
 exclude sage/combinat/permutation.p*
 exclude sage/combinat/permutation_cython.p*
+exclude sage/combinat/q_analogues.p*
 exclude sage/combinat/ranker.py                                         # for sage.sets.finite_set_map_cy
 exclude sage/combinat/subset.p*
 exclude sage/combinat/tools.p*

--- a/pkgs/sagemath-flint/known-test-failures.json
+++ b/pkgs/sagemath-flint/known-test-failures.json
@@ -32,7 +32,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "ntests": 73
+        "ntests": 75
     },
     "sage.algebras.orlik_terao": {
         "ntests": 80
@@ -73,7 +73,7 @@
         "ntests": 77
     },
     "sage.calculus.functional": {
-        "ntests": 2
+        "ntests": 3
     },
     "sage.calculus.interpolation": {
         "ntests": 67
@@ -169,6 +169,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 26
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -216,11 +219,10 @@
         "ntests": 2
     },
     "sage.categories.coxeter_groups": {
-        "failed": true,
         "ntests": 368
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -272,8 +274,7 @@
         "ntests": 17
     },
     "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 96
+        "ntests": 1
     },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
@@ -330,12 +331,10 @@
         "ntests": 136
     },
     "sage.categories.filtered_algebras": {
-        "failed": true,
         "ntests": 5
     },
     "sage.categories.filtered_algebras_with_basis": {
-        "failed": true,
-        "ntests": 63
+        "ntests": 53
     },
     "sage.categories.filtered_hopf_algebras_with_basis": {
         "ntests": 17
@@ -351,11 +350,10 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "failed": true,
-        "ntests": 123
+        "ntests": 92
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -370,8 +368,7 @@
         "ntests": 3
     },
     "sage.categories.finite_dimensional_lie_algebras_with_basis": {
-        "failed": true,
-        "ntests": 172
+        "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "failed": true,
@@ -399,7 +396,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -426,7 +423,6 @@
         "ntests": 11
     },
     "sage.categories.functor": {
-        "failed": true,
         "ntests": 137
     },
     "sage.categories.g_sets": {
@@ -535,11 +531,9 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "failed": true,
-        "ntests": 120
+        "ntests": 112
     },
     "sage.categories.lie_algebras_with_basis": {
-        "failed": true,
         "ntests": 19
     },
     "sage.categories.lie_conformal_algebras": {
@@ -904,6 +898,13 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 13
     },
+    "sage.combinat.partition": {
+        "failed": true,
+        "ntests": 1231
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
     "sage.combinat.permutation": {
         "failed": true,
         "ntests": 1195
@@ -1091,7 +1092,6 @@
         "ntests": 138
     },
     "sage.crypto.boolean_function": {
-        "failed": true,
         "ntests": 206
     },
     "sage.crypto.classical": {
@@ -1138,7 +1138,6 @@
         "ntests": 283
     },
     "sage.crypto.sboxes": {
-        "failed": true,
         "ntests": 27
     },
     "sage.data_structures.bitset": {
@@ -1156,6 +1155,9 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
+    "sage.databases.conway": {
+        "ntests": 42
+    },
     "sage.databases.sql_db": {
         "ntests": 230
     },
@@ -1166,7 +1168,7 @@
         "ntests": 3
     },
     "sage.doctest.external": {
-        "ntests": 43
+        "ntests": 42
     },
     "sage.doctest.fixtures": {
         "ntests": 59
@@ -1236,6 +1238,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
     "sage.features.ecm": {
         "ntests": 4
     },
@@ -1272,6 +1277,9 @@
     "sage.features.imagemagick": {
         "ntests": 10
     },
+    "sage.features.info": {
+        "ntests": 4
+    },
     "sage.features.interfaces": {
         "ntests": 34
     },
@@ -1297,7 +1305,7 @@
         "ntests": 16
     },
     "sage.features.macaulay2": {
-        "ntests": 4
+        "ntests": 3
     },
     "sage.features.mcqd": {
         "ntests": 4
@@ -1306,7 +1314,7 @@
         "ntests": 4
     },
     "sage.features.mip_backends": {
-        "ntests": 7
+        "ntests": 9
     },
     "sage.features.msolve": {
         "ntests": 6
@@ -1345,7 +1353,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "ntests": 181
+        "ntests": 182
     },
     "sage.features.sat": {
         "ntests": 16
@@ -1386,14 +1394,14 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 160
+        "ntests": 162
     },
     "sage.functions.gamma": {
         "failed": true,
         "ntests": 141
     },
     "sage.functions.generalized": {
-        "ntests": 69
+        "ntests": 70
     },
     "sage.functions.hyperbolic": {
         "ntests": 81
@@ -1419,7 +1427,7 @@
     },
     "sage.functions.other": {
         "failed": true,
-        "ntests": 244
+        "ntests": 245
     },
     "sage.functions.piecewise": {
         "ntests": 6
@@ -1453,12 +1461,15 @@
     "sage.geometry.toric_lattice_element": {
         "ntests": 80
     },
+    "sage.graphs.chrompoly": {
+        "ntests": 2
+    },
     "sage.graphs.matchpoly": {
         "ntests": 3
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 238
+        "ntests": 240
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 26
@@ -1498,7 +1509,6 @@
         "ntests": 32
     },
     "sage.groups.generic": {
-        "failed": true,
         "ntests": 185
     },
     "sage.groups.group": {
@@ -1518,7 +1528,7 @@
     },
     "sage.groups.matrix_gps.matrix_group": {
         "failed": true,
-        "ntests": 53
+        "ntests": 54
     },
     "sage.groups.matrix_gps.named_group": {
         "ntests": 21
@@ -1588,11 +1598,14 @@
     "sage.interfaces.abc": {
         "ntests": 8
     },
+    "sage.interfaces.genus2reduction": {
+        "ntests": 23
+    },
     "sage.interfaces.gp": {
         "ntests": 142
     },
     "sage.interfaces.interface": {
-        "ntests": 4
+        "ntests": 10
     },
     "sage.interfaces.process": {
         "ntests": 39
@@ -1646,7 +1659,6 @@
         "ntests": 22
     },
     "sage.libs.mpmath.utils": {
-        "failed": true,
         "ntests": 57
     },
     "sage.libs.ntl.error": {
@@ -1659,7 +1671,6 @@
         "ntests": 70
     },
     "sage.libs.ntl.ntl_GF2EContext": {
-        "failed": true,
         "ntests": 20
     },
     "sage.libs.ntl.ntl_GF2EX": {
@@ -1712,7 +1723,6 @@
         "ntests": 107
     },
     "sage.libs.ntl.ntl_mat_GF2E": {
-        "failed": true,
         "ntests": 132
     },
     "sage.libs.ntl.ntl_mat_ZZ": {
@@ -1774,7 +1784,7 @@
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 447
+        "ntests": 441
     },
     "sage.matrix.matrix2": {
         "failed": true,
@@ -1899,7 +1909,7 @@
         "ntests": 654
     },
     "sage.matroids.matroid": {
-        "ntests": 943
+        "ntests": 938
     },
     "sage.matroids.matroids_plot_helpers": {
         "ntests": 13
@@ -1956,6 +1966,9 @@
     "sage.misc.classcall_metaclass": {
         "ntests": 78
     },
+    "sage.misc.classgraph": {
+        "ntests": 1
+    },
     "sage.misc.compat": {
         "ntests": 2
     },
@@ -2001,7 +2014,6 @@
         "ntests": 32
     },
     "sage.misc.functional": {
-        "failed": true,
         "ntests": 315
     },
     "sage.misc.gperftools": {
@@ -2139,7 +2151,7 @@
     },
     "sage.misc.sageinspect": {
         "failed": true,
-        "ntests": 330
+        "ntests": 326
     },
     "sage.misc.search": {
         "ntests": 4
@@ -2187,6 +2199,12 @@
     "sage.misc.weak_dict": {
         "ntests": 281
     },
+    "sage.modular.modform.eis_series_cython": {
+        "ntests": 6
+    },
+    "sage.modular.modsym.apply": {
+        "ntests": 6
+    },
     "sage.modules.complex_double_vector": {
         "ntests": 2
     },
@@ -2211,17 +2229,17 @@
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1466
+        "ntests": 1465
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 959
+        "ntests": 954
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 8
+        "ntests": 12
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
@@ -2252,7 +2270,6 @@
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "failed": true,
         "ntests": 124
     },
     "sage.modules.real_double_vector": {
@@ -2288,7 +2305,7 @@
         "ntests": 45
     },
     "sage.modules.vector_numpy_integer_dense": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.modules.vector_rational_dense": {
         "ntests": 45
@@ -2300,18 +2317,15 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "failed": true,
         "ntests": 157
     },
     "sage.modules.with_basis.indexed_element": {
-        "failed": true,
-        "ntests": 166
+        "ntests": 160
     },
     "sage.modules.with_basis.morphism": {
         "ntests": 353
     },
     "sage.modules.with_basis.subquotient": {
-        "failed": true,
         "ntests": 152
     },
     "sage.numerical.backends.generic_backend": {
@@ -2481,7 +2495,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 116
+        "ntests": 113
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -2589,11 +2603,9 @@
         "ntests": 333
     },
     "sage.rings.complex_interval": {
-        "failed": true,
         "ntests": 265
     },
     "sage.rings.complex_interval_field": {
-        "failed": true,
         "ntests": 131
     },
     "sage.rings.complex_mpc": {
@@ -2641,7 +2653,7 @@
     },
     "sage.rings.finite_rings.finite_field_base": {
         "failed": true,
-        "ntests": 345
+        "ntests": 340
     },
     "sage.rings.finite_rings.finite_field_constructor": {
         "failed": true,
@@ -2652,7 +2664,6 @@
         "ntests": 61
     },
     "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "failed": true,
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
@@ -2676,8 +2687,7 @@
         "ntests": 583
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "failed": true,
-        "ntests": 369
+        "ntests": 367
     },
     "sage.rings.finite_rings.maps_finite_field": {
         "ntests": 31
@@ -2725,8 +2735,7 @@
         "ntests": 7
     },
     "sage.rings.function_field.function_field": {
-        "failed": true,
-        "ntests": 184
+        "ntests": 168
     },
     "sage.rings.function_field.function_field_rational": {
         "failed": true,
@@ -2772,8 +2781,7 @@
         "ntests": 44
     },
     "sage.rings.ideal": {
-        "failed": true,
-        "ntests": 370
+        "ntests": 361
     },
     "sage.rings.ideal_monoid": {
         "ntests": 22
@@ -2782,15 +2790,13 @@
         "ntests": 313
     },
     "sage.rings.integer": {
-        "failed": true,
         "ntests": 1160
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
     },
     "sage.rings.integer_ring": {
-        "failed": true,
-        "ntests": 230
+        "ntests": 229
     },
     "sage.rings.invariants.invariant_theory": {
         "failed": true,
@@ -2814,7 +2820,7 @@
     },
     "sage.rings.morphism": {
         "failed": true,
-        "ntests": 547
+        "ntests": 549
     },
     "sage.rings.multi_power_series_ring": {
         "failed": true,
@@ -2903,26 +2909,21 @@
         "ntests": 175
     },
     "sage.rings.padics.CA_template.pxi": {
-        "failed": true,
         "ntests": 311
     },
     "sage.rings.padics.CR_template.pxi": {
-        "failed": true,
         "ntests": 431
     },
     "sage.rings.padics.FM_template.pxi": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.padics.FP_template.pxi": {
-        "failed": true,
         "ntests": 342
     },
     "sage.rings.padics.eisenstein_extension_generic": {
         "ntests": 41
     },
     "sage.rings.padics.factory": {
-        "failed": true,
         "ntests": 559
     },
     "sage.rings.padics.generic_nodes": {
@@ -2960,11 +2961,9 @@
         "ntests": 185
     },
     "sage.rings.padics.padic_extension_generic": {
-        "failed": true,
         "ntests": 208
     },
     "sage.rings.padics.padic_extension_leaves": {
-        "failed": true,
         "ntests": 72
     },
     "sage.rings.padics.padic_generic": {
@@ -2978,7 +2977,6 @@
         "ntests": 269
     },
     "sage.rings.padics.padic_printing": {
-        "failed": true,
         "ntests": 108
     },
     "sage.rings.padics.padic_relaxed_errors": {
@@ -2997,43 +2995,33 @@
         "ntests": 76
     },
     "sage.rings.padics.pow_computer_relative": {
-        "failed": true,
         "ntests": 97
     },
     "sage.rings.padics.qadic_flint_CA": {
-        "failed": true,
         "ntests": 19
     },
     "sage.rings.padics.qadic_flint_CR": {
-        "failed": true,
         "ntests": 23
     },
     "sage.rings.padics.qadic_flint_FM": {
-        "failed": true,
         "ntests": 17
     },
     "sage.rings.padics.qadic_flint_FP": {
-        "failed": true,
         "ntests": 22
     },
     "sage.rings.padics.relative_extension_leaves": {
-        "failed": true,
         "ntests": 87
     },
     "sage.rings.padics.relative_ramified_CA": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_CR": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FM": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relative_ramified_FP": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.padics.relaxed_template.pxi": {
@@ -3043,11 +3031,9 @@
         "ntests": 12
     },
     "sage.rings.padics.tutorial": {
-        "failed": true,
         "ntests": 45
     },
     "sage.rings.padics.unramified_extension_generic": {
-        "failed": true,
         "ntests": 33
     },
     "sage.rings.pari_ring": {
@@ -3095,22 +3081,22 @@
         "ntests": 160
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 117
+        "ntests": 119
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 545
+        "ntests": 542
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
-        "ntests": 291
+        "ntests": 289
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "ntests": 51
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 155
+        "ntests": 149
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "failed": true,
@@ -3118,7 +3104,7 @@
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 141
+        "ntests": 138
     },
     "sage.rings.polynomial.ore_function_element": {
         "failed": true,
@@ -3148,7 +3134,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2366
+        "ntests": 2368
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 209
@@ -3160,7 +3146,6 @@
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
-        "failed": true,
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
@@ -3169,10 +3154,9 @@
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
         "failed": true,
-        "ntests": 349
+        "ntests": 340
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "failed": true,
         "ntests": 119
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
@@ -3184,7 +3168,7 @@
     },
     "sage.rings.polynomial.polynomial_ring": {
         "failed": true,
-        "ntests": 523
+        "ntests": 521
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -3217,8 +3201,7 @@
         "ntests": 9
     },
     "sage.rings.polynomial.term_order": {
-        "failed": true,
-        "ntests": 328
+        "ntests": 327
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 32
@@ -3258,8 +3241,7 @@
         "ntests": 153
     },
     "sage.rings.quotient_ring": {
-        "failed": true,
-        "ntests": 208
+        "ntests": 204
     },
     "sage.rings.quotient_ring_element": {
         "ntests": 100
@@ -3268,8 +3250,7 @@
         "ntests": 556
     },
     "sage.rings.rational_field": {
-        "failed": true,
-        "ntests": 203
+        "ntests": 202
     },
     "sage.rings.real_arb": {
         "failed": true,
@@ -3279,7 +3260,6 @@
         "ntests": 299
     },
     "sage.rings.real_double_element_gsl": {
-        "failed": true,
         "ntests": 145
     },
     "sage.rings.real_field": {
@@ -3293,8 +3273,7 @@
         "ntests": 279
     },
     "sage.rings.real_mpfi": {
-        "failed": true,
-        "ntests": 907
+        "ntests": 894
     },
     "sage.rings.real_mpfr": {
         "failed": true,
@@ -3305,11 +3284,9 @@
         "ntests": 186
     },
     "sage.rings.ring_extension": {
-        "failed": true,
         "ntests": 380
     },
     "sage.rings.ring_extension_conversion": {
-        "failed": true,
         "ntests": 75
     },
     "sage.rings.ring_extension_element": {
@@ -3317,11 +3294,9 @@
         "ntests": 247
     },
     "sage.rings.ring_extension_homset": {
-        "failed": true,
         "ntests": 9
     },
     "sage.rings.ring_extension_morphism": {
-        "failed": true,
         "ntests": 138
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
@@ -3337,13 +3312,12 @@
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
-        "ntests": 8
+        "ntests": 6
     },
     "sage.rings.sum_of_squares": {
         "ntests": 35
     },
     "sage.rings.tate_algebra": {
-        "failed": true,
         "ntests": 267
     },
     "sage.rings.tate_algebra_element": {
@@ -3366,7 +3340,7 @@
         "ntests": 139
     },
     "sage.rings.valuation.inductive_valuation": {
-        "ntests": 271
+        "ntests": 273
     },
     "sage.rings.valuation.limit_valuation": {
         "ntests": 22
@@ -3394,7 +3368,7 @@
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 318
+        "ntests": 321
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
@@ -3409,6 +3383,10 @@
     },
     "sage.schemes.affine.affine_subscheme": {
         "ntests": 79
+    },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "failed": true,
+        "ntests": 17
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
@@ -3642,7 +3620,6 @@
         "ntests": 320
     },
     "sage.structure.parent_gens": {
-        "failed": true,
         "ntests": 41
     },
     "sage.structure.parent_old": {
@@ -3752,7 +3729,7 @@
         "ntests": 245
     },
     "sage.tests.cmdline": {
-        "ntests": 133
+        "ntests": 113
     },
     "sage.tests.finite_poset": {
         "ntests": 1

--- a/pkgs/sagemath-flint/known-test-failures.json
+++ b/pkgs/sagemath-flint/known-test-failures.json
@@ -643,7 +643,6 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "failed": true,
         "ntests": 227
     },
     "sage.categories.rngs": {
@@ -785,7 +784,6 @@
         "ntests": 81
     },
     "sage.coding.gabidulin_code": {
-        "failed": true,
         "ntests": 235
     },
     "sage.coding.golay_code": {
@@ -899,7 +897,6 @@
         "ntests": 13
     },
     "sage.combinat.partition": {
-        "failed": true,
         "ntests": 1231
     },
     "sage.combinat.partitions": {
@@ -911,6 +908,9 @@
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "ntests": 127
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -3107,7 +3107,6 @@
         "ntests": 138
     },
     "sage.rings.polynomial.ore_function_element": {
-        "failed": true,
         "ntests": 243
     },
     "sage.rings.polynomial.ore_function_field": {

--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -770,7 +770,8 @@
         "ntests": 5
     },
     "sage.coding.linear_code": {
-        "ntests": 40
+        "failed": true,
+        "ntests": 0
     },
     "sage.coding.linear_code_no_metric": {
         "ntests": 2
@@ -829,11 +830,21 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 13
     },
+    "sage.combinat.partition": {
+        "ntests": 1194
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
     "sage.combinat.permutation": {
         "ntests": 1195
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "failed": true,
+        "ntests": 113
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -1220,7 +1231,7 @@
         "ntests": 4
     },
     "sage.features.mip_backends": {
-        "ntests": 7
+        "ntests": 9
     },
     "sage.features.msolve": {
         "ntests": 6
@@ -1489,6 +1500,7 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
+        "failed": true,
         "ntests": 5
     },
     "sage.interfaces.abc": {
@@ -2887,7 +2899,7 @@
     },
     "sage.structure.element": {
         "failed": true,
-        "ntests": 657
+        "ntests": 660
     },
     "sage.structure.element.pxd": {
         "ntests": 23

--- a/src/sage/combinat/all__sagemath_categories.py
+++ b/src/sage/combinat/all__sagemath_categories.py
@@ -26,6 +26,8 @@ from sage.combinat.partition import (Partition, Partitions, PartitionsInBox,
 from sage.combinat.subset import Subsets, subsets, powerset, uniq
 from sage.combinat.tuple import Tuples, UnorderedTuples
 
+lazy_import('sage.combinat.q_analogues', ['gaussian_binomial', 'q_binomial',
+                                          'number_of_irreducible_polynomials'])
 
 from sage.combinat.dlx import DLXMatrix, AllExactCovers, OneExactCover
 

--- a/src/sage/combinat/all__sagemath_combinat.py
+++ b/src/sage/combinat/all__sagemath_combinat.py
@@ -144,8 +144,6 @@ from sage.combinat.matrices.all import *
 lazy_import('sage.combinat.integer_vectors_mod_permgroup',
             'IntegerVectorsModPermutationGroup')
 
-lazy_import('sage.combinat.q_analogues', ['gaussian_binomial', 'q_binomial', 'number_of_irreducible_polynomials'])
-
 from sage.combinat.species.all import *
 
 lazy_import('sage.combinat.kazhdan_lusztig', 'KazhdanLusztigPolynomial')

--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -1557,7 +1557,7 @@ class SignedPermutation(ColoredPermutation,
             sage: G = SignedPermutations(5)
             sage: all(pi.cycle_type().size() == 5 for pi in G)
             True
-            sage: set(pi.cycle_type() for pi in G) == set(PartitionTuples(2, 5))
+            sage: set(pi.cycle_type() for pi in G) == set(PartitionTuples(2, 5))        # needs sage.libs.flint
             True
         """
         cycles = self.to_cycles(negative_cycles=False)
@@ -1864,7 +1864,7 @@ class SignedPermutations(ColoredPermutations):
         EXAMPLES::
 
             sage: G = SignedPermutations(4)
-            sage: for nu in PartitionTuples(2, 4):
+            sage: for nu in PartitionTuples(2, 4):                                      # needs sage.libs.flint
             ....:     print(nu, G.conjugacy_class_representative(nu))
             ....:     assert nu == G.conjugacy_class_representative(nu).cycle_type(), nu
             ([4], []) [2, 3, 4, 1]
@@ -1890,7 +1890,7 @@ class SignedPermutations(ColoredPermutations):
 
         TESTS::
 
-            sage: all(nu == SignedPermutations(n).conjugacy_class_representative(nu).cycle_type()
+            sage: all(nu == SignedPermutations(n).conjugacy_class_representative(nu).cycle_type()   # needs sage.libs.flint
             ....:     for n in range(1, 6) for nu in PartitionTuples(2, n))
             True
         """

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7416,12 +7416,12 @@ class Partitions_nk(Partitions):
 
             sage: N = [0, 1, 2, 3, 5, 10, 20, 500, 850]
             sage: K = [0, 1, 2, 3, 5, 10, 11, 20, 21, 250, 499, 500]
-            sage: all(Partitions(n, length=k).cardinality()                             # needs sage.libs.flint
+            sage: all(Partitions(n, length=k).cardinality()                             # needs sage.libs.flint sage.libs.gap
             ....:       == Partitions(n,length=k).cardinality('gap')
             ....:     for n in N for k in K)
             True
             sage: P = Partitions(4562, length=2800)
-            sage: P.cardinality() == P.cardinality('gap')                               # needs sage.libs.flint
+            sage: P.cardinality() == P.cardinality('gap')                               # needs sage.libs.flint sage.libs.gap
             True
         """
         return number_of_partitions_length(self.n, self.k, algorithm)

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -9458,8 +9458,7 @@ except ImportError:
 
 # October 2012: fixing outdated pickles which use classes being deprecated
 from sage.misc.persist import register_unpickle_override
-lazy_import('sage.combinat.partition_tuple', 'PartitionTuples_level_size')
-register_unpickle_override('sage.combinat.partition', 'PartitionTuples_nk', PartitionTuples_level_size)
+
 register_unpickle_override('sage.combinat.partition', 'Partition_class', Partition)
 register_unpickle_override('sage.combinat.partition', 'OrderedPartitions_nk', OrderedPartitions)
 register_unpickle_override('sage.combinat.partition', 'PartitionsInBox_hw', PartitionsInBox)

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7009,7 +7009,7 @@ class Partitions_n(Partitions):
 
             sage: Partitions(5).random_element()  # random                              # needs sage.libs.flint
             [2, 1, 1, 1]
-            sage: Partitions(5).random_element(measure='Plancherel')  # random          # needs sage.libs.flint
+            sage: Partitions(5).random_element(measure='Plancherel')  # random          # needs sage.combinat sage.libs.flint
             [2, 1, 1, 1]
         """
         if measure == 'uniform':
@@ -7335,7 +7335,7 @@ class Partitions_nk(Partitions):
             [[]]
 
             sage: from sage.combinat.partition import number_of_partitions_length
-            sage: all( len(Partitions(n, length=k).list())                              # needs sage.libs.flint
+            sage: all( len(Partitions(n, length=k).list())                              # needs sage.libs.flint sage.libs.gap
             ....:      == number_of_partitions_length(n, k)
             ....:      for n in range(9) for k in range(n+2) )
             True
@@ -7399,7 +7399,7 @@ class Partitions_nk(Partitions):
             5
             sage: Partitions(8, length=5).cardinality()
             3
-            sage: Partitions(15, length=6).cardinality()
+            sage: Partitions(15, length=6).cardinality()                                # needs sage.libs.gap
             26
             sage: Partitions(0, length=0).cardinality()
             1
@@ -8973,7 +8973,7 @@ class PartitionsGreatestEQ(UniqueRepresentation, IntegerListsLex):
 
         TESTS::
 
-            sage: all(PartitionsGreatestEQ(n, a).cardinality() ==                       # needs sage.libs.flint
+            sage: all(PartitionsGreatestEQ(n, a).cardinality() ==                       # needs sage.libs.flint sage.libs.gap
             ....:     len(PartitionsGreatestEQ(n, a).list())
             ....:     for n in range(20) for a in range(6))
             True

--- a/src/sage/combinat/partition_tuple.py
+++ b/src/sage/combinat/partition_tuple.py
@@ -3107,3 +3107,8 @@ class RegularPartitionTuples_level_size(PartitionTuples_level_size):
                 mu[0] = [1]
                 mu[-1] = [self._size - 1]
         return self.element_class(self, mu)
+
+
+from sage.misc.persist import register_unpickle_override
+
+register_unpickle_override('sage.combinat.partition', 'PartitionTuples_nk', PartitionTuples_level_size)

--- a/src/sage/combinat/q_analogues.py
+++ b/src/sage/combinat/q_analogues.py
@@ -219,7 +219,7 @@ def q_binomial(n, k, q=None, algorithm='auto'):
         5
         sage: q_binomial(4,2,-1)
         2
-        sage: q_binomial(4,2,3.14)
+        sage: q_binomial(4,2,3.14)                                                      # needs sage.rings.real_mpfr
         152.030056160000
         sage: R = GF((5, 2), 't')
         sage: t = R.gen(0)

--- a/src/sage/combinat/q_analogues.py
+++ b/src/sage/combinat/q_analogues.py
@@ -221,6 +221,8 @@ def q_binomial(n, k, q=None, algorithm='auto'):
         2
         sage: q_binomial(4,2,3.14)                                                      # needs sage.rings.real_mpfr
         152.030056160000
+
+        sage: # needs sage.rings.finite_rings
         sage: R = GF((5, 2), 't')
         sage: t = R.gen(0)
         sage: q_binomial(6, 3, t)
@@ -301,6 +303,7 @@ def q_binomial(n, k, q=None, algorithm='auto'):
 
     Check that the parent is always the parent of ``q``::
 
+        sage: # needs sage.rings.number_field
         sage: R.<q> = CyclotomicField(3)
         sage: for algo in ["naive", "cyclotomic"]:
         ....:     for n in range(4):

--- a/src/sage/combinat/q_analogues.py
+++ b/src/sage/combinat/q_analogues.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-combinat
+# sage_setup: distribution = sagemath-categories
 r"""
 `q`-Analogues
 """
@@ -12,14 +12,16 @@ r"""
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-from sage.combinat.dyck_word import DyckWords
 from sage.combinat.partition import _Partitions
 from sage.misc.cachefunc import cached_function
+from sage.misc.lazy_import import lazy_import
 from sage.misc.misc_c import prod
 from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.laurent_polynomial_ring import LaurentPolynomialRing
 from sage.rings.polynomial.polynomial_ring import polygen
 from sage.structure.element import parent
+
+lazy_import('sage.combinat.dyck_word', 'DyckWords')
 
 
 def q_int(n, q=None):
@@ -227,9 +229,11 @@ def q_binomial(n, k, q=None, algorithm='auto'):
     We can also do this for more complicated objects such as matrices or
     symmetric functions::
 
-        sage: q_binomial(4,2,matrix([[2,1],[-1,3]]))
+        sage: q_binomial(4, 2, matrix([[2,1],[-1,3]]))                                  # needs sage.modules
         [ -6  84]
         [-84  78]
+
+        sage: # needs sage.combinat sage.modules
         sage: Sym = SymmetricFunctions(QQ)
         sage: s = Sym.schur()
         sage: q_binomial(4,1, s[2]+s[1])
@@ -526,6 +530,7 @@ def qt_catalan_number(n):
 
     EXAMPLES::
 
+        sage: # needs sage.combinat
         sage: from sage.combinat.q_analogues import qt_catalan_number
         sage: qt_catalan_number(1)
         1
@@ -539,7 +544,7 @@ def qt_catalan_number(n):
     The `q,t`-Catalan number of index `n` is only defined for `n` a
     nonnegative integer (:issue:`11411`)::
 
-        sage: qt_catalan_number(-2)
+        sage: qt_catalan_number(-2)                                                     # needs sage.combinat
         Traceback (most recent call last):
         ...
         ValueError: argument (-2) must be a nonnegative integer

--- a/src/sage/matrix/misc_flint.pyx
+++ b/src/sage/matrix/misc_flint.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.linbox
 r"""
 Misc matrix algorithms using FLINT
 """

--- a/src/sage/modules/finite_submodule_iter.pyx
+++ b/src/sage/modules/finite_submodule_iter.pyx
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-modules
-# sage.doctest: needs sage.rings.finite_rings
+# sage.doctest: needs sage.combinat sage.rings.finite_rings
 r"""
 Iterators over finite submodules of a `\ZZ`-module
 

--- a/src/sage/parallel/map_reduce.py
+++ b/src/sage/parallel/map_reduce.py
@@ -184,8 +184,8 @@ Second, you need the information necessary to describe a
 
   Compare::
 
-      sage: from sage.combinat.q_analogues import q_factorial                           # needs sage.combinat
-      sage: q_factorial(5)                                                              # needs sage.combinat
+      sage: from sage.combinat.q_analogues import q_factorial
+      sage: q_factorial(5)
       q^10 + 4*q^9 + 9*q^8 + 15*q^7 + 20*q^6 + 22*q^5 + 20*q^4 + 15*q^3 + 9*q^2 + 4*q + 1
 
 * **Listing the objects.** One can also compute the list of objects in a

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -1508,7 +1508,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
             sage: TestSuite(L).run()
 
             sage: L = LazyLaurentSeriesRing(GF(5)['x, y'], 't')
-            sage: TestSuite(L).run()
+            sage: TestSuite(L).run()                                                    # needs sage.libs.singular
 
             sage: L = LazyLaurentSeriesRing(Zmod(6), 't')
             sage: TestSuite(L).run(skip=['_test_revert'])
@@ -2589,6 +2589,7 @@ class LazyPowerSeriesRing(LazySeriesRing):
         For inputs as symbolic functions/expressions, the function must
         not have any poles at `0`::
 
+            sage: # needs sage.symbolic
             sage: L.<z> = LazyPowerSeriesRing(QQ, sparse=True)
             sage: f = 1 / sin(x)
             sage: L.taylor(f)
@@ -2600,12 +2601,12 @@ class LazyPowerSeriesRing(LazySeriesRing):
             sage: def f(x, y): return (1 + x) / (1 + y)
             sage: L.taylor(f)
             1 + (a-b) + (-a*b+b^2) + (a*b^2-b^3) + (-a*b^3+b^4) + (a*b^4-b^5) + (-a*b^5+b^6) + O(a,b)^7
-            sage: g(w, z) = (1 + w) / (1 + z)
-            sage: L.taylor(g)
+            sage: g(w, z) = (1 + w) / (1 + z)                                           # needs sage.symbolic
+            sage: L.taylor(g)                                                           # needs sage.symbolic
             1 + (a-b) + (-a*b+b^2) + (a*b^2-b^3) + (-a*b^3+b^4) + (a*b^4-b^5) + (-a*b^5+b^6) + O(a,b)^7
-            sage: y = SR.var('y')
-            sage: h = (1 + x) / (1 + y)
-            sage: L.taylor(h)
+            sage: y = SR.var('y')                                                       # needs sage.symbolic
+            sage: h = (1 + x) / (1 + y)                                                 # needs sage.symbolic
+            sage: L.taylor(h)                                                           # needs sage.symbolic
             1 + (a-b) + (-a*b+b^2) + (a*b^2-b^3) + (-a*b^3+b^4) + (a*b^4-b^5) + (-a*b^5+b^6) + O(a,b)^7
         """
         try:

--- a/src/sage/structure/element.pxd
+++ b/src/sage/structure/element.pxd
@@ -40,8 +40,8 @@ cpdef inline parent(x):
 
     Some more complicated examples::
 
-        sage: x = Partition([3,2,1,1,1])                                                # needs sage.combinat
-        sage: parent(x)                                                                 # needs sage.combinat
+        sage: x = Partition([3,2,1,1,1])
+        sage: parent(x)
         Partitions
         sage: v = vector(RDF, [1,2,3])                                                  # needs sage.modules
         sage: parent(v)                                                                 # needs sage.modules

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -3291,11 +3291,11 @@ cdef class CommutativeRingElement(RingElement):
             x
             sage: f = x^2 - 4*x + 4; f.sqrt(all=True)
             [x - 2, -x + 2]
-            sage: sqrtx = x.sqrt(name='y'); sqrtx
+            sage: sqrtx = x.sqrt(name='y'); sqrtx                                       # needs sage.libs.singular
             y
-            sage: sqrtx^2
+            sage: sqrtx^2                                                               # needs sage.libs.singular
             x
-            sage: x.sqrt(all=true, name='y')
+            sage: x.sqrt(all=true, name='y')                                            # needs sage.libs.singular
             [y, -y]
             sage: x.sqrt(extend=False, all=True)
             []
@@ -3336,11 +3336,11 @@ cdef class CommutativeRingElement(RingElement):
             sage: R.<x> = QQ[]
             sage: a = 2*(x+1)^2 / (2*(x-1)^2); a.sqrt()
             (x + 1)/(x - 1)
-            sage: sqrtx=(1/x).sqrt(name='y'); sqrtx
+            sage: sqrtx = (1/x).sqrt(name='y'); sqrtx                                   # needs sage.libs.singular
             y
-            sage: sqrtx^2
+            sage: sqrtx^2                                                               # needs sage.libs.singular
             1/x
-            sage: (1/x).sqrt(all=true, name='y')
+            sage: (1/x).sqrt(all=true, name='y')                                        # needs sage.libs.singular
             [y, -y]
             sage: (1/x).sqrt(extend=False, all=True)
             []


### PR DESCRIPTION
- **src/sage/combinat/partition.py: Add # needs**
- **pkgs/sagemath-categories: Move sage.combinat.q_analogues here from sagemath-combinat**
- **src/sage/matrix/misc_flint.pyx: Add # needs**
- **src/sage/modules/finite_submodule_iter.pyx: Add # needs**
- **src/sage/parallel/map_reduce.py: Add # needs**
- **src/sage/structure/element.pyx: Add # needs**
- **src/sage/combinat/partition.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-flint' --update-known-test-failures**
- **src/sage/combinat/q_analogues.py: Add # needs**
- **src/sage/combinat/q_analogues.py: Add # needs**
- **src/sage/structure/element.pxd: Remove some # needs sage.combinat**
- **./sage --fixdoctests --distribution 'sagemath-categories' --update-known-test-failures**
- **./sage --fixdoctests --distribution 'sagemath-modules' --update-known-test-failures**
- **src/sage/combinat/colored_permutations.py: Add # needs**
- **src/sage/combinat/partition.py: Do not register_unpickle_override a LazyImport**
- **src/sage/rings/lazy_series_ring.py: Add # needs**
