### PR TITLE
sage.categories.rings: Remove use of sage.combinat.words

### DIFF
--- a/pkgs/sagemath-categories/known-test-failures.json
+++ b/pkgs/sagemath-categories/known-test-failures.json
@@ -30,7 +30,7 @@
     },
     "sage.categories.additive_magmas": {
         "failed": true,
-        "ntests": 134
+        "ntests": 133
     },
     "sage.categories.additive_monoids": {
         "ntests": 16
@@ -572,7 +572,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "ntests": 204
+        "ntests": 209
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -705,7 +705,7 @@
         "ntests": 9
     },
     "sage.combinat.partition": {
-        "ntests": 1194
+        "ntests": 1195
     },
     "sage.combinat.partitions": {
         "ntests": 69
@@ -851,6 +851,9 @@
     "sage.features.databases": {
         "ntests": 38
     },
+    "sage.features.dot2tex": {
+        "ntests": 4
+    },
     "sage.features.dvipng": {
         "ntests": 4
     },
@@ -969,7 +972,7 @@
         "ntests": 28
     },
     "sage.features.sagemath": {
-        "ntests": 178
+        "ntests": 177
     },
     "sage.features.sat": {
         "ntests": 16
@@ -979,6 +982,9 @@
     },
     "sage.features.sirocco": {
         "ntests": 4
+    },
+    "sage.features.sloane_database": {
+        "ntests": 6
     },
     "sage.features.sphinx": {
         "ntests": 8
@@ -1916,7 +1922,7 @@
         "ntests": 382
     },
     "sage.schemes.projective.projective_subscheme": {
-        "ntests": 233
+        "ntests": 234
     },
     "sage.sets.cartesian_product": {
         "ntests": 54

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -11,6 +11,8 @@ Rings
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
+import itertools
+
 from functools import reduce
 from types import GeneratorType
 
@@ -1712,6 +1714,24 @@ class Rings(CategoryWithAxiom):
             return q
 
 
+def _gen_words():
+    r"""
+    Generate words.
+
+    EXAMPLES::
+
+        sage: from sage.categories.rings import _gen_words
+        sage: import itertools
+        sage: list(itertools.islice(_gen_words(), 30))[20:]
+        ['u', 'v', 'w', 'x', 'y', 'z', 'aa', 'ab', 'ac', 'ad']
+    """
+    repeat = 1
+    while True:
+        for w in itertools.product("abcdefghijklmnopqrstuvwxyz", repeat=repeat):
+            yield ''.join(w)
+        repeat += 1
+
+
 def _gen_names(elts):
     r"""
     Used to find a name for a generator when rings are created using the
@@ -1719,7 +1739,6 @@ def _gen_names(elts):
 
     EXAMPLES::
 
-        sage: # needs sage.combinat
         sage: from sage.categories.rings import _gen_names
         sage: list(_gen_names([sqrt(5)]))                                               # needs sage.symbolic
         ['sqrt5']
@@ -1730,9 +1749,7 @@ def _gen_names(elts):
     """
     import re
     from sage.structure.category_object import certify_names
-    from sage.combinat.words.words import Words
-    it = iter(Words("abcdefghijklmnopqrstuvwxyz", infinite=False))
-    next(it)  # skip empty word
+    it = _gen_words()
     for x in elts:
         name = str(x)
         m = re.match(r'^sqrt\((\d+)\)$', name)
@@ -1741,5 +1758,5 @@ def _gen_names(elts):
         try:
             certify_names([name])
         except ValueError:
-            name = next(it).string_rep()
+            name = next(it)
         yield name


### PR DESCRIPTION
- **src/sage/categories/rings.py: Remove use of sage.combinat.words**
- **./sage --fixdoctests --distribution 'sagemath-categories' --update-known-test-failures**
