### PR TITLE
pkgs/sagemath-schemes: Doctest fixes

### DIFF
--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -12,7 +12,6 @@
         "ntests": 67
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra": {
-        "failed": true,
         "ntests": 167
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_element": {
@@ -71,8 +70,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "failed": true,
-        "ntests": 88
+        "ntests": 78
     },
     "sage.algebras.orlik_terao": {
         "ntests": 89
@@ -158,14 +156,14 @@
         "ntests": 66
     },
     "sage.categories.action": {
+        "failed": true,
         "ntests": 107
     },
     "sage.categories.additive_groups": {
         "ntests": 9
     },
     "sage.categories.additive_magmas": {
-        "failed": true,
-        "ntests": 161
+        "ntests": 157
     },
     "sage.categories.additive_monoids": {
         "ntests": 16
@@ -227,6 +225,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 24
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -258,7 +259,7 @@
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
-        "ntests": 30
+        "ntests": 61
     },
     "sage.categories.complex_reflection_groups": {
         "ntests": 16
@@ -273,7 +274,7 @@
         "ntests": 368
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -282,7 +283,7 @@
         "ntests": 39
     },
     "sage.categories.discrete_valuation": {
-        "ntests": 41
+        "ntests": 56
     },
     "sage.categories.distributive_magmas_and_additive_magmas": {
         "ntests": 13
@@ -291,7 +292,7 @@
         "ntests": 11
     },
     "sage.categories.domains": {
-        "ntests": 7
+        "ntests": 13
     },
     "sage.categories.drinfeld_modules": {
         "failed": true,
@@ -377,7 +378,7 @@
     },
     "sage.categories.fields": {
         "failed": true,
-        "ntests": 141
+        "ntests": 145
     },
     "sage.categories.filtered_algebras": {
         "ntests": 5
@@ -399,7 +400,7 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "ntests": 97
@@ -444,7 +445,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -598,7 +599,6 @@
         "ntests": 1
     },
     "sage.categories.magmas": {
-        "failed": true,
         "ntests": 147
     },
     "sage.categories.magmas_and_additive_magmas": {
@@ -608,11 +608,9 @@
         "ntests": 27
     },
     "sage.categories.manifolds": {
-        "failed": true,
         "ntests": 55
     },
     "sage.categories.map": {
-        "failed": true,
         "ntests": 423
     },
     "sage.categories.matrix_algebras": {
@@ -628,8 +626,7 @@
         "ntests": 145
     },
     "sage.categories.modules_with_basis": {
-        "failed": true,
-        "ntests": 507
+        "ntests": 512
     },
     "sage.categories.monoid_algebras": {
         "ntests": 4
@@ -671,8 +668,7 @@
         "ntests": 45
     },
     "sage.categories.pushout": {
-        "failed": true,
-        "ntests": 857
+        "ntests": 915
     },
     "sage.categories.quantum_group_representations": {
         "ntests": 13
@@ -696,8 +692,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "failed": true,
-        "ntests": 254
+        "ntests": 263
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -772,7 +767,7 @@
         "ntests": 4
     },
     "sage.categories.unique_factorization_domains": {
-        "ntests": 39
+        "ntests": 43
     },
     "sage.categories.unital_algebras": {
         "ntests": 36
@@ -843,7 +838,6 @@
         "ntests": 81
     },
     "sage.coding.gabidulin_code": {
-        "failed": true,
         "ntests": 235
     },
     "sage.coding.golay_code": {
@@ -925,7 +919,6 @@
         "ntests": 65
     },
     "sage.combinat.free_module": {
-        "failed": true,
         "ntests": 401
     },
     "sage.combinat.integer_lists.base": {
@@ -953,11 +946,21 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 13
     },
+    "sage.combinat.partition": {
+        "ntests": 1232
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
     "sage.combinat.permutation": {
         "ntests": 1195
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "failed": true,
+        "ntests": 127
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -1257,6 +1260,9 @@
     "sage.dynamics.arithmetic_dynamics.affine_ds": {
         "ntests": 219
     },
+    "sage.dynamics.arithmetic_dynamics.berkovich_ds": {
+        "ntests": 185
+    },
     "sage.dynamics.arithmetic_dynamics.dynamical_semigroup": {
         "failed": true,
         "ntests": 398
@@ -1322,6 +1328,9 @@
     },
     "sage.features.databases": {
         "ntests": 38
+    },
+    "sage.features.dot2tex": {
+        "ntests": 4
     },
     "sage.features.dvipng": {
         "ntests": 4
@@ -1402,7 +1411,7 @@
         "ntests": 4
     },
     "sage.features.mip_backends": {
-        "ntests": 7
+        "ntests": 9
     },
     "sage.features.msolve": {
         "ntests": 6
@@ -1451,6 +1460,9 @@
     },
     "sage.features.sirocco": {
         "ntests": 4
+    },
+    "sage.features.sloane_database": {
+        "ntests": 6
     },
     "sage.features.sphinx": {
         "ntests": 8
@@ -1514,7 +1526,7 @@
     },
     "sage.functions.orthogonal_polys": {
         "failed": true,
-        "ntests": 251
+        "ntests": 255
     },
     "sage.functions.other": {
         "failed": true,
@@ -1596,7 +1608,6 @@
         "ntests": 8
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
-        "failed": true,
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
@@ -1685,7 +1696,6 @@
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
-        "failed": true,
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
@@ -1745,7 +1755,6 @@
         "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
-        "failed": true,
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
@@ -1788,6 +1797,9 @@
     "sage.geometry.voronoi_diagram": {
         "failed": true,
         "ntests": 24
+    },
+    "sage.graphs.chrompoly": {
+        "ntests": 2
     },
     "sage.graphs.matchpoly": {
         "ntests": 3
@@ -1851,7 +1863,6 @@
         "ntests": 33
     },
     "sage.groups.matrix_gps.linear": {
-        "failed": true,
         "ntests": 47
     },
     "sage.groups.matrix_gps.matrix_group": {
@@ -1910,6 +1921,9 @@
     },
     "sage.homology.graded_resolution": {
         "ntests": 93
+    },
+    "sage.homology.hochschild_complex": {
+        "ntests": 3
     },
     "sage.homology.homology_group": {
         "ntests": 23
@@ -2003,7 +2017,6 @@
         "ntests": 22
     },
     "sage.libs.mpmath.utils": {
-        "failed": true,
         "ntests": 57
     },
     "sage.libs.ntl.error": {
@@ -2083,7 +2096,7 @@
         "ntests": 16
     },
     "sage.libs.pari.convert_sage": {
-        "ntests": 94
+        "ntests": 97
     },
     "sage.libs.pari.convert_sage_complex_double": {
         "ntests": 22
@@ -2100,7 +2113,7 @@
     },
     "sage.libs.pari.tests": {
         "failed": true,
-        "ntests": 799
+        "ntests": 812
     },
     "sage.libs.singular.function": {
         "failed": true,
@@ -2145,7 +2158,6 @@
         "ntests": 99
     },
     "sage.matrix.constructor": {
-        "failed": true,
         "ntests": 155
     },
     "sage.matrix.docs": {
@@ -2156,18 +2168,17 @@
     },
     "sage.matrix.matrix0": {
         "failed": true,
-        "ntests": 846
+        "ntests": 860
     },
     "sage.matrix.matrix1": {
-        "failed": true,
         "ntests": 441
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2647
+        "ntests": 2667
     },
     "sage.matrix.matrix_cdv": {
-        "ntests": 5
+        "ntests": 10
     },
     "sage.matrix.matrix_complex_ball_dense": {
         "ntests": 118
@@ -2232,7 +2243,6 @@
         "ntests": 105
     },
     "sage.matrix.matrix_mpolynomial_dense": {
-        "failed": true,
         "ntests": 86
     },
     "sage.matrix.matrix_numpy_dense": {
@@ -2258,7 +2268,6 @@
         "ntests": 462
     },
     "sage.matrix.matrix_sparse": {
-        "failed": true,
         "ntests": 164
     },
     "sage.matrix.misc": {
@@ -2268,7 +2277,6 @@
         "ntests": 5
     },
     "sage.matrix.misc_mpfr": {
-        "failed": true,
         "ntests": 7
     },
     "sage.matrix.operation_table": {
@@ -2282,7 +2290,6 @@
         "ntests": 69
     },
     "sage.matrix.symplectic_basis": {
-        "failed": true,
         "ntests": 46
     },
     "sage.matrix.tests": {
@@ -2370,7 +2377,7 @@
         "ntests": 150
     },
     "sage.misc.cachefunc": {
-        "ntests": 688
+        "ntests": 751
     },
     "sage.misc.call": {
         "ntests": 28
@@ -2566,6 +2573,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
+        "failed": true,
         "ntests": 326
     },
     "sage.misc.search": {
@@ -2689,10 +2697,7 @@
         "ntests": 89
     },
     "sage.modular.btquotients.btquotient": {
-        "ntests": 6
-    },
-    "sage.modular.btquotients.pautomorphicform": {
-        "ntests": 5
+        "ntests": 2
     },
     "sage.modular.buzzard": {
         "ntests": 7
@@ -2765,7 +2770,7 @@
     },
     "sage.modular.hypergeometric_motive": {
         "failed": true,
-        "ntests": 320
+        "ntests": 321
     },
     "sage.modular.local_comp.liftings": {
         "ntests": 48
@@ -2775,7 +2780,6 @@
         "ntests": 101
     },
     "sage.modular.local_comp.smoothchar": {
-        "failed": true,
         "ntests": 324
     },
     "sage.modular.local_comp.type_space": {
@@ -2937,24 +2941,46 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
+        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
-        "ntests": 1
+        "failed": true,
+        "ntests": 218
     },
     "sage.modular.overconvergent.hecke_series": {
         "failed": true,
         "ntests": 76
     },
+    "sage.modular.overconvergent.weightspace": {
+        "failed": true,
+        "ntests": 108
+    },
     "sage.modular.pollack_stevens.dist": {
         "ntests": 168
+    },
+    "sage.modular.pollack_stevens.distributions": {
+        "failed": true,
+        "ntests": 164
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
         "ntests": 166
     },
+    "sage.modular.pollack_stevens.manin_map": {
+        "failed": true,
+        "ntests": 180
+    },
+    "sage.modular.pollack_stevens.padic_lseries": {
+        "failed": true,
+        "ntests": 48
+    },
     "sage.modular.pollack_stevens.sigma0": {
         "ntests": 101
+    },
+    "sage.modular.pollack_stevens.space": {
+        "failed": true,
+        "ntests": 182
     },
     "sage.modular.quasimodform.element": {
         "failed": true,
@@ -2989,12 +3015,7 @@
     "sage.modules.filtered_vector_space": {
         "ntests": 169
     },
-    "sage.modules.finite_submodule_iter": {
-        "failed": true,
-        "ntests": 95
-    },
     "sage.modules.free_module": {
-        "failed": true,
         "ntests": 1484
     },
     "sage.modules.free_module_element": {
@@ -3005,7 +3026,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3029,7 +3050,6 @@
         "ntests": 57
     },
     "sage.modules.multi_filtered_vector_space": {
-        "failed": true,
         "ntests": 122
     },
     "sage.modules.quotient_module": {
@@ -3090,7 +3110,6 @@
         "ntests": 353
     },
     "sage.modules.with_basis.subquotient": {
-        "failed": true,
         "ntests": 152
     },
     "sage.numerical.backends.cvxpy_backend": {
@@ -3198,6 +3217,9 @@
     },
     "sage.quadratic_forms.genera.genus": {
         "ntests": 496
+    },
+    "sage.quadratic_forms.genera.normal_form": {
+        "ntests": 275
     },
     "sage.quadratic_forms.qfsolve": {
         "ntests": 38
@@ -3326,7 +3348,6 @@
         "ntests": 12
     },
     "sage.repl.ipython_kernel.widgets": {
-        "failed": true,
         "ntests": 98
     },
     "sage.repl.ipython_kernel.widgets_sagenb": {
@@ -3392,7 +3413,6 @@
         "ntests": 36
     },
     "sage.rings.abc": {
-        "failed": true,
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
@@ -3405,7 +3425,7 @@
         "ntests": 26
     },
     "sage.rings.big_oh": {
-        "ntests": 22
+        "ntests": 27
     },
     "sage.rings.complex_arb": {
         "failed": true,
@@ -3486,7 +3506,7 @@
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
-        "ntests": 42
+        "ntests": 44
     },
     "sage.rings.finite_rings.galois_group": {
         "ntests": 20
@@ -3504,7 +3524,7 @@
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
-        "ntests": 583
+        "ntests": 588
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "ntests": 367
@@ -3513,7 +3533,6 @@
         "ntests": 31
     },
     "sage.rings.finite_rings.residue_field": {
-        "failed": true,
         "ntests": 445
     },
     "sage.rings.finite_rings.residue_field_givaro": {
@@ -3526,14 +3545,13 @@
         "ntests": 34
     },
     "sage.rings.fraction_field": {
-        "ntests": 262
+        "ntests": 266
     },
     "sage.rings.fraction_field_FpT": {
         "ntests": 371
     },
     "sage.rings.fraction_field_element": {
-        "failed": true,
-        "ntests": 290
+        "ntests": 295
     },
     "sage.rings.function_field.constructor": {
         "ntests": 42
@@ -3569,11 +3587,9 @@
         "ntests": 316
     },
     "sage.rings.function_field.function_field_polymod": {
-        "failed": true,
-        "ntests": 437
+        "ntests": 433
     },
     "sage.rings.function_field.function_field_rational": {
-        "failed": true,
         "ntests": 157
     },
     "sage.rings.function_field.hermite_form_polynomial": {
@@ -3666,10 +3682,10 @@
         "ntests": 59
     },
     "sage.rings.laurent_series_ring": {
-        "ntests": 166
+        "ntests": 179
     },
     "sage.rings.laurent_series_ring_element": {
-        "ntests": 402
+        "ntests": 407
     },
     "sage.rings.localization": {
         "ntests": 208
@@ -3678,11 +3694,9 @@
         "ntests": 5
     },
     "sage.rings.morphism": {
-        "failed": true,
-        "ntests": 744
+        "ntests": 748
     },
     "sage.rings.multi_power_series_ring": {
-        "failed": true,
         "ntests": 239
     },
     "sage.rings.multi_power_series_ring_element": {
@@ -3690,6 +3704,10 @@
     },
     "sage.rings.noncommutative_ideals": {
         "ntests": 23
+    },
+    "sage.rings.number_field.S_unit_solver": {
+        "failed": true,
+        "ntests": 312
     },
     "sage.rings.number_field.bdd_height": {
         "ntests": 76
@@ -3711,7 +3729,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2255
+        "ntests": 2292
     },
     "sage.rings.number_field.number_field_base": {
         "failed": true,
@@ -3796,10 +3814,13 @@
         "ntests": 254
     },
     "sage.rings.padics.lattice_precision": {
-        "ntests": 456
+        "ntests": 463
+    },
+    "sage.rings.padics.local_generic": {
+        "ntests": 240
     },
     "sage.rings.padics.local_generic_element": {
-        "ntests": 1
+        "ntests": 221
     },
     "sage.rings.padics.misc": {
         "ntests": 26
@@ -3807,11 +3828,32 @@
     "sage.rings.padics.morphism": {
         "ntests": 66
     },
+    "sage.rings.padics.padic_ZZ_pX_CA_element": {
+        "ntests": 465
+    },
+    "sage.rings.padics.padic_ZZ_pX_CR_element": {
+        "ntests": 649
+    },
+    "sage.rings.padics.padic_ZZ_pX_FM_element": {
+        "ntests": 363
+    },
+    "sage.rings.padics.padic_ZZ_pX_element": {
+        "ntests": 147
+    },
     "sage.rings.padics.padic_base_generic": {
         "ntests": 44
     },
     "sage.rings.padics.padic_base_leaves": {
         "ntests": 223
+    },
+    "sage.rings.padics.padic_capped_absolute_element": {
+        "ntests": 61
+    },
+    "sage.rings.padics.padic_capped_relative_element": {
+        "ntests": 83
+    },
+    "sage.rings.padics.padic_ext_element": {
+        "ntests": 49
     },
     "sage.rings.padics.padic_extension_generic": {
         "ntests": 208
@@ -3819,9 +3861,18 @@
     "sage.rings.padics.padic_extension_leaves": {
         "ntests": 72
     },
+    "sage.rings.padics.padic_fixed_mod_element": {
+        "ntests": 66
+    },
+    "sage.rings.padics.padic_floating_point_element": {
+        "ntests": 62
+    },
+    "sage.rings.padics.padic_generic": {
+        "ntests": 240
+    },
     "sage.rings.padics.padic_generic_element": {
         "failed": true,
-        "ntests": 813
+        "ntests": 824
     },
     "sage.rings.padics.padic_lattice_element": {
         "ntests": 269
@@ -3837,10 +3888,13 @@
         "ntests": 141
     },
     "sage.rings.padics.padic_valuation": {
-        "ntests": 192
+        "ntests": 196
     },
     "sage.rings.padics.pow_computer": {
         "ntests": 88
+    },
+    "sage.rings.padics.pow_computer_ext": {
+        "ntests": 281
     },
     "sage.rings.padics.pow_computer_flint": {
         "ntests": 76
@@ -3894,7 +3948,6 @@
         "ntests": 7
     },
     "sage.rings.polynomial.complex_roots": {
-        "failed": true,
         "ntests": 42
     },
     "sage.rings.polynomial.cyclotomic": {
@@ -3902,14 +3955,12 @@
         "ntests": 37
     },
     "sage.rings.polynomial.flatten": {
-        "failed": true,
         "ntests": 150
     },
     "sage.rings.polynomial.hilbert": {
         "ntests": 24
     },
     "sage.rings.polynomial.ideal": {
-        "failed": true,
         "ntests": 13
     },
     "sage.rings.polynomial.infinite_polynomial_element": {
@@ -3919,7 +3970,7 @@
         "ntests": 279
     },
     "sage.rings.polynomial.laurent_polynomial": {
-        "ntests": 454
+        "ntests": 459
     },
     "sage.rings.polynomial.laurent_polynomial_ideal": {
         "ntests": 115
@@ -3935,14 +3986,13 @@
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 563
+        "ntests": 573
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
         "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
-        "failed": true,
         "ntests": 891
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
@@ -3964,15 +4014,10 @@
         "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
-        "failed": true,
         "ntests": 251
     },
     "sage.rings.polynomial.ore_function_field": {
-        "failed": true,
-        "ntests": 274
-    },
-    "sage.rings.polynomial.ore_polynomial_ring": {
-        "ntests": 1
+        "ntests": 279
     },
     "sage.rings.polynomial.padics.polynomial_padic": {
         "ntests": 69
@@ -3996,32 +4041,29 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2644
+        "ntests": 2690
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
-        "ntests": 219
+        "ntests": 267
     },
     "sage.rings.polynomial.polynomial_gf2x": {
         "ntests": 43
     },
     "sage.rings.polynomial.polynomial_integer_dense_flint": {
-        "failed": true,
         "ntests": 308
     },
     "sage.rings.polynomial.polynomial_integer_dense_ntl": {
-        "failed": true,
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
-        "failed": true,
-        "ntests": 75
+        "ntests": 82
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
-        "ntests": 513
+        "ntests": 524
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
         "ntests": 151
@@ -4034,11 +4076,9 @@
         "ntests": 136
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "failed": true,
-        "ntests": 534
+        "ntests": 536
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
-        "failed": true,
         "ntests": 154
     },
     "sage.rings.polynomial.polynomial_ring_homomorphism": {
@@ -4085,17 +4125,15 @@
         "ntests": 4
     },
     "sage.rings.power_series_pari": {
-        "ntests": 178
+        "ntests": 185
     },
     "sage.rings.power_series_poly": {
-        "failed": true,
         "ntests": 272
     },
     "sage.rings.power_series_ring": {
         "ntests": 241
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
         "ntests": 491
     },
     "sage.rings.puiseux_series_ring": {
@@ -4106,7 +4144,7 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1370
+        "ntests": 1350
     },
     "sage.rings.qqbar_decorators": {
         "ntests": 10
@@ -4119,7 +4157,6 @@
         "ntests": 191
     },
     "sage.rings.rational": {
-        "failed": true,
         "ntests": 567
     },
     "sage.rings.rational_field": {
@@ -4131,7 +4168,6 @@
         "ntests": 559
     },
     "sage.rings.real_double": {
-        "failed": true,
         "ntests": 299
     },
     "sage.rings.real_double_element_gsl": {
@@ -4141,23 +4177,18 @@
     "sage.rings.real_field": {
         "ntests": 5
     },
-    "sage.rings.real_interval_absolute": {
-        "ntests": 1
-    },
     "sage.rings.real_lazy": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 899
+        "ntests": 894
     },
     "sage.rings.real_mpfr": {
         "failed": true,
         "ntests": 0
     },
     "sage.rings.ring": {
-        "failed": true,
         "ntests": 192
     },
     "sage.rings.ring_extension": {
@@ -4185,7 +4216,6 @@
         "ntests": 8
     },
     "sage.rings.semirings.tropical_semiring": {
-        "failed": true,
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
@@ -4205,7 +4235,7 @@
         "ntests": 126
     },
     "sage.rings.tests": {
-        "ntests": 52
+        "ntests": 56
     },
     "sage.rings.valuation.augmented_valuation": {
         "ntests": 469
@@ -4232,7 +4262,7 @@
         "ntests": 53
     },
     "sage.rings.valuation.valuation": {
-        "ntests": 211
+        "ntests": 229
     },
     "sage.rings.valuation.valuation_space": {
         "ntests": 200
@@ -4261,7 +4291,12 @@
         "ntests": 113
     },
     "sage.schemes.berkovich.berkovich_cp_element": {
-        "ntests": 35
+        "failed": true,
+        "ntests": 421
+    },
+    "sage.schemes.berkovich.berkovich_space": {
+        "failed": true,
+        "ntests": 126
     },
     "sage.schemes.curves.affine_curve": {
         "failed": true,
@@ -4277,18 +4312,20 @@
         "ntests": 129
     },
     "sage.schemes.curves.plane_curve_arrangement": {
-        "failed": true,
         "ntests": 128
     },
     "sage.schemes.curves.point": {
         "ntests": 108
     },
     "sage.schemes.curves.projective_curve": {
-        "failed": true,
-        "ntests": 482
+        "ntests": 476
     },
     "sage.schemes.curves.zariski_vankampen": {
         "ntests": 9
+    },
+    "sage.schemes.cyclic_covers.charpoly_frobenius": {
+        "failed": true,
+        "ntests": 21
     },
     "sage.schemes.cyclic_covers.constructor": {
         "ntests": 15
@@ -4313,7 +4350,6 @@
         "ntests": 92
     },
     "sage.schemes.elliptic_curves.constructor": {
-        "failed": true,
         "ntests": 210
     },
     "sage.schemes.elliptic_curves.descent_two_isogeny": {
@@ -4338,19 +4374,20 @@
         "ntests": 531
     },
     "sage.schemes.elliptic_curves.ell_generic": {
-        "failed": true,
-        "ntests": 559
+        "ntests": 563
     },
     "sage.schemes.elliptic_curves.ell_local_data": {
         "ntests": 167
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
-        "failed": true,
-        "ntests": 43
+        "ntests": 40
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
         "ntests": 817
+    },
+    "sage.schemes.elliptic_curves.ell_padic_field": {
+        "ntests": 13
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
@@ -4358,7 +4395,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 776
+        "ntests": 771
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4433,7 +4470,6 @@
         "ntests": 138
     },
     "sage.schemes.elliptic_curves.lseries_ell": {
-        "failed": true,
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.mod5family": {
@@ -4451,6 +4487,10 @@
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
         "ntests": 1
+    },
+    "sage.schemes.elliptic_curves.padics": {
+        "failed": true,
+        "ntests": 0
     },
     "sage.schemes.elliptic_curves.period_lattice": {
         "failed": true,
@@ -4491,22 +4531,22 @@
         "ntests": 42
     },
     "sage.schemes.generic.morphism": {
-        "failed": true,
         "ntests": 475
     },
     "sage.schemes.generic.point": {
         "ntests": 35
     },
     "sage.schemes.generic.scheme": {
-        "failed": true,
         "ntests": 181
     },
     "sage.schemes.generic.spec": {
-        "failed": true,
         "ntests": 32
     },
     "sage.schemes.hyperelliptic_curves.constructor": {
         "ntests": 42
+    },
+    "sage.schemes.hyperelliptic_curves.hypellfrob": {
+        "ntests": 15
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_finite_field": {
         "ntests": 373
@@ -4516,7 +4556,11 @@
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_generic": {
         "failed": true,
-        "ntests": 202
+        "ntests": 208
+    },
+    "sage.schemes.hyperelliptic_curves.hyperelliptic_padic_field": {
+        "failed": true,
+        "ntests": 334
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_rational_field": {
         "ntests": 8
@@ -4544,7 +4588,7 @@
     },
     "sage.schemes.hyperelliptic_curves.monsky_washnitzer": {
         "failed": true,
-        "ntests": 632
+        "ntests": 649
     },
     "sage.schemes.jacobians.abstract_jacobian": {
         "ntests": 56
@@ -4553,7 +4597,6 @@
         "ntests": 9
     },
     "sage.schemes.plane_conics.con_field": {
-        "failed": true,
         "ntests": 187
     },
     "sage.schemes.plane_conics.con_finite_field": {
@@ -4563,7 +4606,6 @@
         "ntests": 62
     },
     "sage.schemes.plane_conics.con_rational_field": {
-        "failed": true,
         "ntests": 41
     },
     "sage.schemes.plane_conics.con_rational_function_field": {
@@ -4601,16 +4643,14 @@
         "ntests": 45
     },
     "sage.schemes.projective.projective_homset": {
-        "failed": true,
         "ntests": 81
     },
     "sage.schemes.projective.projective_morphism": {
-        "failed": true,
-        "ntests": 659
+        "ntests": 667
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
-        "ntests": 337
+        "ntests": 346
     },
     "sage.schemes.projective.projective_rational_point": {
         "failed": true,
@@ -4622,10 +4662,10 @@
     },
     "sage.schemes.projective.projective_subscheme": {
         "failed": true,
-        "ntests": 299
+        "ntests": 309
     },
     "sage.schemes.riemann_surfaces.riemann_surface": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.schemes.toric.chow_group": {
         "ntests": 1
@@ -4640,7 +4680,6 @@
         "ntests": 9
     },
     "sage.sets.cartesian_product": {
-        "failed": true,
         "ntests": 54
     },
     "sage.sets.condition_set": {
@@ -4740,7 +4779,6 @@
         "ntests": 163
     },
     "sage.structure.coerce": {
-        "failed": true,
         "ntests": 360
     },
     "sage.structure.coerce_actions": {
@@ -4759,7 +4797,6 @@
         "ntests": 83
     },
     "sage.structure.element": {
-        "failed": true,
         "ntests": 710
     },
     "sage.structure.element.pxd": {
@@ -4779,7 +4816,6 @@
         "ntests": 118
     },
     "sage.structure.formal_sum": {
-        "failed": true,
         "ntests": 71
     },
     "sage.structure.global_options": {
@@ -4807,7 +4843,6 @@
         "ntests": 11
     },
     "sage.structure.parent": {
-        "failed": true,
         "ntests": 362
     },
     "sage.structure.parent_gens": {
@@ -4830,7 +4865,7 @@
     },
     "sage.structure.sage_object": {
         "failed": true,
-        "ntests": 84
+        "ntests": 98
     },
     "sage.structure.sequence": {
         "ntests": 183
@@ -4922,7 +4957,7 @@
         "ntests": 237
     },
     "sage.tests.cmdline": {
-        "ntests": 141
+        "ntests": 126
     },
     "sage.tests.finite_poset": {
         "ntests": 1

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -12,7 +12,6 @@
         "ntests": 67
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra": {
-        "failed": true,
         "ntests": 167
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_element": {
@@ -71,8 +70,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "failed": true,
-        "ntests": 88
+        "ntests": 78
     },
     "sage.algebras.orlik_terao": {
         "ntests": 89
@@ -158,14 +156,14 @@
         "ntests": 66
     },
     "sage.categories.action": {
+        "failed": true,
         "ntests": 107
     },
     "sage.categories.additive_groups": {
         "ntests": 9
     },
     "sage.categories.additive_magmas": {
-        "failed": true,
-        "ntests": 161
+        "ntests": 157
     },
     "sage.categories.additive_monoids": {
         "ntests": 16
@@ -227,6 +225,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 24
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -258,7 +259,7 @@
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
-        "ntests": 30
+        "ntests": 61
     },
     "sage.categories.complex_reflection_groups": {
         "ntests": 16
@@ -273,7 +274,7 @@
         "ntests": 368
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -282,7 +283,7 @@
         "ntests": 39
     },
     "sage.categories.discrete_valuation": {
-        "ntests": 41
+        "ntests": 56
     },
     "sage.categories.distributive_magmas_and_additive_magmas": {
         "ntests": 13
@@ -291,7 +292,7 @@
         "ntests": 11
     },
     "sage.categories.domains": {
-        "ntests": 7
+        "ntests": 13
     },
     "sage.categories.drinfeld_modules": {
         "failed": true,
@@ -377,7 +378,7 @@
     },
     "sage.categories.fields": {
         "failed": true,
-        "ntests": 141
+        "ntests": 145
     },
     "sage.categories.filtered_algebras": {
         "ntests": 5
@@ -399,7 +400,7 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "ntests": 97
@@ -444,7 +445,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -598,7 +599,6 @@
         "ntests": 1
     },
     "sage.categories.magmas": {
-        "failed": true,
         "ntests": 147
     },
     "sage.categories.magmas_and_additive_magmas": {
@@ -608,11 +608,9 @@
         "ntests": 27
     },
     "sage.categories.manifolds": {
-        "failed": true,
         "ntests": 55
     },
     "sage.categories.map": {
-        "failed": true,
         "ntests": 423
     },
     "sage.categories.matrix_algebras": {
@@ -628,8 +626,7 @@
         "ntests": 145
     },
     "sage.categories.modules_with_basis": {
-        "failed": true,
-        "ntests": 507
+        "ntests": 512
     },
     "sage.categories.monoid_algebras": {
         "ntests": 4
@@ -671,8 +668,7 @@
         "ntests": 45
     },
     "sage.categories.pushout": {
-        "failed": true,
-        "ntests": 857
+        "ntests": 915
     },
     "sage.categories.quantum_group_representations": {
         "ntests": 13
@@ -696,8 +692,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "failed": true,
-        "ntests": 254
+        "ntests": 263
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -772,7 +767,7 @@
         "ntests": 4
     },
     "sage.categories.unique_factorization_domains": {
-        "ntests": 39
+        "ntests": 43
     },
     "sage.categories.unital_algebras": {
         "ntests": 36
@@ -843,7 +838,6 @@
         "ntests": 81
     },
     "sage.coding.gabidulin_code": {
-        "failed": true,
         "ntests": 235
     },
     "sage.coding.golay_code": {
@@ -925,7 +919,6 @@
         "ntests": 65
     },
     "sage.combinat.free_module": {
-        "failed": true,
         "ntests": 401
     },
     "sage.combinat.integer_lists.base": {
@@ -953,11 +946,21 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 13
     },
+    "sage.combinat.partition": {
+        "ntests": 1232
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
     "sage.combinat.permutation": {
         "ntests": 1195
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "failed": true,
+        "ntests": 127
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -1257,6 +1260,9 @@
     "sage.dynamics.arithmetic_dynamics.affine_ds": {
         "ntests": 219
     },
+    "sage.dynamics.arithmetic_dynamics.berkovich_ds": {
+        "ntests": 185
+    },
     "sage.dynamics.arithmetic_dynamics.dynamical_semigroup": {
         "failed": true,
         "ntests": 398
@@ -1322,6 +1328,9 @@
     },
     "sage.features.databases": {
         "ntests": 38
+    },
+    "sage.features.dot2tex": {
+        "ntests": 4
     },
     "sage.features.dvipng": {
         "ntests": 4
@@ -1402,7 +1411,7 @@
         "ntests": 4
     },
     "sage.features.mip_backends": {
-        "ntests": 7
+        "ntests": 9
     },
     "sage.features.msolve": {
         "ntests": 6
@@ -1451,6 +1460,9 @@
     },
     "sage.features.sirocco": {
         "ntests": 4
+    },
+    "sage.features.sloane_database": {
+        "ntests": 6
     },
     "sage.features.sphinx": {
         "ntests": 8
@@ -1514,7 +1526,7 @@
     },
     "sage.functions.orthogonal_polys": {
         "failed": true,
-        "ntests": 251
+        "ntests": 255
     },
     "sage.functions.other": {
         "failed": true,
@@ -1596,7 +1608,6 @@
         "ntests": 8
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
-        "failed": true,
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
@@ -1685,7 +1696,6 @@
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
-        "failed": true,
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
@@ -1745,7 +1755,6 @@
         "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
-        "failed": true,
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
@@ -1788,6 +1797,9 @@
     "sage.geometry.voronoi_diagram": {
         "failed": true,
         "ntests": 24
+    },
+    "sage.graphs.chrompoly": {
+        "ntests": 2
     },
     "sage.graphs.matchpoly": {
         "ntests": 3
@@ -1851,7 +1863,6 @@
         "ntests": 33
     },
     "sage.groups.matrix_gps.linear": {
-        "failed": true,
         "ntests": 47
     },
     "sage.groups.matrix_gps.matrix_group": {
@@ -1910,6 +1921,9 @@
     },
     "sage.homology.graded_resolution": {
         "ntests": 93
+    },
+    "sage.homology.hochschild_complex": {
+        "ntests": 3
     },
     "sage.homology.homology_group": {
         "ntests": 23
@@ -2003,7 +2017,6 @@
         "ntests": 22
     },
     "sage.libs.mpmath.utils": {
-        "failed": true,
         "ntests": 57
     },
     "sage.libs.ntl.error": {
@@ -2083,7 +2096,7 @@
         "ntests": 16
     },
     "sage.libs.pari.convert_sage": {
-        "ntests": 94
+        "ntests": 97
     },
     "sage.libs.pari.convert_sage_complex_double": {
         "ntests": 22
@@ -2100,7 +2113,7 @@
     },
     "sage.libs.pari.tests": {
         "failed": true,
-        "ntests": 799
+        "ntests": 812
     },
     "sage.libs.singular.function": {
         "failed": true,
@@ -2145,7 +2158,6 @@
         "ntests": 99
     },
     "sage.matrix.constructor": {
-        "failed": true,
         "ntests": 155
     },
     "sage.matrix.docs": {
@@ -2156,18 +2168,17 @@
     },
     "sage.matrix.matrix0": {
         "failed": true,
-        "ntests": 846
+        "ntests": 860
     },
     "sage.matrix.matrix1": {
-        "failed": true,
         "ntests": 441
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2647
+        "ntests": 2667
     },
     "sage.matrix.matrix_cdv": {
-        "ntests": 5
+        "ntests": 10
     },
     "sage.matrix.matrix_complex_ball_dense": {
         "ntests": 118
@@ -2232,7 +2243,6 @@
         "ntests": 105
     },
     "sage.matrix.matrix_mpolynomial_dense": {
-        "failed": true,
         "ntests": 86
     },
     "sage.matrix.matrix_numpy_dense": {
@@ -2258,7 +2268,6 @@
         "ntests": 462
     },
     "sage.matrix.matrix_sparse": {
-        "failed": true,
         "ntests": 164
     },
     "sage.matrix.misc": {
@@ -2268,7 +2277,6 @@
         "ntests": 5
     },
     "sage.matrix.misc_mpfr": {
-        "failed": true,
         "ntests": 7
     },
     "sage.matrix.operation_table": {
@@ -2282,7 +2290,6 @@
         "ntests": 69
     },
     "sage.matrix.symplectic_basis": {
-        "failed": true,
         "ntests": 46
     },
     "sage.matrix.tests": {
@@ -2370,7 +2377,7 @@
         "ntests": 150
     },
     "sage.misc.cachefunc": {
-        "ntests": 688
+        "ntests": 751
     },
     "sage.misc.call": {
         "ntests": 28
@@ -2566,6 +2573,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
+        "failed": true,
         "ntests": 326
     },
     "sage.misc.search": {
@@ -2689,10 +2697,7 @@
         "ntests": 89
     },
     "sage.modular.btquotients.btquotient": {
-        "ntests": 6
-    },
-    "sage.modular.btquotients.pautomorphicform": {
-        "ntests": 5
+        "ntests": 2
     },
     "sage.modular.buzzard": {
         "ntests": 7
@@ -2765,7 +2770,7 @@
     },
     "sage.modular.hypergeometric_motive": {
         "failed": true,
-        "ntests": 320
+        "ntests": 321
     },
     "sage.modular.local_comp.liftings": {
         "ntests": 48
@@ -2775,7 +2780,6 @@
         "ntests": 101
     },
     "sage.modular.local_comp.smoothchar": {
-        "failed": true,
         "ntests": 324
     },
     "sage.modular.local_comp.type_space": {
@@ -2937,25 +2941,45 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
-        "ntests": 1
+        "failed": true,
+        "ntests": 218
     },
     "sage.modular.overconvergent.hecke_series": {
         "failed": true,
         "ntests": 76
     },
+    "sage.modular.overconvergent.weightspace": {
+        "failed": true,
+        "ntests": 108
+    },
     "sage.modular.pollack_stevens.dist": {
         "ntests": 168
+    },
+    "sage.modular.pollack_stevens.distributions": {
+        "failed": true,
+        "ntests": 164
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
         "ntests": 166
     },
+    "sage.modular.pollack_stevens.manin_map": {
+        "failed": true,
+        "ntests": 180
+    },
+    "sage.modular.pollack_stevens.padic_lseries": {
+        "failed": true,
+        "ntests": 48
+    },
     "sage.modular.pollack_stevens.sigma0": {
         "ntests": 101
+    },
+    "sage.modular.pollack_stevens.space": {
+        "failed": true,
+        "ntests": 182
     },
     "sage.modular.quasimodform.element": {
         "failed": true,
@@ -2990,12 +3014,7 @@
     "sage.modules.filtered_vector_space": {
         "ntests": 169
     },
-    "sage.modules.finite_submodule_iter": {
-        "failed": true,
-        "ntests": 95
-    },
     "sage.modules.free_module": {
-        "failed": true,
         "ntests": 1484
     },
     "sage.modules.free_module_element": {
@@ -3006,7 +3025,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3030,7 +3049,6 @@
         "ntests": 57
     },
     "sage.modules.multi_filtered_vector_space": {
-        "failed": true,
         "ntests": 122
     },
     "sage.modules.quotient_module": {
@@ -3091,7 +3109,6 @@
         "ntests": 353
     },
     "sage.modules.with_basis.subquotient": {
-        "failed": true,
         "ntests": 152
     },
     "sage.numerical.backends.cvxpy_backend": {
@@ -3199,6 +3216,9 @@
     },
     "sage.quadratic_forms.genera.genus": {
         "ntests": 496
+    },
+    "sage.quadratic_forms.genera.normal_form": {
+        "ntests": 275
     },
     "sage.quadratic_forms.qfsolve": {
         "ntests": 38
@@ -3327,7 +3347,6 @@
         "ntests": 12
     },
     "sage.repl.ipython_kernel.widgets": {
-        "failed": true,
         "ntests": 98
     },
     "sage.repl.ipython_kernel.widgets_sagenb": {
@@ -3393,7 +3412,6 @@
         "ntests": 36
     },
     "sage.rings.abc": {
-        "failed": true,
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
@@ -3406,7 +3424,7 @@
         "ntests": 26
     },
     "sage.rings.big_oh": {
-        "ntests": 22
+        "ntests": 27
     },
     "sage.rings.complex_arb": {
         "failed": true,
@@ -3487,7 +3505,7 @@
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
-        "ntests": 42
+        "ntests": 44
     },
     "sage.rings.finite_rings.galois_group": {
         "ntests": 20
@@ -3505,7 +3523,7 @@
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
-        "ntests": 583
+        "ntests": 588
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "ntests": 367
@@ -3514,7 +3532,6 @@
         "ntests": 31
     },
     "sage.rings.finite_rings.residue_field": {
-        "failed": true,
         "ntests": 445
     },
     "sage.rings.finite_rings.residue_field_givaro": {
@@ -3527,14 +3544,13 @@
         "ntests": 34
     },
     "sage.rings.fraction_field": {
-        "ntests": 262
+        "ntests": 266
     },
     "sage.rings.fraction_field_FpT": {
         "ntests": 371
     },
     "sage.rings.fraction_field_element": {
-        "failed": true,
-        "ntests": 290
+        "ntests": 295
     },
     "sage.rings.function_field.constructor": {
         "ntests": 42
@@ -3570,11 +3586,9 @@
         "ntests": 316
     },
     "sage.rings.function_field.function_field_polymod": {
-        "failed": true,
-        "ntests": 437
+        "ntests": 433
     },
     "sage.rings.function_field.function_field_rational": {
-        "failed": true,
         "ntests": 157
     },
     "sage.rings.function_field.hermite_form_polynomial": {
@@ -3667,10 +3681,10 @@
         "ntests": 59
     },
     "sage.rings.laurent_series_ring": {
-        "ntests": 166
+        "ntests": 179
     },
     "sage.rings.laurent_series_ring_element": {
-        "ntests": 402
+        "ntests": 407
     },
     "sage.rings.localization": {
         "ntests": 208
@@ -3679,11 +3693,9 @@
         "ntests": 5
     },
     "sage.rings.morphism": {
-        "failed": true,
-        "ntests": 744
+        "ntests": 748
     },
     "sage.rings.multi_power_series_ring": {
-        "failed": true,
         "ntests": 239
     },
     "sage.rings.multi_power_series_ring_element": {
@@ -3691,6 +3703,10 @@
     },
     "sage.rings.noncommutative_ideals": {
         "ntests": 23
+    },
+    "sage.rings.number_field.S_unit_solver": {
+        "failed": true,
+        "ntests": 312
     },
     "sage.rings.number_field.bdd_height": {
         "ntests": 76
@@ -3712,7 +3728,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2255
+        "ntests": 2292
     },
     "sage.rings.number_field.number_field_base": {
         "failed": true,
@@ -3797,10 +3813,13 @@
         "ntests": 254
     },
     "sage.rings.padics.lattice_precision": {
-        "ntests": 456
+        "ntests": 463
+    },
+    "sage.rings.padics.local_generic": {
+        "ntests": 240
     },
     "sage.rings.padics.local_generic_element": {
-        "ntests": 1
+        "ntests": 221
     },
     "sage.rings.padics.misc": {
         "ntests": 26
@@ -3808,11 +3827,32 @@
     "sage.rings.padics.morphism": {
         "ntests": 66
     },
+    "sage.rings.padics.padic_ZZ_pX_CA_element": {
+        "ntests": 465
+    },
+    "sage.rings.padics.padic_ZZ_pX_CR_element": {
+        "ntests": 649
+    },
+    "sage.rings.padics.padic_ZZ_pX_FM_element": {
+        "ntests": 363
+    },
+    "sage.rings.padics.padic_ZZ_pX_element": {
+        "ntests": 147
+    },
     "sage.rings.padics.padic_base_generic": {
         "ntests": 44
     },
     "sage.rings.padics.padic_base_leaves": {
         "ntests": 223
+    },
+    "sage.rings.padics.padic_capped_absolute_element": {
+        "ntests": 61
+    },
+    "sage.rings.padics.padic_capped_relative_element": {
+        "ntests": 83
+    },
+    "sage.rings.padics.padic_ext_element": {
+        "ntests": 49
     },
     "sage.rings.padics.padic_extension_generic": {
         "ntests": 208
@@ -3820,9 +3860,18 @@
     "sage.rings.padics.padic_extension_leaves": {
         "ntests": 72
     },
+    "sage.rings.padics.padic_fixed_mod_element": {
+        "ntests": 66
+    },
+    "sage.rings.padics.padic_floating_point_element": {
+        "ntests": 62
+    },
+    "sage.rings.padics.padic_generic": {
+        "ntests": 240
+    },
     "sage.rings.padics.padic_generic_element": {
         "failed": true,
-        "ntests": 813
+        "ntests": 824
     },
     "sage.rings.padics.padic_lattice_element": {
         "ntests": 269
@@ -3838,10 +3887,13 @@
         "ntests": 141
     },
     "sage.rings.padics.padic_valuation": {
-        "ntests": 192
+        "ntests": 196
     },
     "sage.rings.padics.pow_computer": {
         "ntests": 88
+    },
+    "sage.rings.padics.pow_computer_ext": {
+        "ntests": 281
     },
     "sage.rings.padics.pow_computer_flint": {
         "ntests": 76
@@ -3895,7 +3947,6 @@
         "ntests": 7
     },
     "sage.rings.polynomial.complex_roots": {
-        "failed": true,
         "ntests": 42
     },
     "sage.rings.polynomial.cyclotomic": {
@@ -3903,14 +3954,12 @@
         "ntests": 37
     },
     "sage.rings.polynomial.flatten": {
-        "failed": true,
         "ntests": 150
     },
     "sage.rings.polynomial.hilbert": {
         "ntests": 24
     },
     "sage.rings.polynomial.ideal": {
-        "failed": true,
         "ntests": 13
     },
     "sage.rings.polynomial.infinite_polynomial_element": {
@@ -3920,7 +3969,7 @@
         "ntests": 279
     },
     "sage.rings.polynomial.laurent_polynomial": {
-        "ntests": 454
+        "ntests": 459
     },
     "sage.rings.polynomial.laurent_polynomial_ideal": {
         "ntests": 115
@@ -3936,14 +3985,13 @@
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 563
+        "ntests": 573
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
         "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
-        "failed": true,
         "ntests": 891
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
@@ -3965,15 +4013,10 @@
         "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
-        "failed": true,
         "ntests": 251
     },
     "sage.rings.polynomial.ore_function_field": {
-        "failed": true,
-        "ntests": 274
-    },
-    "sage.rings.polynomial.ore_polynomial_ring": {
-        "ntests": 1
+        "ntests": 279
     },
     "sage.rings.polynomial.padics.polynomial_padic": {
         "ntests": 69
@@ -3997,32 +4040,29 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2644
+        "ntests": 2690
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
-        "ntests": 219
+        "ntests": 267
     },
     "sage.rings.polynomial.polynomial_gf2x": {
         "ntests": 43
     },
     "sage.rings.polynomial.polynomial_integer_dense_flint": {
-        "failed": true,
         "ntests": 308
     },
     "sage.rings.polynomial.polynomial_integer_dense_ntl": {
-        "failed": true,
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
-        "failed": true,
-        "ntests": 75
+        "ntests": 82
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
-        "ntests": 513
+        "ntests": 524
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
         "ntests": 151
@@ -4035,11 +4075,9 @@
         "ntests": 136
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "failed": true,
-        "ntests": 534
+        "ntests": 536
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
-        "failed": true,
         "ntests": 154
     },
     "sage.rings.polynomial.polynomial_ring_homomorphism": {
@@ -4086,17 +4124,15 @@
         "ntests": 4
     },
     "sage.rings.power_series_pari": {
-        "ntests": 178
+        "ntests": 185
     },
     "sage.rings.power_series_poly": {
-        "failed": true,
         "ntests": 272
     },
     "sage.rings.power_series_ring": {
         "ntests": 241
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
         "ntests": 491
     },
     "sage.rings.puiseux_series_ring": {
@@ -4107,7 +4143,7 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1370
+        "ntests": 1350
     },
     "sage.rings.qqbar_decorators": {
         "ntests": 10
@@ -4120,7 +4156,6 @@
         "ntests": 191
     },
     "sage.rings.rational": {
-        "failed": true,
         "ntests": 567
     },
     "sage.rings.rational_field": {
@@ -4132,7 +4167,6 @@
         "ntests": 559
     },
     "sage.rings.real_double": {
-        "failed": true,
         "ntests": 299
     },
     "sage.rings.real_double_element_gsl": {
@@ -4142,23 +4176,18 @@
     "sage.rings.real_field": {
         "ntests": 5
     },
-    "sage.rings.real_interval_absolute": {
-        "ntests": 1
-    },
     "sage.rings.real_lazy": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 899
+        "ntests": 894
     },
     "sage.rings.real_mpfr": {
         "failed": true,
         "ntests": 0
     },
     "sage.rings.ring": {
-        "failed": true,
         "ntests": 192
     },
     "sage.rings.ring_extension": {
@@ -4186,7 +4215,6 @@
         "ntests": 8
     },
     "sage.rings.semirings.tropical_semiring": {
-        "failed": true,
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
@@ -4206,7 +4234,7 @@
         "ntests": 126
     },
     "sage.rings.tests": {
-        "ntests": 52
+        "ntests": 56
     },
     "sage.rings.valuation.augmented_valuation": {
         "ntests": 469
@@ -4233,7 +4261,7 @@
         "ntests": 53
     },
     "sage.rings.valuation.valuation": {
-        "ntests": 211
+        "ntests": 229
     },
     "sage.rings.valuation.valuation_space": {
         "ntests": 200
@@ -4262,7 +4290,12 @@
         "ntests": 113
     },
     "sage.schemes.berkovich.berkovich_cp_element": {
-        "ntests": 35
+        "failed": true,
+        "ntests": 421
+    },
+    "sage.schemes.berkovich.berkovich_space": {
+        "failed": true,
+        "ntests": 126
     },
     "sage.schemes.curves.affine_curve": {
         "failed": true,
@@ -4278,18 +4311,20 @@
         "ntests": 129
     },
     "sage.schemes.curves.plane_curve_arrangement": {
-        "failed": true,
         "ntests": 128
     },
     "sage.schemes.curves.point": {
         "ntests": 108
     },
     "sage.schemes.curves.projective_curve": {
-        "failed": true,
-        "ntests": 482
+        "ntests": 476
     },
     "sage.schemes.curves.zariski_vankampen": {
         "ntests": 9
+    },
+    "sage.schemes.cyclic_covers.charpoly_frobenius": {
+        "failed": true,
+        "ntests": 21
     },
     "sage.schemes.cyclic_covers.constructor": {
         "ntests": 15
@@ -4314,7 +4349,6 @@
         "ntests": 92
     },
     "sage.schemes.elliptic_curves.constructor": {
-        "failed": true,
         "ntests": 210
     },
     "sage.schemes.elliptic_curves.descent_two_isogeny": {
@@ -4339,19 +4373,20 @@
         "ntests": 531
     },
     "sage.schemes.elliptic_curves.ell_generic": {
-        "failed": true,
-        "ntests": 559
+        "ntests": 563
     },
     "sage.schemes.elliptic_curves.ell_local_data": {
         "ntests": 167
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
-        "failed": true,
-        "ntests": 43
+        "ntests": 40
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
         "ntests": 817
+    },
+    "sage.schemes.elliptic_curves.ell_padic_field": {
+        "ntests": 13
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
@@ -4359,7 +4394,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 776
+        "ntests": 771
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4434,7 +4469,6 @@
         "ntests": 138
     },
     "sage.schemes.elliptic_curves.lseries_ell": {
-        "failed": true,
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.mod5family": {
@@ -4452,6 +4486,10 @@
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
         "ntests": 1
+    },
+    "sage.schemes.elliptic_curves.padics": {
+        "failed": true,
+        "ntests": 0
     },
     "sage.schemes.elliptic_curves.period_lattice": {
         "failed": true,
@@ -4492,22 +4530,22 @@
         "ntests": 42
     },
     "sage.schemes.generic.morphism": {
-        "failed": true,
         "ntests": 475
     },
     "sage.schemes.generic.point": {
         "ntests": 35
     },
     "sage.schemes.generic.scheme": {
-        "failed": true,
         "ntests": 181
     },
     "sage.schemes.generic.spec": {
-        "failed": true,
         "ntests": 32
     },
     "sage.schemes.hyperelliptic_curves.constructor": {
         "ntests": 42
+    },
+    "sage.schemes.hyperelliptic_curves.hypellfrob": {
+        "ntests": 15
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_finite_field": {
         "ntests": 373
@@ -4517,7 +4555,11 @@
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_generic": {
         "failed": true,
-        "ntests": 202
+        "ntests": 208
+    },
+    "sage.schemes.hyperelliptic_curves.hyperelliptic_padic_field": {
+        "failed": true,
+        "ntests": 334
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_rational_field": {
         "ntests": 8
@@ -4545,7 +4587,7 @@
     },
     "sage.schemes.hyperelliptic_curves.monsky_washnitzer": {
         "failed": true,
-        "ntests": 632
+        "ntests": 649
     },
     "sage.schemes.jacobians.abstract_jacobian": {
         "ntests": 56
@@ -4554,7 +4596,6 @@
         "ntests": 9
     },
     "sage.schemes.plane_conics.con_field": {
-        "failed": true,
         "ntests": 187
     },
     "sage.schemes.plane_conics.con_finite_field": {
@@ -4564,7 +4605,6 @@
         "ntests": 62
     },
     "sage.schemes.plane_conics.con_rational_field": {
-        "failed": true,
         "ntests": 41
     },
     "sage.schemes.plane_conics.con_rational_function_field": {
@@ -4602,16 +4642,14 @@
         "ntests": 45
     },
     "sage.schemes.projective.projective_homset": {
-        "failed": true,
         "ntests": 81
     },
     "sage.schemes.projective.projective_morphism": {
-        "failed": true,
-        "ntests": 659
+        "ntests": 667
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
-        "ntests": 337
+        "ntests": 346
     },
     "sage.schemes.projective.projective_rational_point": {
         "failed": true,
@@ -4623,10 +4661,10 @@
     },
     "sage.schemes.projective.projective_subscheme": {
         "failed": true,
-        "ntests": 299
+        "ntests": 309
     },
     "sage.schemes.riemann_surfaces.riemann_surface": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.schemes.toric.chow_group": {
         "ntests": 1
@@ -4641,7 +4679,6 @@
         "ntests": 9
     },
     "sage.sets.cartesian_product": {
-        "failed": true,
         "ntests": 54
     },
     "sage.sets.condition_set": {
@@ -4741,7 +4778,6 @@
         "ntests": 163
     },
     "sage.structure.coerce": {
-        "failed": true,
         "ntests": 360
     },
     "sage.structure.coerce_actions": {
@@ -4760,7 +4796,6 @@
         "ntests": 83
     },
     "sage.structure.element": {
-        "failed": true,
         "ntests": 710
     },
     "sage.structure.element.pxd": {
@@ -4780,7 +4815,6 @@
         "ntests": 118
     },
     "sage.structure.formal_sum": {
-        "failed": true,
         "ntests": 71
     },
     "sage.structure.global_options": {
@@ -4808,7 +4842,6 @@
         "ntests": 11
     },
     "sage.structure.parent": {
-        "failed": true,
         "ntests": 362
     },
     "sage.structure.parent_gens": {
@@ -4831,7 +4864,7 @@
     },
     "sage.structure.sage_object": {
         "failed": true,
-        "ntests": 84
+        "ntests": 98
     },
     "sage.structure.sequence": {
         "ntests": 183
@@ -4923,7 +4956,7 @@
         "ntests": 237
     },
     "sage.tests.cmdline": {
-        "ntests": 141
+        "ntests": 126
     },
     "sage.tests.finite_poset": {
         "ntests": 1

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -12,7 +12,6 @@
         "ntests": 67
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra": {
-        "failed": true,
         "ntests": 167
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_element": {
@@ -71,8 +70,7 @@
         "ntests": 222
     },
     "sage.algebras.orlik_solomon": {
-        "failed": true,
-        "ntests": 88
+        "ntests": 78
     },
     "sage.algebras.orlik_terao": {
         "ntests": 89
@@ -158,14 +156,14 @@
         "ntests": 66
     },
     "sage.categories.action": {
+        "failed": true,
         "ntests": 107
     },
     "sage.categories.additive_groups": {
         "ntests": 9
     },
     "sage.categories.additive_magmas": {
-        "failed": true,
-        "ntests": 161
+        "ntests": 157
     },
     "sage.categories.additive_monoids": {
         "ntests": 16
@@ -227,6 +225,9 @@
     "sage.categories.chain_complexes": {
         "ntests": 24
     },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
     "sage.categories.coalgebras": {
         "ntests": 1
     },
@@ -258,7 +259,7 @@
         "ntests": 115
     },
     "sage.categories.complete_discrete_valuation": {
-        "ntests": 30
+        "ntests": 61
     },
     "sage.categories.complex_reflection_groups": {
         "ntests": 16
@@ -273,7 +274,7 @@
         "ntests": 368
     },
     "sage.categories.crystals": {
-        "ntests": 1
+        "ntests": 3
     },
     "sage.categories.cw_complexes": {
         "ntests": 36
@@ -282,7 +283,7 @@
         "ntests": 39
     },
     "sage.categories.discrete_valuation": {
-        "ntests": 41
+        "ntests": 56
     },
     "sage.categories.distributive_magmas_and_additive_magmas": {
         "ntests": 13
@@ -291,7 +292,7 @@
         "ntests": 11
     },
     "sage.categories.domains": {
-        "ntests": 7
+        "ntests": 13
     },
     "sage.categories.drinfeld_modules": {
         "failed": true,
@@ -377,7 +378,7 @@
     },
     "sage.categories.fields": {
         "failed": true,
-        "ntests": 141
+        "ntests": 145
     },
     "sage.categories.filtered_algebras": {
         "ntests": 5
@@ -399,7 +400,7 @@
         "ntests": 172
     },
     "sage.categories.finite_coxeter_groups": {
-        "ntests": 6
+        "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
         "ntests": 97
@@ -444,7 +445,7 @@
         "ntests": 28
     },
     "sage.categories.finite_permutation_groups": {
-        "ntests": 12
+        "ntests": 15
     },
     "sage.categories.finite_semigroups": {
         "ntests": 14
@@ -598,7 +599,6 @@
         "ntests": 1
     },
     "sage.categories.magmas": {
-        "failed": true,
         "ntests": 147
     },
     "sage.categories.magmas_and_additive_magmas": {
@@ -608,11 +608,9 @@
         "ntests": 27
     },
     "sage.categories.manifolds": {
-        "failed": true,
         "ntests": 55
     },
     "sage.categories.map": {
-        "failed": true,
         "ntests": 423
     },
     "sage.categories.matrix_algebras": {
@@ -628,8 +626,7 @@
         "ntests": 145
     },
     "sage.categories.modules_with_basis": {
-        "failed": true,
-        "ntests": 507
+        "ntests": 512
     },
     "sage.categories.monoid_algebras": {
         "ntests": 4
@@ -671,8 +668,7 @@
         "ntests": 45
     },
     "sage.categories.pushout": {
-        "failed": true,
-        "ntests": 857
+        "ntests": 915
     },
     "sage.categories.quantum_group_representations": {
         "ntests": 13
@@ -696,8 +692,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "failed": true,
-        "ntests": 254
+        "ntests": 263
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -772,7 +767,7 @@
         "ntests": 4
     },
     "sage.categories.unique_factorization_domains": {
-        "ntests": 39
+        "ntests": 43
     },
     "sage.categories.unital_algebras": {
         "ntests": 36
@@ -843,7 +838,6 @@
         "ntests": 81
     },
     "sage.coding.gabidulin_code": {
-        "failed": true,
         "ntests": 235
     },
     "sage.coding.golay_code": {
@@ -925,7 +919,6 @@
         "ntests": 65
     },
     "sage.combinat.free_module": {
-        "failed": true,
         "ntests": 401
     },
     "sage.combinat.integer_lists.base": {
@@ -953,11 +946,21 @@
     "sage.combinat.matrices.dlxcpp": {
         "ntests": 13
     },
+    "sage.combinat.partition": {
+        "ntests": 1232
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
     "sage.combinat.permutation": {
         "ntests": 1195
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "failed": true,
+        "ntests": 127
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -1257,6 +1260,9 @@
     "sage.dynamics.arithmetic_dynamics.affine_ds": {
         "ntests": 219
     },
+    "sage.dynamics.arithmetic_dynamics.berkovich_ds": {
+        "ntests": 185
+    },
     "sage.dynamics.arithmetic_dynamics.dynamical_semigroup": {
         "failed": true,
         "ntests": 398
@@ -1322,6 +1328,9 @@
     },
     "sage.features.databases": {
         "ntests": 38
+    },
+    "sage.features.dot2tex": {
+        "ntests": 4
     },
     "sage.features.dvipng": {
         "ntests": 4
@@ -1402,7 +1411,7 @@
         "ntests": 4
     },
     "sage.features.mip_backends": {
-        "ntests": 7
+        "ntests": 9
     },
     "sage.features.msolve": {
         "ntests": 6
@@ -1451,6 +1460,9 @@
     },
     "sage.features.sirocco": {
         "ntests": 4
+    },
+    "sage.features.sloane_database": {
+        "ntests": 6
     },
     "sage.features.sphinx": {
         "ntests": 8
@@ -1514,7 +1526,7 @@
     },
     "sage.functions.orthogonal_polys": {
         "failed": true,
-        "ntests": 251
+        "ntests": 255
     },
     "sage.functions.other": {
         "failed": true,
@@ -1596,7 +1608,6 @@
         "ntests": 8
     },
     "sage.geometry.hyperplane_arrangement.hyperplane": {
-        "failed": true,
         "ntests": 145
     },
     "sage.geometry.hyperplane_arrangement.library": {
@@ -1685,7 +1696,6 @@
         "ntests": 14
     },
     "sage.geometry.polyhedron.base_ZZ": {
-        "failed": true,
         "ntests": 100
     },
     "sage.geometry.polyhedron.base_mutable": {
@@ -1745,7 +1755,6 @@
         "ntests": 64
     },
     "sage.geometry.polyhedron.parent": {
-        "failed": true,
         "ntests": 200
     },
     "sage.geometry.polyhedron.plot": {
@@ -1788,6 +1797,9 @@
     "sage.geometry.voronoi_diagram": {
         "failed": true,
         "ntests": 24
+    },
+    "sage.graphs.chrompoly": {
+        "ntests": 2
     },
     "sage.graphs.matchpoly": {
         "ntests": 3
@@ -1851,7 +1863,6 @@
         "ntests": 33
     },
     "sage.groups.matrix_gps.linear": {
-        "failed": true,
         "ntests": 47
     },
     "sage.groups.matrix_gps.matrix_group": {
@@ -1910,6 +1921,9 @@
     },
     "sage.homology.graded_resolution": {
         "ntests": 93
+    },
+    "sage.homology.hochschild_complex": {
+        "ntests": 3
     },
     "sage.homology.homology_group": {
         "ntests": 23
@@ -2003,7 +2017,6 @@
         "ntests": 22
     },
     "sage.libs.mpmath.utils": {
-        "failed": true,
         "ntests": 57
     },
     "sage.libs.ntl.error": {
@@ -2083,7 +2096,7 @@
         "ntests": 16
     },
     "sage.libs.pari.convert_sage": {
-        "ntests": 94
+        "ntests": 97
     },
     "sage.libs.pari.convert_sage_complex_double": {
         "ntests": 22
@@ -2100,7 +2113,7 @@
     },
     "sage.libs.pari.tests": {
         "failed": true,
-        "ntests": 799
+        "ntests": 812
     },
     "sage.libs.singular.function": {
         "failed": true,
@@ -2145,7 +2158,6 @@
         "ntests": 99
     },
     "sage.matrix.constructor": {
-        "failed": true,
         "ntests": 155
     },
     "sage.matrix.docs": {
@@ -2156,18 +2168,17 @@
     },
     "sage.matrix.matrix0": {
         "failed": true,
-        "ntests": 846
+        "ntests": 860
     },
     "sage.matrix.matrix1": {
-        "failed": true,
         "ntests": 441
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2647
+        "ntests": 2667
     },
     "sage.matrix.matrix_cdv": {
-        "ntests": 5
+        "ntests": 10
     },
     "sage.matrix.matrix_complex_ball_dense": {
         "ntests": 118
@@ -2232,7 +2243,6 @@
         "ntests": 105
     },
     "sage.matrix.matrix_mpolynomial_dense": {
-        "failed": true,
         "ntests": 86
     },
     "sage.matrix.matrix_numpy_dense": {
@@ -2258,7 +2268,6 @@
         "ntests": 462
     },
     "sage.matrix.matrix_sparse": {
-        "failed": true,
         "ntests": 164
     },
     "sage.matrix.misc": {
@@ -2268,7 +2277,6 @@
         "ntests": 5
     },
     "sage.matrix.misc_mpfr": {
-        "failed": true,
         "ntests": 7
     },
     "sage.matrix.operation_table": {
@@ -2282,7 +2290,6 @@
         "ntests": 69
     },
     "sage.matrix.symplectic_basis": {
-        "failed": true,
         "ntests": 46
     },
     "sage.matrix.tests": {
@@ -2370,7 +2377,7 @@
         "ntests": 150
     },
     "sage.misc.cachefunc": {
-        "ntests": 688
+        "ntests": 751
     },
     "sage.misc.call": {
         "ntests": 28
@@ -2566,6 +2573,7 @@
         "ntests": 102
     },
     "sage.misc.sageinspect": {
+        "failed": true,
         "ntests": 326
     },
     "sage.misc.search": {
@@ -2689,10 +2697,7 @@
         "ntests": 89
     },
     "sage.modular.btquotients.btquotient": {
-        "ntests": 6
-    },
-    "sage.modular.btquotients.pautomorphicform": {
-        "ntests": 5
+        "ntests": 2
     },
     "sage.modular.buzzard": {
         "ntests": 7
@@ -2765,7 +2770,7 @@
     },
     "sage.modular.hypergeometric_motive": {
         "failed": true,
-        "ntests": 320
+        "ntests": 321
     },
     "sage.modular.local_comp.liftings": {
         "ntests": 48
@@ -2775,7 +2780,6 @@
         "ntests": 101
     },
     "sage.modular.local_comp.smoothchar": {
-        "failed": true,
         "ntests": 324
     },
     "sage.modular.local_comp.type_space": {
@@ -2937,25 +2941,45 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
-        "ntests": 1
+        "failed": true,
+        "ntests": 218
     },
     "sage.modular.overconvergent.hecke_series": {
         "failed": true,
         "ntests": 76
     },
+    "sage.modular.overconvergent.weightspace": {
+        "failed": true,
+        "ntests": 108
+    },
     "sage.modular.pollack_stevens.dist": {
         "ntests": 168
+    },
+    "sage.modular.pollack_stevens.distributions": {
+        "failed": true,
+        "ntests": 164
     },
     "sage.modular.pollack_stevens.fund_domain": {
         "failed": true,
         "ntests": 166
     },
+    "sage.modular.pollack_stevens.manin_map": {
+        "failed": true,
+        "ntests": 180
+    },
+    "sage.modular.pollack_stevens.padic_lseries": {
+        "failed": true,
+        "ntests": 48
+    },
     "sage.modular.pollack_stevens.sigma0": {
         "ntests": 101
+    },
+    "sage.modular.pollack_stevens.space": {
+        "failed": true,
+        "ntests": 182
     },
     "sage.modular.quasimodform.element": {
         "failed": true,
@@ -2990,12 +3014,7 @@
     "sage.modules.filtered_vector_space": {
         "ntests": 169
     },
-    "sage.modules.finite_submodule_iter": {
-        "failed": true,
-        "ntests": 95
-    },
     "sage.modules.free_module": {
-        "failed": true,
         "ntests": 1484
     },
     "sage.modules.free_module_element": {
@@ -3006,7 +3025,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 11
+        "ntests": 12
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3030,7 +3049,6 @@
         "ntests": 57
     },
     "sage.modules.multi_filtered_vector_space": {
-        "failed": true,
         "ntests": 122
     },
     "sage.modules.quotient_module": {
@@ -3091,7 +3109,6 @@
         "ntests": 353
     },
     "sage.modules.with_basis.subquotient": {
-        "failed": true,
         "ntests": 152
     },
     "sage.numerical.backends.cvxpy_backend": {
@@ -3199,6 +3216,9 @@
     },
     "sage.quadratic_forms.genera.genus": {
         "ntests": 496
+    },
+    "sage.quadratic_forms.genera.normal_form": {
+        "ntests": 275
     },
     "sage.quadratic_forms.qfsolve": {
         "ntests": 38
@@ -3327,7 +3347,6 @@
         "ntests": 12
     },
     "sage.repl.ipython_kernel.widgets": {
-        "failed": true,
         "ntests": 98
     },
     "sage.repl.ipython_kernel.widgets_sagenb": {
@@ -3393,7 +3412,6 @@
         "ntests": 36
     },
     "sage.rings.abc": {
-        "failed": true,
         "ntests": 91
     },
     "sage.rings.algebraic_closure_finite_field": {
@@ -3406,7 +3424,7 @@
         "ntests": 26
     },
     "sage.rings.big_oh": {
-        "ntests": 22
+        "ntests": 27
     },
     "sage.rings.complex_arb": {
         "failed": true,
@@ -3487,7 +3505,7 @@
         "ntests": 41
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
-        "ntests": 42
+        "ntests": 44
     },
     "sage.rings.finite_rings.galois_group": {
         "ntests": 20
@@ -3505,7 +3523,7 @@
         "ntests": 67
     },
     "sage.rings.finite_rings.integer_mod": {
-        "ntests": 583
+        "ntests": 588
     },
     "sage.rings.finite_rings.integer_mod_ring": {
         "ntests": 367
@@ -3514,7 +3532,6 @@
         "ntests": 31
     },
     "sage.rings.finite_rings.residue_field": {
-        "failed": true,
         "ntests": 445
     },
     "sage.rings.finite_rings.residue_field_givaro": {
@@ -3527,14 +3544,13 @@
         "ntests": 34
     },
     "sage.rings.fraction_field": {
-        "ntests": 262
+        "ntests": 266
     },
     "sage.rings.fraction_field_FpT": {
         "ntests": 371
     },
     "sage.rings.fraction_field_element": {
-        "failed": true,
-        "ntests": 290
+        "ntests": 295
     },
     "sage.rings.function_field.constructor": {
         "ntests": 42
@@ -3570,11 +3586,9 @@
         "ntests": 316
     },
     "sage.rings.function_field.function_field_polymod": {
-        "failed": true,
-        "ntests": 437
+        "ntests": 433
     },
     "sage.rings.function_field.function_field_rational": {
-        "failed": true,
         "ntests": 157
     },
     "sage.rings.function_field.hermite_form_polynomial": {
@@ -3667,10 +3681,10 @@
         "ntests": 59
     },
     "sage.rings.laurent_series_ring": {
-        "ntests": 166
+        "ntests": 179
     },
     "sage.rings.laurent_series_ring_element": {
-        "ntests": 402
+        "ntests": 407
     },
     "sage.rings.localization": {
         "ntests": 208
@@ -3679,11 +3693,9 @@
         "ntests": 5
     },
     "sage.rings.morphism": {
-        "failed": true,
-        "ntests": 744
+        "ntests": 748
     },
     "sage.rings.multi_power_series_ring": {
-        "failed": true,
         "ntests": 239
     },
     "sage.rings.multi_power_series_ring_element": {
@@ -3691,6 +3703,10 @@
     },
     "sage.rings.noncommutative_ideals": {
         "ntests": 23
+    },
+    "sage.rings.number_field.S_unit_solver": {
+        "failed": true,
+        "ntests": 312
     },
     "sage.rings.number_field.bdd_height": {
         "ntests": 76
@@ -3712,7 +3728,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2255
+        "ntests": 2292
     },
     "sage.rings.number_field.number_field_base": {
         "failed": true,
@@ -3797,10 +3813,13 @@
         "ntests": 254
     },
     "sage.rings.padics.lattice_precision": {
-        "ntests": 456
+        "ntests": 463
+    },
+    "sage.rings.padics.local_generic": {
+        "ntests": 240
     },
     "sage.rings.padics.local_generic_element": {
-        "ntests": 1
+        "ntests": 221
     },
     "sage.rings.padics.misc": {
         "ntests": 26
@@ -3808,11 +3827,32 @@
     "sage.rings.padics.morphism": {
         "ntests": 66
     },
+    "sage.rings.padics.padic_ZZ_pX_CA_element": {
+        "ntests": 465
+    },
+    "sage.rings.padics.padic_ZZ_pX_CR_element": {
+        "ntests": 649
+    },
+    "sage.rings.padics.padic_ZZ_pX_FM_element": {
+        "ntests": 363
+    },
+    "sage.rings.padics.padic_ZZ_pX_element": {
+        "ntests": 147
+    },
     "sage.rings.padics.padic_base_generic": {
         "ntests": 44
     },
     "sage.rings.padics.padic_base_leaves": {
         "ntests": 223
+    },
+    "sage.rings.padics.padic_capped_absolute_element": {
+        "ntests": 61
+    },
+    "sage.rings.padics.padic_capped_relative_element": {
+        "ntests": 83
+    },
+    "sage.rings.padics.padic_ext_element": {
+        "ntests": 49
     },
     "sage.rings.padics.padic_extension_generic": {
         "ntests": 208
@@ -3820,9 +3860,18 @@
     "sage.rings.padics.padic_extension_leaves": {
         "ntests": 72
     },
+    "sage.rings.padics.padic_fixed_mod_element": {
+        "ntests": 66
+    },
+    "sage.rings.padics.padic_floating_point_element": {
+        "ntests": 62
+    },
+    "sage.rings.padics.padic_generic": {
+        "ntests": 240
+    },
     "sage.rings.padics.padic_generic_element": {
         "failed": true,
-        "ntests": 813
+        "ntests": 824
     },
     "sage.rings.padics.padic_lattice_element": {
         "ntests": 269
@@ -3838,10 +3887,13 @@
         "ntests": 141
     },
     "sage.rings.padics.padic_valuation": {
-        "ntests": 192
+        "ntests": 196
     },
     "sage.rings.padics.pow_computer": {
         "ntests": 88
+    },
+    "sage.rings.padics.pow_computer_ext": {
+        "ntests": 281
     },
     "sage.rings.padics.pow_computer_flint": {
         "ntests": 76
@@ -3895,7 +3947,6 @@
         "ntests": 7
     },
     "sage.rings.polynomial.complex_roots": {
-        "failed": true,
         "ntests": 42
     },
     "sage.rings.polynomial.cyclotomic": {
@@ -3903,14 +3954,12 @@
         "ntests": 37
     },
     "sage.rings.polynomial.flatten": {
-        "failed": true,
         "ntests": 150
     },
     "sage.rings.polynomial.hilbert": {
         "ntests": 24
     },
     "sage.rings.polynomial.ideal": {
-        "failed": true,
         "ntests": 13
     },
     "sage.rings.polynomial.infinite_polynomial_element": {
@@ -3920,7 +3969,7 @@
         "ntests": 279
     },
     "sage.rings.polynomial.laurent_polynomial": {
-        "ntests": 454
+        "ntests": 459
     },
     "sage.rings.polynomial.laurent_polynomial_ideal": {
         "ntests": 115
@@ -3936,14 +3985,13 @@
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 563
+        "ntests": 573
     },
     "sage.rings.polynomial.multi_polynomial_element": {
         "failed": true,
         "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
-        "failed": true,
         "ntests": 891
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
@@ -3965,15 +4013,10 @@
         "ntests": 126
     },
     "sage.rings.polynomial.ore_function_element": {
-        "failed": true,
         "ntests": 251
     },
     "sage.rings.polynomial.ore_function_field": {
-        "failed": true,
-        "ntests": 274
-    },
-    "sage.rings.polynomial.ore_polynomial_ring": {
-        "ntests": 1
+        "ntests": 279
     },
     "sage.rings.polynomial.padics.polynomial_padic": {
         "ntests": 69
@@ -3997,32 +4040,29 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2644
+        "ntests": 2690
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
-        "ntests": 219
+        "ntests": 267
     },
     "sage.rings.polynomial.polynomial_gf2x": {
         "ntests": 43
     },
     "sage.rings.polynomial.polynomial_integer_dense_flint": {
-        "failed": true,
         "ntests": 308
     },
     "sage.rings.polynomial.polynomial_integer_dense_ntl": {
-        "failed": true,
         "ntests": 188
     },
     "sage.rings.polynomial.polynomial_modn_dense_ntl": {
         "ntests": 383
     },
     "sage.rings.polynomial.polynomial_number_field": {
-        "failed": true,
-        "ntests": 75
+        "ntests": 82
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
-        "ntests": 513
+        "ntests": 524
     },
     "sage.rings.polynomial.polynomial_quotient_ring_element": {
         "ntests": 151
@@ -4035,11 +4075,9 @@
         "ntests": 136
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "failed": true,
-        "ntests": 534
+        "ntests": 536
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
-        "failed": true,
         "ntests": 154
     },
     "sage.rings.polynomial.polynomial_ring_homomorphism": {
@@ -4086,17 +4124,15 @@
         "ntests": 4
     },
     "sage.rings.power_series_pari": {
-        "ntests": 178
+        "ntests": 185
     },
     "sage.rings.power_series_poly": {
-        "failed": true,
         "ntests": 272
     },
     "sage.rings.power_series_ring": {
         "ntests": 241
     },
     "sage.rings.power_series_ring_element": {
-        "failed": true,
         "ntests": 491
     },
     "sage.rings.puiseux_series_ring": {
@@ -4107,7 +4143,7 @@
     },
     "sage.rings.qqbar": {
         "failed": true,
-        "ntests": 1370
+        "ntests": 1350
     },
     "sage.rings.qqbar_decorators": {
         "ntests": 10
@@ -4120,7 +4156,6 @@
         "ntests": 191
     },
     "sage.rings.rational": {
-        "failed": true,
         "ntests": 567
     },
     "sage.rings.rational_field": {
@@ -4132,7 +4167,6 @@
         "ntests": 559
     },
     "sage.rings.real_double": {
-        "failed": true,
         "ntests": 299
     },
     "sage.rings.real_double_element_gsl": {
@@ -4142,23 +4176,18 @@
     "sage.rings.real_field": {
         "ntests": 5
     },
-    "sage.rings.real_interval_absolute": {
-        "ntests": 1
-    },
     "sage.rings.real_lazy": {
-        "failed": true,
         "ntests": 279
     },
     "sage.rings.real_mpfi": {
         "failed": true,
-        "ntests": 899
+        "ntests": 894
     },
     "sage.rings.real_mpfr": {
         "failed": true,
         "ntests": 0
     },
     "sage.rings.ring": {
-        "failed": true,
         "ntests": 192
     },
     "sage.rings.ring_extension": {
@@ -4186,7 +4215,6 @@
         "ntests": 8
     },
     "sage.rings.semirings.tropical_semiring": {
-        "failed": true,
         "ntests": 132
     },
     "sage.rings.semirings.tropical_variety": {
@@ -4206,7 +4234,7 @@
         "ntests": 126
     },
     "sage.rings.tests": {
-        "ntests": 52
+        "ntests": 56
     },
     "sage.rings.valuation.augmented_valuation": {
         "ntests": 469
@@ -4233,7 +4261,7 @@
         "ntests": 53
     },
     "sage.rings.valuation.valuation": {
-        "ntests": 211
+        "ntests": 229
     },
     "sage.rings.valuation.valuation_space": {
         "ntests": 200
@@ -4262,7 +4290,12 @@
         "ntests": 113
     },
     "sage.schemes.berkovich.berkovich_cp_element": {
-        "ntests": 35
+        "failed": true,
+        "ntests": 421
+    },
+    "sage.schemes.berkovich.berkovich_space": {
+        "failed": true,
+        "ntests": 126
     },
     "sage.schemes.curves.affine_curve": {
         "failed": true,
@@ -4278,18 +4311,20 @@
         "ntests": 129
     },
     "sage.schemes.curves.plane_curve_arrangement": {
-        "failed": true,
         "ntests": 128
     },
     "sage.schemes.curves.point": {
         "ntests": 108
     },
     "sage.schemes.curves.projective_curve": {
-        "failed": true,
-        "ntests": 482
+        "ntests": 476
     },
     "sage.schemes.curves.zariski_vankampen": {
         "ntests": 9
+    },
+    "sage.schemes.cyclic_covers.charpoly_frobenius": {
+        "failed": true,
+        "ntests": 21
     },
     "sage.schemes.cyclic_covers.constructor": {
         "ntests": 15
@@ -4314,7 +4349,6 @@
         "ntests": 92
     },
     "sage.schemes.elliptic_curves.constructor": {
-        "failed": true,
         "ntests": 210
     },
     "sage.schemes.elliptic_curves.descent_two_isogeny": {
@@ -4339,19 +4373,20 @@
         "ntests": 531
     },
     "sage.schemes.elliptic_curves.ell_generic": {
-        "failed": true,
-        "ntests": 559
+        "ntests": 563
     },
     "sage.schemes.elliptic_curves.ell_local_data": {
         "ntests": 167
     },
     "sage.schemes.elliptic_curves.ell_modular_symbols": {
-        "failed": true,
-        "ntests": 43
+        "ntests": 40
     },
     "sage.schemes.elliptic_curves.ell_number_field": {
         "failed": true,
         "ntests": 817
+    },
+    "sage.schemes.elliptic_curves.ell_padic_field": {
+        "ntests": 13
     },
     "sage.schemes.elliptic_curves.ell_point": {
         "failed": true,
@@ -4359,7 +4394,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 776
+        "ntests": 771
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4434,7 +4469,6 @@
         "ntests": 138
     },
     "sage.schemes.elliptic_curves.lseries_ell": {
-        "failed": true,
         "ntests": 59
     },
     "sage.schemes.elliptic_curves.mod5family": {
@@ -4452,6 +4486,10 @@
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
         "ntests": 1
+    },
+    "sage.schemes.elliptic_curves.padics": {
+        "failed": true,
+        "ntests": 0
     },
     "sage.schemes.elliptic_curves.period_lattice": {
         "failed": true,
@@ -4492,22 +4530,22 @@
         "ntests": 42
     },
     "sage.schemes.generic.morphism": {
-        "failed": true,
         "ntests": 475
     },
     "sage.schemes.generic.point": {
         "ntests": 35
     },
     "sage.schemes.generic.scheme": {
-        "failed": true,
         "ntests": 181
     },
     "sage.schemes.generic.spec": {
-        "failed": true,
         "ntests": 32
     },
     "sage.schemes.hyperelliptic_curves.constructor": {
         "ntests": 42
+    },
+    "sage.schemes.hyperelliptic_curves.hypellfrob": {
+        "ntests": 15
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_finite_field": {
         "ntests": 373
@@ -4517,7 +4555,11 @@
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_generic": {
         "failed": true,
-        "ntests": 202
+        "ntests": 208
+    },
+    "sage.schemes.hyperelliptic_curves.hyperelliptic_padic_field": {
+        "failed": true,
+        "ntests": 334
     },
     "sage.schemes.hyperelliptic_curves.hyperelliptic_rational_field": {
         "ntests": 8
@@ -4545,7 +4587,7 @@
     },
     "sage.schemes.hyperelliptic_curves.monsky_washnitzer": {
         "failed": true,
-        "ntests": 632
+        "ntests": 649
     },
     "sage.schemes.jacobians.abstract_jacobian": {
         "ntests": 56
@@ -4554,7 +4596,6 @@
         "ntests": 9
     },
     "sage.schemes.plane_conics.con_field": {
-        "failed": true,
         "ntests": 187
     },
     "sage.schemes.plane_conics.con_finite_field": {
@@ -4564,7 +4605,6 @@
         "ntests": 62
     },
     "sage.schemes.plane_conics.con_rational_field": {
-        "failed": true,
         "ntests": 41
     },
     "sage.schemes.plane_conics.con_rational_function_field": {
@@ -4602,16 +4642,14 @@
         "ntests": 45
     },
     "sage.schemes.projective.projective_homset": {
-        "failed": true,
         "ntests": 81
     },
     "sage.schemes.projective.projective_morphism": {
-        "failed": true,
-        "ntests": 659
+        "ntests": 667
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
-        "ntests": 337
+        "ntests": 346
     },
     "sage.schemes.projective.projective_rational_point": {
         "failed": true,
@@ -4623,10 +4661,10 @@
     },
     "sage.schemes.projective.projective_subscheme": {
         "failed": true,
-        "ntests": 299
+        "ntests": 309
     },
     "sage.schemes.riemann_surfaces.riemann_surface": {
-        "ntests": 3
+        "ntests": 4
     },
     "sage.schemes.toric.chow_group": {
         "ntests": 1
@@ -4641,7 +4679,6 @@
         "ntests": 9
     },
     "sage.sets.cartesian_product": {
-        "failed": true,
         "ntests": 54
     },
     "sage.sets.condition_set": {
@@ -4741,7 +4778,6 @@
         "ntests": 163
     },
     "sage.structure.coerce": {
-        "failed": true,
         "ntests": 360
     },
     "sage.structure.coerce_actions": {
@@ -4760,7 +4796,6 @@
         "ntests": 83
     },
     "sage.structure.element": {
-        "failed": true,
         "ntests": 710
     },
     "sage.structure.element.pxd": {
@@ -4780,7 +4815,6 @@
         "ntests": 118
     },
     "sage.structure.formal_sum": {
-        "failed": true,
         "ntests": 71
     },
     "sage.structure.global_options": {
@@ -4808,7 +4842,6 @@
         "ntests": 11
     },
     "sage.structure.parent": {
-        "failed": true,
         "ntests": 362
     },
     "sage.structure.parent_gens": {
@@ -4831,7 +4864,7 @@
     },
     "sage.structure.sage_object": {
         "failed": true,
-        "ntests": 84
+        "ntests": 98
     },
     "sage.structure.sequence": {
         "ntests": 183
@@ -4923,7 +4956,7 @@
         "ntests": 237
     },
     "sage.tests.cmdline": {
-        "ntests": 141
+        "ntests": 126
     },
     "sage.tests.finite_poset": {
         "ntests": 1

--- a/src/sage/all__sagemath_polyhedra.py
+++ b/src/sage/all__sagemath_polyhedra.py
@@ -39,6 +39,8 @@ try:  # extra
 except ImportError:
     pass
 
+from .all__sagemath_modules import RR
+
 from sage.geometry.all__sagemath_polyhedra import *
 from sage.geometry.triangulation.all import *
 from sage.numerical.all import *

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -106,7 +106,7 @@ def algdep(z, degree, known_bits=None, use_bits=None, known_digits=None,
     compute a 200-bit approximation to `sqrt(2)` which is wrong in the
     33'rd bit::
 
-        sage: # needs sage.libs.pari sage.rings.real_mpfr
+        sage: # needs fpylll sage.libs.pari sage.rings.real_mpfr
         sage: z = sqrt(RealField(200)(2)) + (1/2)^33
         sage: p = algdep(z, 4); p
         227004321085*x^4 - 216947902586*x^3 - 99411220986*x^2 + 82234881648*x - 211871195088
@@ -6272,7 +6272,7 @@ def gauss_sum(char_value, finite_field):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.pari sage.rings.number_field
+        sage: # needs sage.libs.gap sage.libs.pari sage.rings.number_field
         sage: from sage.arith.misc import gauss_sum
         sage: F = GF(5); q = 5
         sage: zq = UniversalCyclotomicField().zeta(q - 1)

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -274,7 +274,7 @@ Miscellaneous methods (see documentation for an explanation)::
     True
     sage: b = a.change_ring(GF(5))
     sage: pa = a.intersection_poset()                                                   # needs sage.graphs
-    sage: pb = b.intersection_poset()                                                   # needs sage.rings.finite_rings
+    sage: pb = b.intersection_poset()                                                   # needs sage.graphs sage.rings.finite_rings
     sage: pa.is_isomorphic(pb)                                                          # needs sage.graphs sage.rings.finite_rings
     True
     sage: a.face_vector()                                                               # needs sage.graphs
@@ -1089,6 +1089,7 @@ class HyperplaneArrangementElement(Element):
             sage: H.primitive_eulerian_polynomial()
             z^3 + 28*z^2 + 16*z
 
+            sage: # needs sage.libs.gap
             sage: W = CoxeterGroup(['F',4], implementation='permutation')
             sage: A = HyperplaneArrangements(QQ, tuple(f'x{s}' for s in range(W.rank())))
             sage: H = A([[0] + list(r) for r in W.positive_roots()])

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -977,7 +977,7 @@ class Polyhedron_base6(Polyhedron_base5):
             Traceback (most recent call last):
             ...
             ValueError: the base ring needs to be extended; try with "extend=True"
-            sage: P.affine_hull_projection(orthonormal=True, extend=True)               # needs sage.rings.number_field
+            sage: P.affine_hull_projection(orthonormal=True, extend=True)               # needs sage.rings.number_field sage.symbolic
             A 4-dimensional polyhedron in AA^4 defined as the convex hull of 6 vertices
         """
         result = AffineHullProjectionData()
@@ -1193,13 +1193,13 @@ class Polyhedron_base6(Polyhedron_base5):
             A 1-dimensional polyhedron in QQ^1 defined as the convex hull of 2 vertices
             sage: A.vertices()
             (A vertex at (0), A vertex at (2))
-            sage: A = L.affine_hull_projection(orthonormal=True)                        # needs sage.rings.number_field
+            sage: A = L.affine_hull_projection(orthonormal=True)                        # needs sage.rings.number_field sage.symbolic
             Traceback (most recent call last):
             ...
             ValueError: the base ring needs to be extended; try with "extend=True"
-            sage: A = L.affine_hull_projection(orthonormal=True, extend=True); A        # needs sage.rings.number_field
+            sage: A = L.affine_hull_projection(orthonormal=True, extend=True); A        # needs sage.rings.number_field sage.symbolic
             A 1-dimensional polyhedron in AA^1 defined as the convex hull of 2 vertices
-            sage: A.vertices()                                                          # needs sage.rings.number_field
+            sage: A.vertices()                                                          # needs sage.rings.number_field sage.symbolic
             (A vertex at (1.414213562373095?), A vertex at (0.?e-18))
 
         More generally::

--- a/src/sage/libs/singular/function.pyx
+++ b/src/sage/libs/singular/function.pyx
@@ -1749,6 +1749,7 @@ def singular_function(name):
         sage: singular_list(resolution)
         [[(-2*y, 2, y + 1, 0), (0, -2, x - 1, 0), (x*y - y, -y + 1, 1, -y), (x^2 + 1, -x - 1, -1, -x)], [(-x - 1, y - 1, 2*x, -2*y)], [(0)]]
 
+        sage: # needs sage.combinat
         sage: A.<x,y> = FreeAlgebra(QQ, 2)
         sage: P.<x,y> = A.g_algebra({y*x:-x*y})
         sage: I= Sequence([x*y,x+y], check=False, immutable=True)

--- a/src/sage/libs/singular/groebner_strategy.pyx
+++ b/src/sage/libs/singular/groebner_strategy.pyx
@@ -322,6 +322,8 @@ cdef class NCGroebnerStrategy(SageObject):
         EXAMPLES::
 
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
+
+            sage: # needs sage.combinat
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
             sage: I = H.ideal([y^2, x^2, z^2-H.one()])
@@ -399,6 +401,7 @@ cdef class NCGroebnerStrategy(SageObject):
         """
         TESTS::
 
+            sage: # needs sage.combinat
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -431,6 +434,7 @@ cdef class NCGroebnerStrategy(SageObject):
         """
         TESTS::
 
+            sage: # needs sage.combinat
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -447,6 +451,7 @@ cdef class NCGroebnerStrategy(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -463,6 +468,7 @@ cdef class NCGroebnerStrategy(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -477,6 +483,7 @@ cdef class NCGroebnerStrategy(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -500,6 +507,7 @@ cdef class NCGroebnerStrategy(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -517,6 +525,7 @@ cdef class NCGroebnerStrategy(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
             sage: JL = H.ideal([x^3, y^3, z^3 - 4*z])
@@ -545,6 +554,7 @@ def unpickle_NCGroebnerStrategy0(I):
     """
     EXAMPLES::
 
+        sage: # needs sage.combinat
         sage: from sage.libs.singular.groebner_strategy import NCGroebnerStrategy
         sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
         sage: H.<x,y,z> = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
@@ -560,6 +570,7 @@ def unpickle_GroebnerStrategy0(I):
     """
     EXAMPLES::
 
+        sage: # needs sage.rings.finite_rings
         sage: from sage.libs.singular.groebner_strategy import GroebnerStrategy
         sage: P.<x,y,z> = PolynomialRing(GF(32003))
         sage: I = Ideal([x + z, y + z])

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -4455,11 +4455,11 @@ cdef class Matrix(Matrix1):
             sage: A*X.transpose() == zero_matrix(ZZ, 4, 3)
             True
 
-            sage: X = A.right_kernel_matrix(algorithm='padic', basis='LLL'); X
+            sage: X = A.right_kernel_matrix(algorithm='padic', basis='LLL'); X          # needs fpylll
             [ -3  -1   5   7   2  -3  -2]
             [  3   1   2   5  -5   2  -6]
             [ -4 -13   2  -7   5   7  -3]
-            sage: A*X.transpose() == zero_matrix(ZZ, 4, 3)
+            sage: A*X.transpose() == zero_matrix(ZZ, 4, 3)                              # needs fpylll
             True
 
             sage: # needs sage.libs.pari
@@ -4994,7 +4994,7 @@ cdef class Matrix(Matrix1):
             [  1   5  -8   3  -1  -1  -1]
             [  0  11 -19   5  -2  -3  -3]
             sage: B = copy(A)
-            sage: B.right_kernel(basis='LLL')
+            sage: B.right_kernel(basis='LLL')                                           # needs fpylll
             Free module of degree 7 and rank 2 over Integer Ring
             User basis matrix:
             [ 2 -1  3  1  0  1  1]
@@ -5011,7 +5011,7 @@ cdef class Matrix(Matrix1):
             [  1   5  -8   3  -1  -1  -1]
             [  0  11 -19   5  -2  -3  -3]
             sage: E = copy(A)
-            sage: E.right_kernel(algorithm='padic', basis='LLL')
+            sage: E.right_kernel(algorithm='padic', basis='LLL')                        # needs fpylll
             Free module of degree 7 and rank 2 over Integer Ring
             User basis matrix:
             [-2  1 -3 -1  0 -1 -1]

--- a/src/sage/modular/arithgroup/farey_symbol.pyx
+++ b/src/sage/modular/arithgroup/farey_symbol.pyx
@@ -151,8 +151,8 @@ cdef class Farey:
     <sage.modular.arithgroup.arithgroup_perm.HsuExample10>` of an
     index 10 arithmetic subgroup given by Tim Hsu::
 
-         sage: from sage.modular.arithgroup.arithgroup_perm import HsuExample10
-         sage: FareySymbol(HsuExample10()).generators()
+         sage: from sage.modular.arithgroup.arithgroup_perm import HsuExample10         # needs sage.groups
+         sage: FareySymbol(HsuExample10()).generators()                                 # needs sage.groups
          [
          [1 2]  [-2  1]  [ 4 -3]
          [0 1], [-7  3], [ 3 -2]
@@ -428,6 +428,7 @@ cdef class Farey:
 
         Check that :issue:`20347` is solved::
 
+            sage: # needs sage.groups
             sage: from sage.misc.misc_c import prod
             sage: G = ArithmeticSubgroup_Permutation(S2="(1,2)(3,4)", S3="(1,2,3)")
             sage: S = G.farey_symbol()

--- a/src/sage/modular/drinfeld_modform/ring.py
+++ b/src/sage/modular/drinfeld_modform/ring.py
@@ -156,7 +156,7 @@ class DrinfeldModularForms(Parent, UniqueRepresentation):
     weight, use the methode :meth:`basis_of_weight`::
 
         sage: M = DrinfeldModularForms(K, 2)
-        sage: M.basis_of_weight(q^3 - 1)
+        sage: M.basis_of_weight(q^3 - 1)                                                # needs sage.combinat
         [g1*g2^3, g1^5*g2^2, g1^9*g2, g1^13]
 
     In order to compute the coefficient forms, use the methods
@@ -730,6 +730,7 @@ class DrinfeldModularForms(Parent, UniqueRepresentation):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: q = 3; A = GF(q)['T']; K = Frac(A);
             sage: M = DrinfeldModularForms(K, 2)
             sage: M.basis_of_weight(q - 1)

--- a/src/sage/modular/hypergeometric_motive.py
+++ b/src/sage/modular/hypergeometric_motive.py
@@ -204,8 +204,8 @@ def enumerate_hypergeometric_data(d, weight=None):
     EXAMPLES::
 
         sage: from sage.modular.hypergeometric_motive import enumerate_hypergeometric_data as enum
-        sage: l = [H for H in enum(6, weight=2) if H.hodge_numbers()[0] == 1]
-        sage: len(l)
+        sage: l = [H for H in enum(6, weight=2) if H.hodge_numbers()[0] == 1]           # needs sage.combinat
+        sage: len(l)                                                                    # needs sage.combinat
         112
     """
     bound = 2 * d * d  # to make sure that phi(n) <= d
@@ -238,7 +238,7 @@ def possible_hypergeometric_data(d, weight=None) -> list:
     EXAMPLES::
 
         sage: from sage.modular.hypergeometric_motive import possible_hypergeometric_data as P
-        sage: [len(P(i,weight=2)) for i in range(1, 7)]
+        sage: [len(P(i, weight=2)) for i in range(1, 7)]                                # needs sage.combinat
         [0, 0, 10, 30, 93, 234]
     """
     return list(enumerate_hypergeometric_data(d, weight))

--- a/src/sage/modular/modform/find_generators.py
+++ b/src/sage/modular/modform/find_generators.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
-# sage.doctest: needs sage.libs.flint
+# sage.doctest: needs sage.combinat sage.libs.flint
 r"""
 This module is now called ``ring.py`` (see :issue:`31559`). Do not import from here as
 it will generate a deprecation warning.

--- a/src/sage/modular/modform/ring.py
+++ b/src/sage/modular/modform/ring.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
-# sage.doctest: needs sage.libs.flint sage.libs.pari
+# sage.doctest: needs sage.combinat sage.libs.flint sage.libs.pari
 """
 Graded rings of modular forms
 
@@ -98,7 +98,8 @@ def _span_of_forms_in_weight(forms, weight, prec, stop_dim=None, use_random=Fals
 
     Test the alternative randomized algorithm::
 
-        sage: f._span_of_forms_in_weight(forms, 24, prec=5, use_random=True, stop_dim=3)
+        sage: f._span_of_forms_in_weight(forms, 24, prec=5,
+        ....:                            use_random=True, stop_dim=3)
         Vector space of degree 5 and dimension 3 over Rational Field
         Basis matrix:
         [          1           0           0    52416000 39007332000]

--- a/src/sage/modular/overconvergent/hecke_series.py
+++ b/src/sage/modular/overconvergent/hecke_series.py
@@ -227,11 +227,11 @@ def low_weight_generators(N, p, m, NN):
     EXAMPLES::
 
         sage: from sage.modular.overconvergent.hecke_series import low_weight_generators
-        sage: low_weight_generators(3, 7, 3, 10)
+        sage: low_weight_generators(3, 7, 3, 10)                                        # needs sage.combinat
         ([[1 + 12*q + 36*q^2 + 12*q^3 + 84*q^4 + 72*q^5 + 36*q^6 + 96*q^7 + 180*q^8 + 12*q^9 + O(q^10)],
         [1 + 240*q^3 + 102*q^6 + 203*q^9 + O(q^10)],
         [1 + 182*q^3 + 175*q^6 + 161*q^9 + O(q^10)]], 6)
-        sage: low_weight_generators(11, 5, 3, 10)
+        sage: low_weight_generators(11, 5, 3, 10)                                       # needs sage.combinat
         ([[1 + 12*q^2 + 12*q^3 + 12*q^4 + 12*q^5 + 24*q^6 + 24*q^7 + 36*q^8 + 36*q^9 + O(q^10),
         q + 123*q^2 + 124*q^3 + 2*q^4 + q^5 + 2*q^6 + 123*q^7 + 123*q^9 + O(q^10)],
         [q + 116*q^4 + 115*q^5 + 102*q^6 + 121*q^7 + 96*q^8 + 106*q^9 + O(q^10)]], 4)
@@ -491,12 +491,12 @@ def complementary_spaces(N, p, k0, n, mdash, elldashp, elldash, modformsring, bo
     EXAMPLES::
 
         sage: from sage.modular.overconvergent.hecke_series import complementary_spaces
-        sage: complementary_spaces(2, 5, 0, 3, 2, 5, 4, True, 6) # random
+        sage: complementary_spaces(2, 5, 0, 3, 2, 5, 4, True, 6)  # random              # needs sage.combinat
         [[1],
         [1 + 23*q + 24*q^2 + 19*q^3 + 7*q^4 + O(q^5)],
         [1 + 21*q + 2*q^2 + 17*q^3 + 14*q^4 + O(q^5)],
         [1 + 19*q + 9*q^2 + 11*q^3 + 9*q^4 + O(q^5)]]
-        sage: complementary_spaces(2, 5, 0, 3, 2, 5, 4, False, 6) # random
+        sage: complementary_spaces(2, 5, 0, 3, 2, 5, 4, False, 6)  # random             # needs sage.combinat
         [[1],
         [3 + 4*q + 2*q^2 + 12*q^3 + 11*q^4 + O(q^5)],
         [2 + 2*q + 14*q^2 + 19*q^3 + 18*q^4 + O(q^5)],
@@ -554,6 +554,7 @@ def higher_level_katz_exp(p, N, k0, m, mdash, elldash, elldashp, modformsring, b
 
     EXAMPLES::
 
+        sage: # needs sage.combinat
         sage: from sage.modular.overconvergent.hecke_series import higher_level_katz_exp
         sage: e, Ep1 = higher_level_katz_exp(5, 2, 0, 1, 2, 4, 20, True, 6)
         sage: e
@@ -700,6 +701,7 @@ def higher_level_UpGj(p, N, klist, m, modformsring, bound, extra_data=False):
 
     EXAMPLES::
 
+        sage: # needs sage.combinat
         sage: from sage.modular.overconvergent.hecke_series import higher_level_UpGj
         sage: A = Matrix([
         ....:     [1,  0,  0,  0,  0,  0],

--- a/src/sage/modular/pollack_stevens/fund_domain.py
+++ b/src/sage/modular/pollack_stevens/fund_domain.py
@@ -1523,6 +1523,7 @@ class ManinRelations(PollackStevensModularDomain):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()

--- a/src/sage/modular/pollack_stevens/manin_map.py
+++ b/src/sage/modular/pollack_stevens/manin_map.py
@@ -11,6 +11,7 @@ provides basic arithmetic and right action of matrices.
 
 EXAMPLES::
 
+    sage: # needs eclib
     sage: E = EllipticCurve('11a')
     sage: phi = E.pollack_stevens_modular_symbol()
     sage: phi
@@ -777,6 +778,7 @@ class ManinMap:
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -829,6 +831,7 @@ class ManinMap:
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: f = phi._map

--- a/src/sage/modular/pollack_stevens/padic_lseries.py
+++ b/src/sage/modular/pollack_stevens/padic_lseries.py
@@ -58,6 +58,7 @@ class pAdicLseries(SageObject):
 
     ::
 
+        sage: # needs eclib
         sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
         sage: E = EllipticCurve('20a')
         sage: phi = E.pollack_stevens_modular_symbol()
@@ -93,6 +94,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('11a3')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -205,6 +207,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('21a4')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -237,6 +240,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -324,6 +328,7 @@ class pAdicLseries(SageObject):
 
         Comparing against a different implementation::
 
+            sage: # needs eclib
             sage: L = E.padic_lseries(3)
             sage: (1-1/L.alpha(prec=4))^2
             3^2 + 3^3 + O(3^5)

--- a/src/sage/modular/pollack_stevens/space.py
+++ b/src/sage/modular/pollack_stevens/space.py
@@ -49,6 +49,7 @@ classical modular symbols (or even elliptic curves) as follows::
 
 ::
 
+    sage: # needs eclib
     sage: E = EllipticCurve('37a1')
     sage: phi = E.pollack_stevens_modular_symbol(); phi
     Modular symbol of level 37 with values in Sym^0 Q^2
@@ -857,6 +858,7 @@ def ps_modsym_from_elliptic_curve(E, sign=0, implementation='eclib'):
 
     EXAMPLES::
 
+        sage: # needs eclib
         sage: E = EllipticCurve('113a1')
         sage: symb = E.pollack_stevens_modular_symbol() # indirect doctest
         sage: symb
@@ -972,6 +974,7 @@ def ps_modsym_from_simple_modsym_space(A, name='alpha'):
 
     A consistency check with :meth:`sage.modular.pollack_stevens.space.ps_modsym_from_simple_modsym_space`::
 
+        sage: # needs eclib
         sage: from sage.modular.pollack_stevens.space import ps_modsym_from_simple_modsym_space
         sage: E = EllipticCurve('11a')
         sage: f_E = E.pollack_stevens_modular_symbol(); f_E.values()
@@ -988,6 +991,7 @@ def ps_modsym_from_simple_modsym_space(A, name='alpha'):
     ``ps_modsym_from_simple_modsym_space`` is only well-defined up to a nonzero
     scalar::
 
+        sage: # needs eclib
         sage: (-1/5)*vector(QQ, f_plus.values()) + (1/2)*vector(QQ, f_minus.values())
         (-1/5, 1, 0)
         sage: vector(QQ, f_E.values())

--- a/src/sage/modular/quasimodform/element.py
+++ b/src/sage/modular/quasimodform/element.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
-# sage.doctest: needs sage.libs.flint
+# sage.doctest: needs sage.combinat sage.libs.flint
 """
 Elements of quasimodular forms rings
 

--- a/src/sage/modular/quasimodform/ring.py
+++ b/src/sage/modular/quasimodform/ring.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
+# sage.doctest: needs sage.combinat
 r"""
 Graded quasimodular forms ring
 

--- a/src/sage/rings/function_field/jacobian_hess.py
+++ b/src/sage/rings/function_field/jacobian_hess.py
@@ -903,7 +903,7 @@ class JacobianGroup_finite_field(JacobianGroup, JacobianGroup_finite_field_base)
             sage: C = Curve(y^2 + x^3 + 2*x + 1).projective_closure()
             sage: J = C.jacobian(model='hess')
             sage: G = J.group()
-            sage: len([pt for pt in G])
+            sage: len([pt for pt in G])                                                 # needs sage.combinat
             11
         """
         g = self._parent._function_field.genus()
@@ -976,6 +976,8 @@ class JacobianGroup_finite_field(JacobianGroup, JacobianGroup_finite_field_base)
             11
             sage: K = k.extension(3)
             sage: G3 = J.group(K)
+
+            sage: # needs sage.combinat
             sage: pts1 = G1.get_points(11)
             sage: pts3 = G3.get_points(12)
             sage: pt = next(pt for pt in pts3 if pt not in pts1)

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -465,6 +465,8 @@ class WeilPolynomials():
         sage: ans1.sort()
         sage: l = [(x-1)^2, (x+1)^2] + [cyclotomic_polynomial(n,x)
         ....:     for n in range(3, 2*d*d) if euler_phi(n) <= d]
+
+        sage: # needs sage.combinat
         sage: w = WeightedIntegerVectors(d, [i.degree() for i in l])
         sage: ans2 = [prod(l[i]^v[i] for i in range(len(l))) for v in w]
         sage: ans2.sort()

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -294,6 +294,7 @@ that algebraic number if you type the string into Sage. We can see
 that until exact computation is triggered, an algebraic number keeps
 track of the computation steps used to produce that number::
 
+    sage: # needs sage.symbolic
     sage: rt2 = AA(sqrt(2))
     sage: rt3 = AA(sqrt(3))
     sage: n = (rt2 + rt3)^5; n
@@ -307,6 +308,7 @@ track of the computation steps used to produce that number::
 But once exact computation is triggered, the computation tree is discarded,
 and we get a way to produce the number directly::
 
+    sage: # needs sage.symbolic
     sage: n == 109*rt2 + 89*rt3
     True
     sage: sage_input(n)
@@ -2831,6 +2833,7 @@ def number_field_elements_from_algebraics(numbers, minimal=False,
 
     Test ``embedded`` for quadratic and cyclotomic fields::
 
+        sage: # needs sage.symbolic
         sage: v = number_field_elements_from_algebraics([QQbar((-1)^(2/3))], embedded=False, minimal=True); v
         (Number Field in zeta6 with defining polynomial x^2 - x + 1,
          [zeta6 - 1],
@@ -2909,6 +2912,7 @@ def number_field_elements_from_algebraics(numbers, minimal=False,
 
     Test that the semantic of ``AA`` constructor does not affect this function (:issue:`36735`)::
 
+        sage: # needs sage.symbolic
         sage: AA((-1)^(2/3))
         1
         sage: number_field_elements_from_algebraics([(-1)^(2/3)])
@@ -4569,16 +4573,17 @@ class AlgebraicNumber_base(sage.structure.element.FieldElement):
 
         EXAMPLES::
 
-            sage: QQbar(sqrt(-23)).is_integral()
+            sage: QQbar(sqrt(-23)).is_integral()                                        # needs sage.symbolic
             True
-            sage: AA(sqrt(23/2)).is_integral()
+            sage: AA(sqrt(23/2)).is_integral()                                          # needs sage.symbolic
             False
 
         TESTS:
 
         Method should return the same value as :meth:`NumberFieldElement.is_integral`::
 
-             sage: for a in [QQbar(2^(1/3)), AA(2^(1/3)), QQbar(sqrt(1/2)), AA(1/2), AA(2), QQbar(1/2)]:
+             sage: for a in [QQbar(2^(1/3)), AA(2^(1/3)), QQbar(sqrt(1/2)),             # needs sage.symbolic
+             ....:           AA(1/2), AA(2), QQbar(1/2)]:
              ....:    assert a.as_number_field_element()[1].is_integral() == a.is_integral()
         """
         return all(a in ZZ for a in self.minpoly())

--- a/src/sage/rings/valuation/valuation.py
+++ b/src/sage/rings/valuation/valuation.py
@@ -614,7 +614,7 @@ class DiscreteValuation(DiscretePseudoValuation):
             sage: Delta = (x^12 + 20*x^11 + 154*x^10 + 664*x^9 + 1873*x^8 + 3808*x^7 + 5980*x^6
             ....:           + 7560*x^5 + 7799*x^4 + 6508*x^3 + 4290*x^2 + 2224*x + 887)
             sage: K.<theta> = NumberField(x^6 + 108)
-            sage: K.is_galois()
+            sage: K.is_galois()                                                         # needs sage.groups
             True
             sage: vK = QQ.valuation(2).extension(K)
             sage: vK(2)

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -1796,6 +1796,7 @@ class ProjectivePlaneCurve_field(ProjectivePlaneCurve, ProjectiveCurve_field):
 
         TESTS::
 
+            sage: # needs sage.combinat
             sage: F.<x0, x1> = FreeGroup()
             sage: G = F / [x1^-1*(x1^-1*x0^-1*x1*x0^-1)^2, (x1^-1*x0^-1)^2*x1^-1*(x0*x1)^2*x0]
             sage: G.order()
@@ -1903,7 +1904,7 @@ class ProjectivePlaneCurve_field(ProjectivePlaneCurve, ProjectiveCurve_field):
 
             sage: R.<x,y,z> = QQ[]
             sage: C = Curve(x^3 + 3*y^3 + 5*z^3)
-            sage: C.riemann_surface()
+            sage: C.riemann_surface()                                                   # needs sage.graphs
             Riemann surface defined by polynomial f = x^3 + 3*y^3 + 5 = 0,
             with 53 bits of precision
         """

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1237,7 +1237,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         normalized::
 
             sage: E = EllipticCurve('11a2')
-            sage: E.modular_symbol(implementation='eclib')(0)
+            sage: E.modular_symbol(implementation='eclib')(0)                           # needs eclib
             1
             sage: E.modular_symbol(implementation='sage', normalize='L_ratio')(0)   # needs sage.graphs
             1
@@ -1494,7 +1494,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             2
             sage: E.analytic_rank(algorithm='zero_sum')                                 # needs sage.symbolic
             2
-            sage: E.analytic_rank(algorithm='all')
+            sage: E.analytic_rank(algorithm='all')              # needs lcalc
             2
 
         With the optional parameter leading_coefficient set to ``True``,
@@ -1681,7 +1681,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E.analytic_rank_upper_bound(max_Delta=1, adaptive=False)              # needs sage.symbolic
             0
             sage: E = EllipticCurve([-39,123])
-            sage: E.rank()
+            sage: E.rank()                                                              # needs eclib
             1
             sage: E.analytic_rank_upper_bound(max_Delta=1, adaptive=True)
             1
@@ -2342,9 +2342,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             2
             sage: E.saturation(E.gens())[1]                             # needs eclib
             1
-            sage: len(E.gens(algorithm='pari'))
+            sage: len(E.gens(algorithm='pari'))                         # needs eclib
             2
-            sage: E.saturation(E.gens(algorithm='pari'))[1]
+            sage: E.saturation(E.gens(algorithm='pari'))[1]             # needs eclib
             1
             sage: E = EllipticCurve([-3/8,-2/3])
             sage: P = E.lift_x(10/9)
@@ -6073,7 +6073,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         ::
 
             sage: E = EllipticCurve([0,0,1,-7,6])
-            sage: a = E.integral_points(both_signs=True); a
+            sage: a = E.integral_points(both_signs=True); a                             # needs eclib
             [(-3 : -1 : 1), (-3 : 0 : 1), (-2 : -4 : 1), (-2 : 3 : 1), (-1 : -4 : 1),
              (-1 : 3 : 1), (0 : -3 : 1), (0 : 2 : 1), (1 : -1 : 1), (1 : 0 : 1),
              (2 : -1 : 1), (2 : 0 : 1), (3 : -4 : 1), (3 : 3 : 1), (4 : -7 : 1),
@@ -6535,8 +6535,8 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: a = E.S_integral_points([2,3])
-            sage: len(a)
+            sage: a = E.S_integral_points([2,3])                                            # needs eclib
+            sage: len(a)                                                                    # needs eclib
             43
 
         An example with negative discriminant::

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1250,7 +1250,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         while the non-normalized symbol is incorrect::
 
             sage: E = EllipticCurve('11a3')
-            sage: E.modular_symbol(implementation='eclib')(0)
+            sage: E.modular_symbol(implementation='eclib')(0)                       # needs eclib
             1/25
             sage: E.modular_symbol(implementation='sage', normalize='none')(0)      # needs sage.graphs
             1
@@ -1492,7 +1492,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             2
             sage: E.analytic_rank(algorithm='magma')    # optional - magma
             2
-            sage: E.analytic_rank(algorithm='zero_sum')
+            sage: E.analytic_rank(algorithm='zero_sum')                                 # needs sage.symbolic
             2
             sage: E.analytic_rank(algorithm='all')
             2
@@ -1678,7 +1678,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve("11a")
             sage: E.rank()
             0
-            sage: E.analytic_rank_upper_bound(max_Delta=1, adaptive=False)
+            sage: E.analytic_rank_upper_bound(max_Delta=1, adaptive=False)              # needs sage.symbolic
             0
             sage: E = EllipticCurve([-39,123])
             sage: E.rank()
@@ -2099,7 +2099,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         An example to check if the points are saturated::
 
             sage: E = EllipticCurve([0,0, 1, -7, 6])
-            sage: E.gens(use_database=False, algorithm='pari') # random
+            sage: E.gens(use_database=False, algorithm='pari')  # random    # needs eclib
             [(2 : 0 : 1), (-1 : 3 : 1), (11 : 35 : 1)]
             sage: E.saturation(_)[1]
             1
@@ -2332,7 +2332,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
              over Rational Field
             sage: E1.gens()  # random (if database not used)            # needs eclib
             [(-400 : 8000 : 1), (0 : -8000 : 1)]
-            sage: E1.gens(algorithm='pari')   #random
+            sage: E1.gens(algorithm='pari')   # random                  # needs eclib
             [(-400 : 8000 : 1), (0 : -8000 : 1)]
 
         TESTS::
@@ -2408,8 +2408,8 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         TESTS::
 
             sage: P = E.lift_x(611429153205013185025/9492121848205441)
-            sage: ge = set(E.gens(use_database=False, algorithm='pari',pari_effort=4))
-            sage: ge <= set([P+T for T in E.torsion_points()]
+            sage: ge = set(E.gens(use_database=False, algorithm='pari', pari_effort=4))     # needs eclib
+            sage: ge <= set([P+T for T in E.torsion_points()]                               # needs eclib
             ....:        + [-P+T for T in E.torsion_points()])
             True
         """
@@ -3627,7 +3627,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('389a')
-            sage: E.Lambda(1.4 + 0.5*I, 50)
+            sage: E.Lambda(1.4 + 0.5*I, 50)                                             # needs sage.symbolic
             -0.354172680517... + 0.874518681720...*I
         """
         from sage.symbolic.constants import pi
@@ -3914,13 +3914,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, -1, 0, -79, 289])
             sage: factor(E.conductor())  # conductor is 234446
             2 * 117223
-            sage: factor(E.modular_degree())
+            sage: factor(E.modular_degree())                                         # needs sympow
             2^7 * 2617
 
         Higher level cases::
 
             sage: E = EllipticCurve('11a')
-            sage: for M in range(1,11): print(E.modular_degree(M=M)) # long time (20s on 2009 MBP)
+            sage: for M in range(1,11): print(E.modular_degree(M=M)) # long time (20s on 2009 MBP), needs sympow
             1
             1
             3
@@ -6044,7 +6044,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
             sage: E = EllipticCurve([0,0,1,-7,6])
             sage: P1 = E.point((2,0)); P2 = E.point((-1,3)); P3 = E.point((4,6))
-            sage: a = E.integral_points([P1,P2,P3]); a
+            sage: a = E.integral_points([P1,P2,P3]); a                                  # needs sage.symbolic
             [(-3 : -1 : 1), (-2 : -4 : 1), (-1 : -4 : 1), (0 : -3 : 1),
              (1 : -1 : 1), (2 : -1 : 1), (3 : -4 : 1), (4 : -7 : 1),
              (8 : -22 : 1), (11 : -36 : 1), (14 : -52 : 1), (21 : -96 : 1),
@@ -6053,7 +6053,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: a = E.integral_points([P1,P2,P3], verbose=True)
+            sage: a = E.integral_points([P1,P2,P3], verbose=True)                       # needs sage.symbolic
             Using mw_basis  [(2 : 0 : 1), (3 : -4 : 1), (8 : -22 : 1)]
             e1,e2,e3:  -3.0124303725933... 1.0658205476962... 1.94660982489710
             Minimal and maximal eigenvalues of height pairing matrix: 0.637920814585005,2.31982967525725
@@ -6459,7 +6459,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: P1 = E.point((2,0))
             sage: P2 = E.point((-1,3))
             sage: P3 = E.point((4,6))
-            sage: a = E.S_integral_points(S=[2,3], mw_base=[P1,P2,P3], verbose=True); a
+            sage: a = E.S_integral_points(S=[2,3], mw_base=[P1,P2,P3], verbose=True); a     # needs sage.symbolic
             max_S: 3 len_S: 3 len_tors: 1
             lambda 0.485997517468...
             k1,k2,k3,k4 7.65200453902598e234 1.31952866480763 3.54035317966420e9 2.42767548272846e17

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -935,7 +935,7 @@ class Lseries_ell(SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve("5077a")
-            sage: E.lseries().zero_sums()
+            sage: E.lseries().zero_sums()                                               # needs sage.symbolic
             Zero sum estimator for L-function attached to
              Elliptic Curve defined by y^2 + y = x^3 - 7*x + 6 over Rational Field
         """

--- a/src/sage/schemes/elliptic_curves/padic_lseries.py
+++ b/src/sage/schemes/elliptic_curves/padic_lseries.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-schemes
-# sage.doctest: needs sage.rings.padics
+# sage.doctest: needs eclib sage.rings.padics
 r"""
 `p`-adic `L`-functions of elliptic curves
 


### PR DESCRIPTION
- **src/sage/rings: Add # needs**
- **src/sage/schemes: Add # needs**
- **src/sage/all__sagemath_polyhedra.py: Override RR import**
- **./sage --fixdoctests --distribution 'sagemath-schemes*' --update-known-test-failures**
- **src/sage/arith/misc.py: Add # needs**
- **src/sage/geometry: Add # needs**
- **src/sage/libs/singular: Add # needs**
- **src/sage/matrix/matrix2.pyx: Add # needs**
- **src/sage/modular: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/schemes/elliptic_curves/ell_rational_field.py: Add # needs**
