### PR TITLE
build/pkgs/boost_cropped/distros/debian.txt: Add libboost-regex-dev

### DIFF
--- a/build/pkgs/boost_cropped/distros/debian.txt
+++ b/build/pkgs/boost_cropped/distros/debian.txt
@@ -1,1 +1,2 @@
 libboost-dev
+libboost-regex-dev


### PR DESCRIPTION
- Fixes #530