### PR TITLE
src/sage/libs/braiding.pyx: Use std=c++11

### DIFF
--- a/src/sage/libs/braiding.pyx
+++ b/src/sage/libs/braiding.pyx
@@ -1,6 +1,7 @@
 # sage_setup: distribution = sagemath-libbraiding
 # distutils: libraries = braiding
 # distutils: language = c++
+# distutils: extra_compile_args = -std=c++11
 r"""
 Cython wrapper for the libbraiding library.
 


### PR DESCRIPTION
- Fixes #533