### PR TITLE
pkgs/sagemath-flint: Modularization fixes (pari)

### DIFF
--- a/src/sage/functions/gamma.py
+++ b/src/sage/functions/gamma.py
@@ -458,9 +458,9 @@ class Function_gamma_inc(BuiltinFunction):
 
         Check that :issue:`17130` is fixed::
 
-            sage: r = gamma_inc(float(0), float(1)); r                                  # needs sage.rings.real_mpfr
+            sage: r = gamma_inc(float(0), float(1)); r                                  # needs sage.libs.pari sage.rings.real_mpfr
             0.21938393439552029
-            sage: type(r)                                                               # needs sage.rings.real_mpfr
+            sage: type(r)                                                               # needs sage.libs.pari sage.rings.real_mpfr
             <... 'float'>
         """
         R = parent or s_parent(x)

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -4161,7 +4161,7 @@ cdef class Matrix(sage.structure.element.Matrix):
             sage: A = matrix(QQbar, [[-I, 2+I], [-2+I, 0]])                             # needs sage.rings.number_field
             sage: A._is_hermitian(skew=False, tolerance=0)                              # needs sage.rings.number_field
             False
-            sage: A._is_hermitian(skew=True, tolerance=0)
+            sage: A._is_hermitian(skew=True, tolerance=0)                               # needs sage.libs.pari
             True
         """
         key = ("_is_hermitian", skew, tolerance)

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -15328,8 +15328,8 @@ cdef class Matrix(Matrix1):
         EXAMPLES::
 
             sage: A = Matrix([[1,-1/2,0], [-1/2,1,-1/2], [0,-1/2,1]])
-            sage: B = A.principal_square_root()
-            sage: A == B^2
+            sage: B = A.principal_square_root()                                         # needs libs.pari
+            sage: A == B^2                                                              # needs libs.pari
             True
         """
         from sage.matrix.special import diagonal_matrix

--- a/src/sage/modular/modform/eis_series_cython.pyx
+++ b/src/sage/modular/modform/eis_series_cython.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 """
 Eisenstein series, optimized
 """

--- a/src/sage/quadratic_forms/binary_qf.py
+++ b/src/sage/quadratic_forms/binary_qf.py
@@ -929,12 +929,12 @@ class BinaryQF(SageObject):
             sage: g = f.reduced_form(algorithm=a)
             sage: g.is_reduced()
             True
-            sage: g.is_equivalent(f)
+            sage: g.is_equivalent(f)                                                    # needs sage.libs.pari
             True
             sage: g,M = f.reduced_form(transformation=True, algorithm=a)
             sage: g.is_reduced()
             True
-            sage: g.is_equivalent(f)
+            sage: g.is_equivalent(f)                                                    # needs sage.libs.pari
             True
             sage: f * M == g
             True

--- a/src/sage/rings/bernoulli_mod_p.pyx
+++ b/src/sage/rings/bernoulli_mod_p.pyx
@@ -5,6 +5,7 @@
 # distutils: library_dirs = NTL_LIBDIR
 # distutils: extra_link_args = NTL_LIBEXTRA
 # distutils: language = c++
+# sage.doctest: needs sage.libs.pari
 r"""
 Bernoulli numbers modulo p
 

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -128,7 +128,7 @@ Check that :issue:`19839` is fixed::
 
 :issue:`24621`::
 
-    sage: CBF(NumberField(polygen(QQ, 'y')^3 + 20, 'a', embedding=CC(1.35,2.35)).gen())
+    sage: CBF(NumberField(polygen(QQ, 'y')^3 + 20, 'a', embedding=CC(1.35,2.35)).gen())     # needs sage.rings.number_field
     [1.35720880829745...] + [2.35075461245119...]*I
 
 Classes and Methods
@@ -533,9 +533,9 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
             True
             sage: CBF.has_coerce_map_from(RealBallField(52))
             False
-            sage: CBF.has_coerce_map_from(QuadraticField(-2))
+            sage: CBF.has_coerce_map_from(QuadraticField(-2))                               # needs sage.rings.number_field
             True
-            sage: CBF.has_coerce_map_from(QuadraticField(2, embedding=None))
+            sage: CBF.has_coerce_map_from(QuadraticField(2, embedding=None))                # needs sage.rings.number_field
             False
 
         Check that there are no coercions from interval or floating-point parents::
@@ -551,6 +551,7 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
 
         Check that the map goes through the ``_acb_`` method::
 
+            sage: # needs sage.rings.number_field
             sage: CBF.coerce_map_from(QuadraticField(-2, embedding=AA(-2).sqrt()))
             Conversion via _acb_ method map:
             ...
@@ -606,9 +607,9 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
             1.000000000000000*I
             sage: CBF(pi + I/3)                                                         # needs sage.symbolic
             [3.141592653589793 +/- ...e-16] + [0.3333333333333333 +/- ...e-17]*I
-            sage: CBF(QQbar(i/7)) # abs tol 1e-16
+            sage: CBF(QQbar(i/7))  # abs tol 1e-16                                      # needs sage.rings.number_field
             [0.1428571428571429 +/- 4.29e-17]*I
-            sage: CBF(AA(sqrt(2)))                                                      # needs sage.symbolic
+            sage: CBF(AA(sqrt(2)))                                                      # needs sage.rings.number_field sage.symbolic
             [1.414213562373095 +/- ...e-16]
             sage: CBF(CIF(0, 1))
             1.000000000000000*I
@@ -622,8 +623,8 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
             [0.3333333333333333 +/- ...e-17] + [0.1666666666666667 +/- ...e-17]*I
             sage: ComplexBallField(106)(1/3, 1/6)
             [0.33333333333333333333333333333333 +/- ...e-33] + [0.16666666666666666666666666666666 +/- ...e-33]*I
-            sage: NF.<a> = QuadraticField(-2)
-            sage: CBF(1/5 + a/2)
+            sage: NF.<a> = QuadraticField(-2)                                           # needs sage.rings.number_field
+            sage: CBF(1/5 + a/2)                                                        # needs sage.rings.number_field
             [0.2000000000000000 +/- ...e-17] + [0.707106781186547 +/- ...e-16]*I
             sage: CBF(infinity, NaN)                                                    # needs sage.symbolic
             [+/- inf] + nan*I
@@ -1104,6 +1105,7 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
         We can integrate the real absolute value function by defining a
         piecewise holomorphic extension::
 
+            sage: # needs sage.symbolic
             sage: def real_abs(z, analytic):
             ....:     if z.real().contains_zero():
             ....:         if analytic:
@@ -1375,20 +1377,20 @@ cdef class ComplexBall(RingElement):
             sage: ComplexBall(CBF100, 10^100)
             [1.000000000000000000000000000000e+100 +/- ...]
 
-            sage: NF.<a> = QuadraticField(-1, embedding=CC(0, -1))
-            sage: CBF(a)
+            sage: NF.<a> = QuadraticField(-1, embedding=CC(0, -1))                      # needs sage.rings.number_field
+            sage: CBF(a)                                                                # needs sage.rings.number_field
             -1.000000000000000*I
 
-            sage: NF.<a> = QuadraticField(-1, embedding=None)
-            sage: CBF(a)
+            sage: NF.<a> = QuadraticField(-1, embedding=None)                           # needs sage.rings.number_field
+            sage: CBF(a)                                                                # needs sage.rings.number_field
             1.000000000000000*I
             sage: CBF.coerce(a)
             Traceback (most recent call last):
             ...
             TypeError: no canonical coercion ...
 
-            sage: NF.<a> = QuadraticField(-2)
-            sage: CBF(1/3 + a).real()
+            sage: NF.<a> = QuadraticField(-2)                                           # needs sage.rings.number_field
+            sage: CBF(1/3 + a).real()                                                   # needs sage.rings.number_field
             [0.3333333333333333 +/- ...e-17]
 
             sage: ComplexBall(CBF, 1, 1/2)

--- a/src/sage/rings/complex_double.pyx
+++ b/src/sage/rings/complex_double.pyx
@@ -2293,7 +2293,7 @@ cdef class ComplexDoubleElement(FieldElement):
             -0.3715916523517613 + 0.31989466020683*I
             sage: a.agm(b, algorithm='principal')  # rel tol 1e-15
             0.33817546298618006 - 0.013532696956540503*I
-            sage: a.agm(b, algorithm='pari')
+            sage: a.agm(b, algorithm='pari')                                            # needs sage.libs.pari
             -0.37159165235176134 + 0.31989466020683005*I
 
         Some degenerate cases::

--- a/src/sage/rings/complex_interval_field.py
+++ b/src/sage/rings/complex_interval_field.py
@@ -440,8 +440,8 @@ class ComplexIntervalField_class(sage.rings.abc.ComplexIntervalField):
             sage: QQi.<i> = QuadraticField(-1)
             sage: CIF(i)
             1*I
-            sage: QQi.<i> = QuadraticField(-1, embedding=CC(0,-1))
-            sage: CIF(i)
+            sage: QQi.<i> = QuadraticField(-1, embedding=CC(0,-1))                      # needs sage.libs.pari
+            sage: CIF(i)                                                                # needs sage.libs.pari
             -1*I
             sage: QQi.<i> = QuadraticField(-1, embedding=None)
             sage: CIF(i)

--- a/src/sage/rings/fraction_field_FpT.pyx
+++ b/src/sage/rings/fraction_field_FpT.pyx
@@ -1062,6 +1062,7 @@ cdef class Polyring_FpT_coerce(RingHomomorphism):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<t> = GF(next_prime(2000))[]
             sage: K = R.fraction_field() # indirect doctest
         """
@@ -1262,6 +1263,7 @@ cdef class FpT_Polyring_section(Section):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<t> = GF(next_prime(2000))[]
             sage: K = R.fraction_field()
             sage: R(K.gen(0)) # indirect doctest
@@ -1378,6 +1380,7 @@ cdef class Fp_FpT_coerce(RingHomomorphism):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<t> = GF(next_prime(3000))[]
             sage: K = R.fraction_field() # indirect doctest
         """
@@ -1562,6 +1565,7 @@ cdef class FpT_Fp_section(Section):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<t> = GF(next_prime(2000))[]
             sage: K = R.fraction_field()
             sage: GF(next_prime(2000))(K(127)) # indirect doctest
@@ -1697,6 +1701,7 @@ cdef class ZZ_FpT_coerce(RingHomomorphism):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<t> = GF(next_prime(3000))[]
             sage: K = R.fraction_field() # indirect doctest
         """

--- a/src/sage/rings/fraction_field_element.pyx
+++ b/src/sage/rings/fraction_field_element.pyx
@@ -411,7 +411,7 @@ cdef class FractionFieldElement(FieldElement):
             sage: R.<x,y,z> = QQbar[]                                                   # needs sage.rings.number_field
             sage: hash(R.0) == hash(FractionField(R).0)
             True
-            sage: ((x+1)/(x^2+1)).subs({x: 1})
+            sage: ((x+1)/(x^2+1)).subs({x: 1})                                          # needs sage.libs.pari
             1
         """
         if self._denominator.is_one():

--- a/src/sage/rings/number_field/all.py
+++ b/src/sage/rings/number_field/all.py
@@ -15,6 +15,6 @@ lazy_import('sage.rings.number_field.totallyreal_rel',
 lazy_import('sage.rings.number_field.totallyreal_rel',
             'enumerate_totallyreal_fields_rel')
 
-from sage.rings.number_field.unit_group import UnitGroup
+lazy_import('sage.rings.number_field.unit_group', 'UnitGroup')
 
 del lazy_import

--- a/src/sage/rings/number_field/class_group.py
+++ b/src/sage/rings/number_field/class_group.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.rings.number_field
 r"""
 Class groups of number fields
 

--- a/src/sage/rings/number_field/homset.py
+++ b/src/sage/rings/number_field/homset.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.rings.number_field
 """
 Sets of homomorphisms between number fields
 """

--- a/src/sage/rings/number_field/maps.py
+++ b/src/sage/rings/number_field/maps.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.rings.number_field
 r"""
 Structure maps for number fields
 

--- a/src/sage/rings/number_field/morphism.py
+++ b/src/sage/rings/number_field/morphism.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 r"""
 Morphisms between number fields
 

--- a/src/sage/rings/number_field/number_field_ideal_rel.py
+++ b/src/sage/rings/number_field/number_field_ideal_rel.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.rings.number_field
 r"""
 Ideals of relative number fields
 

--- a/src/sage/rings/number_field/number_field_rel.py
+++ b/src/sage/rings/number_field/number_field_rel.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.rings.number_field
 r"""
 Relative number fields
 

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -92,8 +92,6 @@ from .number_field_element_quadratic import OrderElement_quadratic
 
 from sage.rings.monomials import monomials
 
-from sage.libs.pari.all import pari
-
 
 def quadratic_order_class_number(disc):
     r"""
@@ -110,6 +108,8 @@ def quadratic_order_class_number(disc):
     ALGORITHM: Either :pari:`qfbclassno` or :pari:`quadclassunit`,
     depending on the size of the discriminant.
     """
+    from sage.libs.pari.all import pari
+
     # cutoffs from PARI documentation
     if disc < -10**25 or disc > 10**10:
         h = pari.quadclassunit(disc)[0]

--- a/src/sage/rings/number_field/selmer_group.py
+++ b/src/sage/rings/number_field/selmer_group.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 r"""
 `p`-Selmer groups of number fields
 

--- a/src/sage/rings/number_field/small_primes_of_degree_one.py
+++ b/src/sage/rings/number_field/small_primes_of_degree_one.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 r"""
 Small primes of degree one
 

--- a/src/sage/rings/number_field/splitting_field.py
+++ b/src/sage/rings/number_field/splitting_field.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 """
 Splitting fields of polynomials over number fields
 

--- a/src/sage/rings/number_field/totallyreal.pyx
+++ b/src/sage/rings/number_field/totallyreal.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 r"""
 Enumeration of primitive totally real fields
 

--- a/src/sage/rings/number_field/unit_group.py
+++ b/src/sage/rings/number_field/unit_group.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 r"""
 Units and `S`-unit groups of number fields
 

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -8148,7 +8148,7 @@ cdef class Polynomial(CommutativePolynomial):
         An example over RR, which illustrates that only the roots in RR are
         returned::
 
-            sage: # needs numpy sage.rings.real_mpfr
+            sage: # needs numpy sage.libs.pari sage.rings.real_mpfr
             sage: x = RR['x'].0
             sage: f = x^3 - 2
             sage: f.roots()
@@ -8165,7 +8165,7 @@ cdef class Polynomial(CommutativePolynomial):
             sage: # needs sage.rings.real_mpfr
             sage: x = CC['x'].0
             sage: f = x^3 - 2
-            sage: f.roots()                                                             # needs numpy
+            sage: f.roots()                                                             # needs numpy sage.libs.pari
             [(1.25992104989487, 1),
              (-0.62996052494743... - 1.09112363597172*I, 1),
              (-0.62996052494743... + 1.09112363597172*I, 1)]
@@ -9155,7 +9155,7 @@ cdef class Polynomial(CommutativePolynomial):
             Complex Double Field
 
             sage: x = polygen(RealField(200))                                           # needs sage.rings.real_mpfr
-            sage: (x^3 - 1).complex_roots()[0].parent()                                 # needs sage.rings.real_mpfr
+            sage: (x^3 - 1).complex_roots()[0].parent()                                 # needs sage.libs.pari sage.rings.real_mpfr
             Complex Field with 200 bits of precision
 
             sage: x = polygen(CDF)                                                      # needs sage.rings.complex_double
@@ -9163,7 +9163,7 @@ cdef class Polynomial(CommutativePolynomial):
             Complex Double Field
 
 
-            sage: # needs sage.rings.real_mpfr
+            sage: # needs sage.libs.pari sage.rings.real_mpfr
             sage: x = polygen(ComplexField(200))
             sage: (x^3 - 1).complex_roots()[0].parent()
             Complex Field with 200 bits of precision
@@ -9544,6 +9544,7 @@ cdef class Polynomial(CommutativePolynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: P.<x> = QQ[]
             sage: p1 = x^2
             sage: p1.is_lorentzian()
@@ -9572,6 +9573,7 @@ cdef class Polynomial(CommutativePolynomial):
 
         The method can give a reason for a polynomial failing to be Lorentzian::
 
+            sage: # needs sage.libs.pari
             sage: p = x^2 + 2*x
             sage: p.is_lorentzian(explain=True)
             (False, 'inhomogeneous')

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -183,6 +183,7 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
 
         Coercion from PARI polynomial::
 
+            sage: # needs sage.libs.pari
             sage: f = R([-1, 2, 5]); f
             5*x^2 + 2*x - 1
             sage: type(f)
@@ -1488,9 +1489,9 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
 
             sage: t = PolynomialRing(ZZ,"t").gen()
             sage: f = t^3 + 3*t - 17
-            sage: pari(f)
+            sage: pari(f)                                                               # needs sage.libs.pari
             t^3 + 3*t - 17
-            sage: f.__pari__(variable='y')
+            sage: f.__pari__(variable='y')                                              # needs sage.libs.pari
             y^3 + 3*y - 17
         """
         if variable is None:
@@ -1566,9 +1567,9 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
 
             sage: R.<x> = ZZ[]
             sage: f = (x^2-2)*(x^5-3)^2
-            sage: f._factor_pari()
+            sage: f._factor_pari()                                                      # needs sage.libs.pari
             (x^2 - 2) * (x^5 - 3)^2
-            sage: (1234567898765432123456789876543212345678987*f)._factor_pari()
+            sage: (1234567898765432123456789876543212345678987*f)._factor_pari()        # needs sage.libs.pari
             1234567898765432123456789876543212345678987 * (x^2 - 2) * (x^5 - 3)^2
         """
         return Polynomial.factor(self) # uses pari for integers over ZZ
@@ -1669,6 +1670,7 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = ZZ['x']
             sage: f = -3*x*(x-2)*(x-9) + x
             sage: f.factor_mod(3)
@@ -1678,7 +1680,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
             Traceback (most recent call last):
             ...
             ArithmeticError: factorization of 0 is not defined
-
             sage: f = 2 * x * (x - 2) * (x - 9)
             sage: f.factor_mod(7)
             (2) * x * (x + 5)^2

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -56,7 +56,6 @@ from sage.libs.ntl.ntl_ZZX cimport ntl_ZZX
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 
-from sage.libs.pari.all import pari, pari_gen
 from sage.structure.factorization import Factorization
 
 from sage.rings.fraction_field_element import FractionFieldElement
@@ -76,6 +75,11 @@ from sage.rings.real_mpfr cimport RealNumber
 from sage.rings.real_mpfi cimport RealIntervalFieldElement
 
 from sage.rings.polynomial.evaluation_flint cimport fmpz_poly_evaluation_mpfr, fmpz_poly_evaluation_mpfi
+
+try:
+    from sage.libs.pari.all import pari, pari_gen
+except ImportError:
+    pari_gen = ()
 
 
 cdef class Polynomial_integer_dense_flint(Polynomial):

--- a/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
@@ -124,6 +124,7 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
 
         Coercion from PARI polynomial::
 
+            sage: # needs sage.libs.pari
             sage: f = R([-1, 2, 5]); f
             5*x^2 + 2*x - 1
             sage: type(f)
@@ -856,7 +857,7 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
 
             sage: t = PolynomialRing(ZZ, "t", implementation='NTL').gen()
             sage: f = t^3 + 3*t - 17
-            sage: pari(f)
+            sage: pari(f)                                                               # needs sage.libs.pari
             t^3 + 3*t - 17
         """
         if variable is None:
@@ -918,7 +919,7 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
             x^2 + 6*x + 9
             sage: f.factor()
             (x + 3)^2
-            sage: f._factor_pari()
+            sage: f._factor_pari()                                                      # needs sage.libs.pari
             (x + 3)^2
         """
         return Polynomial.factor(self) # uses pari for integers over ZZ
@@ -1009,6 +1010,7 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = PolynomialRing(ZZ, 'x', implementation='NTL')
             sage: f = -3*x*(x-2)*(x-9) + x
             sage: f.factor_mod(3)
@@ -1018,7 +1020,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
             Traceback (most recent call last):
             ...
             ArithmeticError: factorization of 0 is not defined
-
             sage: f = 2*x*(x-2)*(x-9)
             sage: f.factor_mod(7)
             (2) * x * (x + 5)^2
@@ -1051,14 +1052,14 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
 
             sage: R.<x> = PolynomialRing(ZZ, implementation='NTL')
             sage: f = x^2 + 1
-            sage: f.factor_padic(5, 4)
+            sage: f.factor_padic(5, 4)                                                  # needs sage.rings.padics
             ((1 + O(5^4))*x + 2 + 5 + 2*5^2 + 5^3 + O(5^4))
             * ((1 + O(5^4))*x + 3 + 3*5 + 2*5^2 + 3*5^3 + O(5^4))
 
         A more difficult example::
 
             sage: f = 100 * (5*x + 1)^2 * (x + 5)^2
-            sage: f.factor_padic(5, 10)
+            sage: f.factor_padic(5, 10)                                                 # needs sage.rings.padics
             (4 + O(5^10)) * (5 + O(5^11))^2 * ((1 + O(5^10))*x + 5 + O(5^10))^2
             * ((5 + O(5^10))*x + 1 + O(5^10))^2
         """

--- a/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
@@ -5,6 +5,7 @@
 # distutils: library_dirs = NTL_LIBDIR
 # distutils: extra_link_args = NTL_LIBEXTRA
 # distutils: language = c++
+# sage.doctest: needs sage.libs.pari
 r"""
 Dense univariate polynomials over  `\ZZ/n\ZZ`, implemented using NTL
 
@@ -96,6 +97,7 @@ cdef class Polynomial_dense_mod_n(Polynomial):
 
     TESTS::
 
+        sage: # needs sage.libs.pari
         sage: f = Integers(5*2^100)['x'].random_element()
         sage: from sage.rings.polynomial.polynomial_modn_dense_ntl import Polynomial_dense_mod_n
         sage: isinstance(f, Polynomial_dense_mod_n)
@@ -170,7 +172,7 @@ cdef class Polynomial_dense_mod_n(Polynomial):
 
             sage: t = PolynomialRing(IntegerModRing(17), "t", implementation='NTL').gen()
             sage: f = t^3 + 3*t - 17
-            sage: pari(f)
+            sage: pari(f)                                                               # needs sage.libs.pari
             Mod(1, 17)*t^3 + Mod(3, 17)*t
         """
         if variable is None:
@@ -398,6 +400,7 @@ cdef class Polynomial_dense_mod_n(Polynomial):
 
         Random testing::
 
+            sage: # needs sage.libs.pari
             sage: p = random_prime(2^99)
             sage: R.<x> = PolynomialRing(GF(p), implementation='NTL')
             sage: d = randrange(1,50)
@@ -419,6 +422,7 @@ cdef class Polynomial_dense_mod_n(Polynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: N = 10001
             sage: K = Zmod(10001)
             sage: P.<x> = PolynomialRing(K, implementation='NTL')
@@ -442,6 +446,7 @@ cdef class Polynomial_dense_mod_n(Polynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<x> = GF(2**127 - 1)[]
             sage: f = R.random_element()
             sage: g = R.random_element()
@@ -500,6 +505,7 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
 
     First consider a small example::
 
+        sage: # needs sage.libs.pari
         sage: N = 10001
         sage: K = Zmod(10001)
         sage: P.<x> = PolynomialRing(K, implementation='NTL')
@@ -507,18 +513,18 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
 
     This polynomial has no roots without modular reduction (i.e. over `\ZZ`)::
 
-        sage: f.change_ring(ZZ).roots()
+        sage: f.change_ring(ZZ).roots()                                                 # needs sage.libs.pari
         []
 
     To compute its roots we need to factor the modulus `N` and use the Chinese
     remainder theorem::
 
+        sage: # needs sage.libs.pari
         sage: p, q = N.prime_divisors()
         sage: f.change_ring(GF(p)).roots()
         [(4, 1)]
         sage: f.change_ring(GF(q)).roots()
         [(4, 1)]
-
         sage: crt(4, 4, p, q)
         4
 
@@ -526,7 +532,7 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
     recover it without factoring `N` using Coppersmith's small root
     method::
 
-        sage: f.small_roots()                                                           # needs fpylll
+        sage: f.small_roots()                                                           # needs fpylll sage.libs.pari
         [4]
 
     An application of this method is to consider RSA. We are using 512-bit RSA
@@ -562,13 +568,13 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
 
     To recover `K` we consider the following polynomial modulo `N`::
 
-        sage: P.<x> = PolynomialRing(ZmodN, implementation='NTL')
-        sage: f = (2^Nbits - 2^Kbits + x)^e - C
+        sage: P.<x> = PolynomialRing(ZmodN, implementation='NTL')                       # needs sage.libs.pari
+        sage: f = (2^Nbits - 2^Kbits + x)^e - C                                         # needs sage.libs.pari
 
     and recover its small roots::
 
-        sage: Kbar = f.small_roots()[0]                                                 # needs fpylll
-        sage: K == Kbar                                                                 # needs fpylll
+        sage: Kbar = f.small_roots()[0]                                                 # needs fpylll sage.libs.pari
+        sage: K == Kbar                                                                 # needs fpylll sage.libs.pari
         True
 
     The same algorithm can be used to factor `N = pq` if partial
@@ -687,8 +693,8 @@ cdef class Polynomial_dense_modn_ntl_zz(Polynomial_dense_mod_n):
         EXAMPLES::
 
             sage: R = Integers(5**21)
-            sage: S.<x> = PolynomialRing(R, implementation='NTL')
-            sage: S(1/4)
+            sage: S.<x> = PolynomialRing(R, implementation='NTL')                       # needs sage.libs.pari
+            sage: S(1/4)                                                                # needs sage.libs.pari
             357627868652344
         """
         if isinstance(v, Polynomial):

--- a/src/sage/rings/polynomial/polynomial_number_field.pyx
+++ b/src/sage/rings/polynomial/polynomial_number_field.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.rings.number_field
 r"""
 Univariate polynomials over number fields
 

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -3356,7 +3356,7 @@ class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.ntl
+            sage: # needs sage.libs.ntl sage.libs.pari
             sage: R.<t> = GF(2)[]
             sage: k.<a> = R.residue_field(t^3 + t + 1); k
             Residue field in a
@@ -3380,7 +3380,7 @@ class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
 
         Non-maximal ideals are not accepted::
 
-            sage: # needs sage.libs.ntl
+            sage: # needs sage.libs.ntl sage.libs.pari
             sage: R.residue_field(t^2 + 1)
             Traceback (most recent call last):
             ...

--- a/src/sage/rings/polynomial/polynomial_template.pxi
+++ b/src/sage/rings/polynomial/polynomial_template.pxi
@@ -21,7 +21,11 @@ from sage.structure.element import coerce_binop
 from sage.structure.richcmp cimport rich_to_bool
 from sage.rings.fraction_field_element import FractionFieldElement
 from sage.rings.integer cimport Integer
-from sage.libs.pari.all import pari_gen
+
+try:
+    from sage.libs.pari.all import pari_gen
+except ImportError:
+    pari_gen = ()
 
 import operator
 

--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -91,8 +91,8 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
         """
         EXAMPLES::
 
-            sage: P.<x> = GF(32003)[]
-            sage: f = 24998*x^2 + 29761*x + 2252
+            sage: P.<x> = GF(32003)[]                                                   # needs sage.rings.finite_rings
+            sage: f = 24998*x^2 + 29761*x + 2252                                        # needs sage.rings.finite_rings
         """
         cdef long nlen
 
@@ -249,6 +249,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: P.<x> = GF(32003)[]
             sage: f = 24998*x^2 + 29761*x + 2252
             sage: f[100]
@@ -370,6 +371,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: N = 10001
             sage: K = Zmod(10001)
             sage: P.<x> = PolynomialRing(K)
@@ -810,6 +812,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         Test that factorization can be interrupted::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<x> = PolynomialRing(GF(65537), implementation="FLINT")
             sage: f = R.random_element(9973) * R.random_element(10007)
             sage: alarm(0.5); f.factor()
@@ -819,6 +822,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         Test zero polynomial::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<x> = PolynomialRing(GF(65537), implementation="FLINT")
             sage: R.zero().factor()
             Traceback (most recent call last):

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -463,10 +463,10 @@ class WeilPolynomials():
         sage: d = 6
         sage: ans1 = list(WeilPolynomials(d, 1, 1))
         sage: ans1.sort()
-        sage: l = [(x-1)^2, (x+1)^2] + [cyclotomic_polynomial(n,x)
+        sage: l = [(x-1)^2, (x+1)^2] + [cyclotomic_polynomial(n,x)                      # needs sage.libs.pari
         ....:     for n in range(3, 2*d*d) if euler_phi(n) <= d]
 
-        sage: # needs sage.combinat
+        sage: # needs sage.combinat sage.libs.pari
         sage: w = WeightedIntegerVectors(d, [i.degree() for i in l])
         sage: ans2 = [prod(l[i]^v[i] for i in range(len(l))) for v in w]
         sage: ans2.sort()

--- a/src/sage/rings/power_series_poly.pyx
+++ b/src/sage/rings/power_series_poly.pyx
@@ -1081,7 +1081,7 @@ cdef class PowerSeries_poly(PowerSeries):
             f2 = f.__pari__()
             g = f2.serreverse()
             return PowerSeries_poly(f.parent(), g.Vec(-out_prec), out_prec)
-        except (TypeError, ValueError, AttributeError, PariError, ImportError):
+        except (TypeError, ValueError, AttributeError, PariError, ImportError, NameError):
             # if pari fails, continue with Lagrange inversion
             from sage.misc.verbose import verbose
             verbose("passing to pari failed; trying Lagrange inversion")

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -3618,7 +3618,7 @@ cdef class RealIntervalFieldElement(RingElement):
             sage: RIF(1/3, 1/2).simplest_rational(high_open=True)
             1/3
             sage: phi = ((RealIntervalField(500)(5).sqrt() + 1)/2)
-            sage: phi.simplest_rational() == fibonacci(362)/fibonacci(361)
+            sage: phi.simplest_rational() == fibonacci(362)/fibonacci(361)              # needs sage.libs.pari
             True
         """
         if mpfr_equal_p(&self.value.left, &self.value.right):

--- a/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
+++ b/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-flint
-# sage.doctest: needs sage.libs.ntl
+# sage.doctest: needs sage.libs.ntl sage.libs.pari
 r"""
 Descent on elliptic curves over `\QQ` with a 2-isogeny
 """

--- a/src/sage/schemes/projective/projective_point.py
+++ b/src/sage/schemes/projective/projective_point.py
@@ -292,7 +292,7 @@ class SchemeMorphism_point_projective_ring(SchemeMorphism_point):
 
         Check that :issue:`17429` is fixed::
 
-            sage: # needs sage.rings.complex_interval_field
+            sage: # needs sage.libs.pari sage.rings.complex_interval_field
             sage: R.<x> = PolynomialRing(QQ)
             sage: r = (x^2 - x - 3).polynomial(x).roots(ComplexIntervalField(),
             ....:                                       multiplicities=False)


### PR DESCRIPTION
- **src/sage/functions/gamma.py: Add # needs**
- **src/sage/matrix: Add # needs**
- **src/sage/modular/modform/eis_series_cython.pyx: Add # needs**
- **src/sage/quadratic_forms/binary_qf.py: Add # needs**
- **src/sage/rings/number_field/all.py: Use lazy_import**
- **src/sage/rings/number_field/order.py: Modularize pari import**
- **src/sage/rings/number_field: Add # needs**
- **src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx: Add # needs**
- **src/sage/schemes/projective/projective_point.py: Add # needs**
- **src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx: Modularize pari imports**
- **src/sage/rings/polynomial: Add # needs**
- **src/sage/rings/bernoulli_mod_p.pyx: Add # needs**
- **src/sage/rings/power_series_poly.pyx: Catch another exception when pari is not present**
- **src/sage/rings: Add # needs**
