### PR TITLE
`sage.matrix.matrix_{integer,rational}_*` modularization 

### DIFF
--- a/pkgs/sagemath-flint/MANIFEST.in
+++ b/pkgs/sagemath-flint/MANIFEST.in
@@ -7,10 +7,13 @@ graft             sage/libs/flint
 graft             sage/libs/linkages
 include           sage/libs/pari/convert_flint.p*
 recursive-include sage/libs/ntl *.pxi *.h                                       # FIXME
+include           sage/matrix/change_ring.p*
 include           sage/matrix/matrix_complex_ball_dense.p*
 include           sage/matrix/misc_flint.p*
 include           sage/matrix/matrix_cyclo_dense.p*
 include           sage/matrix/matrix_integer_dense.p*
+include           sage/matrix/matrix_integer_dense_hnf.p*
+include           sage/matrix/matrix_integer_dense_saturation.p*
 include           sage/matrix/matrix_integer_sparse.p*
 include           sage/matrix/matrix_rational_dense.p*
 include           sage/matrix/matrix_rational_sparse.p*

--- a/pkgs/sagemath-flint/MANIFEST.in
+++ b/pkgs/sagemath-flint/MANIFEST.in
@@ -10,8 +10,11 @@ recursive-include sage/libs/ntl *.pxi *.h                                       
 include           sage/matrix/matrix_complex_ball_dense.p*
 include           sage/matrix/misc_flint.p*
 include           sage/matrix/matrix_cyclo_dense.p*
-include           sage/matrix/matrix_integer*.pxd
-include           sage/matrix/matrix_rational*.pxd
+include           sage/matrix/matrix_integer_dense.p*
+include           sage/matrix/matrix_integer_sparse.p*
+include           sage/matrix/matrix_rational_dense.p*
+include           sage/matrix/matrix_rational_sparse.p*
+include           sage/matrix/matrix_*_pari.p*      # FIXME
 include           sage/rings/*_arb.p*
 include           sage/rings/*_flint.p*
 include           sage/rings/padics/*_flint*.p*

--- a/pkgs/sagemath-linbox/MANIFEST.in
+++ b/pkgs/sagemath-linbox/MANIFEST.in
@@ -7,6 +7,7 @@ graft   sage/libs/linbox
 recursive-include sage/libs/ntl *.pxd *.pxi *.h                                 # FIXME
 include sage/matrix/matrix_integer_dense*.p*
 include sage/matrix/matrix_integer_sparse.p*
+include sage/matrix/matrix_integer_pari.p*      # FIXME
 include sage/matrix/matrix_modn_dense_*.p*
 include sage/matrix/matrix_modn_dense_.p*
 include sage/matrix/matrix_modn_sparse.p*

--- a/pkgs/sagemath-linbox/MANIFEST.in
+++ b/pkgs/sagemath-linbox/MANIFEST.in
@@ -5,16 +5,13 @@ include VERSION.txt
 include sage/libs/iml.p*
 graft   sage/libs/linbox
 recursive-include sage/libs/ntl *.pxd *.pxi *.h                                 # FIXME
-include sage/matrix/matrix_integer_dense*.p*
-include sage/matrix/matrix_integer_sparse.p*
 include sage/matrix/matrix_integer_iml.p*
+include sage/matrix/matrix_integer_dense_hnf.p*
+include sage/matrix/matrix_integer_dense_saturation.p*
 include sage/matrix/matrix_*_linbox.p*
-include sage/matrix/matrix_*_pari.p*      # FIXME
 include sage/matrix/matrix_modn_dense_*.p*
 include sage/matrix/matrix_modn_dense_.p*
 include sage/matrix/matrix_modn_sparse.p*
-include sage/matrix/matrix_rational_dense.p*
-include sage/matrix/matrix_rational_sparse.p*
 include sage/matrix/change_ring.p*
 include sage/matrix/misc.p*
 include sage/rings/finite_rings/*_givaro*.p*

--- a/pkgs/sagemath-linbox/MANIFEST.in
+++ b/pkgs/sagemath-linbox/MANIFEST.in
@@ -9,7 +9,7 @@ include sage/matrix/matrix_integer_dense*.p*
 include sage/matrix/matrix_integer_sparse.p*
 include sage/matrix/matrix_integer_iml.p*
 include sage/matrix/matrix_*_linbox.p*
-include sage/matrix/matrix_integer_pari.p*      # FIXME
+include sage/matrix/matrix_*_pari.p*      # FIXME
 include sage/matrix/matrix_modn_dense_*.p*
 include sage/matrix/matrix_modn_dense_.p*
 include sage/matrix/matrix_modn_sparse.p*

--- a/pkgs/sagemath-linbox/MANIFEST.in
+++ b/pkgs/sagemath-linbox/MANIFEST.in
@@ -6,13 +6,10 @@ include sage/libs/iml.p*
 graft   sage/libs/linbox
 recursive-include sage/libs/ntl *.pxd *.pxi *.h                                 # FIXME
 include sage/matrix/matrix_integer_iml.p*
-include sage/matrix/matrix_integer_dense_hnf.p*
-include sage/matrix/matrix_integer_dense_saturation.p*
 include sage/matrix/matrix_*_linbox.p*
 include sage/matrix/matrix_modn_dense_*.p*
 include sage/matrix/matrix_modn_dense_.p*
 include sage/matrix/matrix_modn_sparse.p*
-include sage/matrix/change_ring.p*
 include sage/matrix/misc.p*
 include sage/rings/finite_rings/*_givaro*.p*
 

--- a/pkgs/sagemath-linbox/MANIFEST.in
+++ b/pkgs/sagemath-linbox/MANIFEST.in
@@ -7,6 +7,8 @@ graft   sage/libs/linbox
 recursive-include sage/libs/ntl *.pxd *.pxi *.h                                 # FIXME
 include sage/matrix/matrix_integer_dense*.p*
 include sage/matrix/matrix_integer_sparse.p*
+include sage/matrix/matrix_integer_iml.p*
+include sage/matrix/matrix_integer_linbox.p*
 include sage/matrix/matrix_integer_pari.p*      # FIXME
 include sage/matrix/matrix_modn_dense_*.p*
 include sage/matrix/matrix_modn_dense_.p*

--- a/pkgs/sagemath-linbox/MANIFEST.in
+++ b/pkgs/sagemath-linbox/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include sage/libs/ntl *.pxd *.pxi *.h                                 
 include sage/matrix/matrix_integer_dense*.p*
 include sage/matrix/matrix_integer_sparse.p*
 include sage/matrix/matrix_integer_iml.p*
-include sage/matrix/matrix_integer_linbox.p*
+include sage/matrix/matrix_*_linbox.p*
 include sage/matrix/matrix_integer_pari.p*      # FIXME
 include sage/matrix/matrix_modn_dense_*.p*
 include sage/matrix/matrix_modn_dense_.p*

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -434,6 +434,8 @@ class sage__libs__flint(JoinFeature):
         JoinFeature.__init__(self, 'sage.libs.flint',
                              [PythonModule('sage.libs.flint.flint_sage'),
                               PythonModule('sage.libs.flint.arith_sage'),
+                              PythonModule('sage.matrix.matrix_integer_dense'),
+                              PythonModule('sage.matrix.matrix_rational_dense'),
                               PythonModule('sage.rings.padics.padic_relaxed_element'),
                               PythonModule('sage.rings.padics.pow_computer_flint'),
                               PythonModule('sage.graphs.chrompoly'),
@@ -560,9 +562,7 @@ class sage__libs__linbox(JoinFeature):
         JoinFeature.__init__(self, 'sage.libs.linbox',
                              [PythonModule('sage.rings.finite_rings.element_givaro'),
                               PythonModule('sage.matrix.matrix_modn_dense_float'),
-                              PythonModule('sage.matrix.matrix_modn_dense_double'),
-                              PythonModule('sage.matrix.matrix_integer_dense'),
-                              PythonModule('sage.matrix.matrix_rational_dense')],
+                              PythonModule('sage.matrix.matrix_modn_dense_double')],
                              spkg='sagemath_linbox', type='standard')
 
 

--- a/src/sage/libs/linbox/linbox_flint_interface.pxd
+++ b/src/sage/libs/linbox/linbox_flint_interface.pxd
@@ -1,7 +1,4 @@
 # sage_setup: distribution = sagemath-linbox
-# distutils: libraries = LINBOX_LIBRARIES
-# distutils: library_dirs = LINBOX_LIBDIR
-# distutils: extra_link_args = LINBOX_LIBEXTRA
 
 from sage.libs.flint.types cimport fmpz_t, fmpz_mat_t, fmpz_poly_t
 

--- a/src/sage/libs/linbox/linbox_flint_interface.pyx
+++ b/src/sage/libs/linbox/linbox_flint_interface.pyx
@@ -1,4 +1,7 @@
 # sage_setup: distribution = sagemath-linbox
+# distutils: libraries = LINBOX_LIBRARIES
+# distutils: library_dirs = LINBOX_LIBDIR
+# distutils: extra_link_args = LINBOX_LIBEXTRA
 r"""
 Interface between flint matrices and linbox
 

--- a/src/sage/matrix/change_ring.pyx
+++ b/src/sage/matrix/change_ring.pyx
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 """
 Functions for changing the base ring of matrices quickly
 """

--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -63,7 +63,7 @@ from sage.matrix.constructor import matrix
 from sage.matrix.matrix_space import MatrixSpace
 from sage.matrix.matrix cimport Matrix
 from sage.matrix import matrix_dense
-from sage.matrix.matrix_integer_dense cimport _lift_crt
+from sage.matrix.matrix_integer_linbox cimport _lift_crt
 from sage.structure.element cimport Matrix as baseMatrix
 from sage.matrix.misc_flint import matrix_integer_dense_rational_reconstruction
 

--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -1461,9 +1461,9 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
         cache[p] = ans
         return ans
 
-    def echelon_form(self, algorithm='multimodular', height_guess=None):
+    def echelon_form(self, algorithm=None, height_guess=None):
         """
-        Find the echelon form of self, using the specified algorithm.
+        Find the echelon form of ``self``, using the specified algorithm.
 
         The result is cached for each algorithm separately.
 
@@ -1531,6 +1531,14 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
             self.cache(key, E)
             self.cache('pivots', ())
             return E
+
+        if algorithm is None:
+            try:
+                from .matrix_cyclo_linbox import _echelon_form_multimodular
+            except ImportError:
+                algorithm = 'classical'
+            else:
+                algorithm = 'multimodular'
 
         if algorithm == 'multimodular':
             E = self._echelon_form_multimodular(height_guess=height_guess)

--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -638,8 +638,12 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
             sage: (-m)*n
             [-23250]
         """
-        from .matrix_cyclo_linbox import _matrix_times_matrix_
-        return _matrix_times_matrix_(self, right)
+        try:
+            from .matrix_cyclo_linbox import _matrix_times_matrix_
+        except ImportError:
+            return Matrix._matrix_times_matrix_(self, right)
+        else:
+            return _matrix_times_matrix_(self, right)
 
     cdef long _hash_(self) except -1:
         """

--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -63,11 +63,9 @@ from sage.matrix.constructor import matrix
 from sage.matrix.matrix_space import MatrixSpace
 from sage.matrix.matrix cimport Matrix
 from sage.matrix import matrix_dense
-from sage.matrix.matrix_integer_linbox cimport _lift_crt
 from sage.structure.element cimport Matrix as baseMatrix
-from sage.matrix.misc_flint import matrix_integer_dense_rational_reconstruction
 
-from sage.arith.misc import binomial, previous_prime
+from sage.arith.misc import binomial
 from sage.rings.rational_field import QQ
 from sage.rings.integer_ring import ZZ
 from sage.rings.real_mpfr import create_RealNumber as RealNumber
@@ -76,16 +74,7 @@ from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.number_field.number_field_element cimport NumberFieldElement
 from sage.rings.number_field.number_field_element_quadratic cimport NumberFieldElement_quadratic
 
-from sage.structure.proof.proof import get_flag as get_proof_flag
 from sage.misc.verbose import verbose
-
-from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_MODULUS_modn_dense_double
-from sage.arith.multi_modular import MAX_MODULUS as MAX_MODULUS_multi_modular
-MAX_MODULUS = min(MAX_MODULUS_modn_dense_double, MAX_MODULUS_multi_modular)
-
-# parameters for tuning
-echelon_primes_increment = 15
-echelon_verbose_level = 1
 
 
 cdef class Matrix_cyclo_dense(Matrix_dense):
@@ -649,41 +638,8 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
             sage: (-m)*n
             [-23250]
         """
-        A, denom_self = self._matrix._clear_denom()
-        B, denom_right = (<Matrix_cyclo_dense>right)._matrix._clear_denom()
-
-        # conservative but correct estimate: 2 is there to account for the
-        # sign of the entries
-        bound = 1 + 2 * A.height() * B.height() * self._ncols
-
-        n = self._base_ring._n()
-        p = previous_prime(MAX_MODULUS)
-        prod = 1
-        v = []
-        while prod <= bound:
-            while (n >= 2 and p % n != 1) or denom_self % p == 0 or denom_right % p == 0:
-                if p == 2:
-                    raise RuntimeError("we ran out of primes in matrix multiplication.")
-                p = previous_prime(p)
-            prod *= p
-            Amodp, _ = self._reductions(p)
-            Bmodp, _ = right._reductions(p)
-            _, S = self._reduction_matrix(p)
-            X = Amodp[0]._matrix_from_rows_of_matrices([Amodp[i] * Bmodp[i] for i in range(len(Amodp))])
-            v.append(S*X)
-            p = previous_prime(p)
-        M = matrix(ZZ, self._base_ring.degree(), self._nrows*right.ncols())
-        _lift_crt(M, v)
-        d = denom_self * denom_right
-        if d == 1:
-            M = M.change_ring(QQ)
-        else:
-            M = (1/d)*M
-        cdef Matrix_cyclo_dense C = Matrix_cyclo_dense.__new__(Matrix_cyclo_dense,
-                    MatrixSpace(self._base_ring, self._nrows, right.ncols()),
-                                                               None, None, None)
-        C._matrix = M
-        return C
+        from .matrix_cyclo_linbox import _matrix_times_matrix_
+        return _matrix_times_matrix_(self, right)
 
     cdef long _hash_(self) except -1:
         """
@@ -1375,56 +1331,8 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
             sage: A = matrix(CyclotomicField(1),2,[1,2,3,4]); A.charpoly()
             x^2 - 5*x - 2
         """
-        cdef Matrix_cyclo_dense A
-        A = Matrix_cyclo_dense.__new__(Matrix_cyclo_dense, self.parent(),
-                                       None, None, None)
-
-        proof = get_proof_flag(proof, "linear_algebra")
-
-        n = self._base_ring._n()
-        p = previous_prime(MAX_MODULUS)
-        prod = 1
-        v = []
-        #A, denom = self._matrix._clear_denom()
-        # TODO: this might be stupidly slow
-        denom = self._matrix.denominator()
-        A._matrix = <Matrix_rational_dense>(denom*self._matrix)
-        bound = A._charpoly_bound()
-        L_last = 0
-        while prod <= bound:
-            while (n >= 2  and p % n != 1) or denom % p == 0:
-                if p == 2:
-                    raise RuntimeError("we ran out of primes in multimodular charpoly algorithm.")
-                p = previous_prime(p)
-
-            X = A._charpoly_mod(p)
-            v.append(X)
-            prod *= p
-            p = previous_prime(p)
-
-            # if we've used enough primes as determined by bound, or
-            # if we've used 3 primes, we check to see if the result is
-            # the same.
-            if prod >= bound or (not proof and (len(v) % 3 == 0)):
-                M = matrix(ZZ, self._base_ring.degree(), self._nrows+1)
-                L = _lift_crt(M, v)
-                if not proof and L == L_last:
-                    break
-                L_last = L
-
-        # Now each column of L encodes a coefficient of the output polynomial,
-        # with column 0 being the constant coefficient.
-        K = self.base_ring()
-        R = K[var]
-        coeffs = [K(w.list()) for w in L.columns()]
-        f = R(coeffs)
-
-        # Rescale to account for denominator, if necessary
-        if denom != 1:
-            x = R.gen()
-            f = f(x * denom) * (1 / (denom**f.degree()))
-
-        return f
+        from .matrix_cyclo_linbox import _charpoly_multimodular
+        return _charpoly_multimodular(self, var, proof)
 
     def _reductions(self, p):
         """
@@ -1672,122 +1580,8 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
             [   1    0 7/19]
             [   0    1 3/19]
         """
-        cdef Matrix_cyclo_dense res
-        cdef bint is_square
-
-        verbose("entering _echelon_form_multimodular",
-                level=echelon_verbose_level)
-
-        denom = self._matrix.denominator()
-        A = denom * self
-
-        # This bound is chosen somewhat arbitrarily. Changing it affects the
-        # runtime, not the correctness of the result.
-        if height_guess is None:
-            height_guess = (A.coefficient_bound() + 100) * 1000000
-
-        # This is all setup to keep track of various data
-        # in the loop below.
-        p = previous_prime(MAX_MODULUS)
-        found = 0
-        prod = 1
-        n = self._base_ring._n()
-        height_bound = self._ncols * height_guess * A.coefficient_bound() + 1
-        mod_p_ech_ls = []
-        max_pivots = tuple()
-        is_square = self._nrows == self._ncols
-
-        verbose("using height bound %s" % height_bound,
-                level=echelon_verbose_level)
-
-        while True:
-            # Generate primes to use, and find echelon form
-            # modulo those primes.
-            while found < num_primes or prod <= height_bound:
-                if (n == 1) or p % n == 1:
-                    try:
-                        mod_p_ech, piv_ls = A._echelon_form_one_prime(p)
-                    except ValueError:
-                        # This means that we chose a prime which divides
-                        # the denominator of the echelon form of self, so
-                        # just skip it and continue
-                        p = previous_prime(p)
-                        continue
-                    # if we have the identity, just return it, and
-                    # we're done.
-                    if is_square and len(piv_ls) == self._nrows:
-                        self.cache('pivots', tuple(range(self._nrows)))
-                        return self.parent().identity_matrix()
-                    if piv_ls > max_pivots:
-                        mod_p_ech_ls = [mod_p_ech]
-                        max_pivots = piv_ls
-                        # add this to the list of primes
-                        prod = p
-                        found = 1
-                    elif piv_ls == max_pivots:
-                        mod_p_ech_ls.append(mod_p_ech)
-                        # add this to the list of primes
-                        prod *= p
-                        found += 1
-                    else:
-                        # this means that the rank profile mod this
-                        # prime is worse than those that came before,
-                        # so we just loop
-                        p = previous_prime(p)
-                        continue
-
-                p = previous_prime(p)
-
-            if found > num_primes:
-                num_primes = found
-
-            verbose("computed echelon form mod %s primes" % num_primes,
-                    level=echelon_verbose_level)
-            verbose("current product of primes used: %s" % prod,
-                    level=echelon_verbose_level)
-
-            # Use CRT to lift back to ZZ
-            mat_over_ZZ = matrix(ZZ, self._base_ring.degree(),
-                                 self._nrows * self._ncols)
-            _lift_crt(mat_over_ZZ, mod_p_ech_ls)
-            # note: saving the CRT intermediate MultiModularBasis does
-            # not seem to affect the runtime at all
-
-            # Attempt to use rational reconstruction to find
-            # our echelon form
-            try:
-                verbose("attempting rational reconstruction ...",
-                        level=echelon_verbose_level)
-                res = Matrix_cyclo_dense.__new__(Matrix_cyclo_dense,
-                                                 self.parent(),
-                                                 None, None, None)
-                res._matrix = <Matrix_rational_dense>matrix_integer_dense_rational_reconstruction(mat_over_ZZ, prod)
-
-            except ValueError:
-                # If a ValueError is raised here, it means that the
-                # rational reconstruction failed. In this case, add
-                # on a few more primes, and try again.
-
-                num_primes += echelon_primes_increment
-                verbose("rational reconstruction failed, trying with %s primes"%num_primes, level=echelon_verbose_level)
-                continue
-
-            verbose("rational reconstruction succeeded with %s primes!"%num_primes, level=echelon_verbose_level)
-
-            if ((res * res.denominator()).coefficient_bound() *
-                self.coefficient_bound() * self.ncols()) > prod:
-                # In this case, we don't know the result to sufficient
-                # "precision" (here precision is just the modulus,
-                # prod) to guarantee its correctness, so loop.
-
-                num_primes += echelon_primes_increment
-                verbose("height not sufficient to determine echelon form",
-                        level=echelon_verbose_level)
-                continue
-
-            verbose("found echelon form with %s primes, whose product is %s"%(num_primes, prod), level=echelon_verbose_level)
-            self.cache('pivots', max_pivots)
-            return res
+        from .matrix_cyclo_linbox import _echelon_form_multimodular
+        return _echelon_form_multimodular(self, num_primes, height_guess)
 
     def _echelon_form_one_prime(self, p):
         """

--- a/src/sage/matrix/matrix_cyclo_linbox.pyx
+++ b/src/sage/matrix/matrix_cyclo_linbox.pyx
@@ -1,0 +1,360 @@
+# sage_setup: distribution = sagemath-linbox
+
+from sage.arith.misc import previous_prime
+from sage.libs.flint.fmpq cimport fmpq_is_zero, fmpq_set_mpq, fmpq_canonicalise
+from sage.libs.flint.fmpq_mat cimport fmpq_mat_entry_num, fmpq_mat_entry_den, fmpq_mat_entry
+from sage.libs.flint.fmpz cimport fmpz_init, fmpz_clear, fmpz_set_mpz, fmpz_one, fmpz_get_mpz, fmpz_add, fmpz_mul, fmpz_sub, fmpz_mul_si, fmpz_mul_si, fmpz_mul_si, fmpz_divexact, fmpz_lcm
+from sage.libs.gmp.types cimport mpz_t
+from sage.matrix.constructor import matrix
+from sage.matrix.matrix_cyclo_dense cimport Matrix_cyclo_dense
+from sage.matrix.matrix_integer_linbox cimport _lift_crt
+from sage.matrix.matrix_rational_dense cimport Matrix_rational_dense
+from sage.matrix.matrix_space import MatrixSpace
+from sage.matrix.misc_flint import matrix_integer_dense_rational_reconstruction
+from sage.misc.verbose import verbose
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational_field import QQ
+from sage.structure.element cimport Matrix as baseMatrix
+from sage.structure.proof.proof import get_flag as get_proof_flag
+
+from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_MODULUS_modn_dense_double
+from sage.arith.multi_modular import MAX_MODULUS as MAX_MODULUS_multi_modular
+MAX_MODULUS = min(MAX_MODULUS_modn_dense_double, MAX_MODULUS_multi_modular)
+
+# parameters for tuning
+echelon_primes_increment = 15
+echelon_verbose_level = 1
+
+
+cpdef _matrix_times_matrix_(Matrix_cyclo_dense self, baseMatrix right):
+    """
+    Return the product of two cyclotomic dense matrices.
+
+    INPUT:
+
+    - ``self``, ``right`` -- cyclotomic dense matrices with compatible
+      parents (same base ring, and compatible dimensions for matrix
+      multiplication)
+
+    OUTPUT: cyclotomic dense matrix
+
+    ALGORITHM:
+
+    Use a multimodular algorithm that involves multiplying the two matrices
+    modulo split primes.
+
+    EXAMPLES::
+
+        sage: W.<z> = CyclotomicField(5)
+        sage: A = matrix(3, 3, [1,z,z^2,z^3,z^4,2/3*z,-3*z,z,2+z]); B = matrix(3, 3, [-1,2*z,3*z^2,5*z+1,z^4,1/3*z,2-z,3-z,5-z])
+        sage: A*B
+        [        -z^3 + 7*z^2 + z - 1       -z^3 + 3*z^2 + 2*z + 1              -z^3 + 25/3*z^2]
+        [-2*z^3 - 5/3*z^2 + 1/3*z + 4           -z^3 - 8/3*z^2 - 2     -2/3*z^2 + 10/3*z + 10/3]
+        [             4*z^2 + 4*z + 4               -7*z^2 + z + 7  -9*z^3 - 2/3*z^2 + 3*z + 10]
+
+    Verify that the answer above is consistent with what the
+    generic sparse matrix multiply gives (which is a different
+    implementation).::
+
+        sage: A*B == A.sparse_matrix()*B.sparse_matrix()
+        True
+
+        sage: N1 = Matrix(CyclotomicField(6), 1, [1])
+        sage: cf6 = CyclotomicField(6) ; z6 = cf6.0
+        sage: N2 = Matrix(CyclotomicField(6), 1, 5, [0,1,z6,-z6,-z6+1])
+        sage: N1*N2
+        [         0          1      zeta6     -zeta6 -zeta6 + 1]
+        sage: N1 = Matrix(CyclotomicField(6), 1, [-1])
+        sage: N1*N2
+        [        0        -1    -zeta6     zeta6 zeta6 - 1]
+
+    Verify that a degenerate case bug reported at :issue:`5974` is fixed.
+
+        sage: K.<zeta6>=CyclotomicField(6); matrix(K,1,2) * matrix(K,2,[0, 1, 0, -2*zeta6, 0, 0, 1, -2*zeta6 + 1])
+        [0 0 0 0]
+
+    TESTS:
+
+    This is from :issue:`8666`::
+
+        sage: K.<zeta4> = CyclotomicField(4)
+        sage: m = matrix(K, [125])
+        sage: n = matrix(K, [186])
+        sage: m*n
+        [23250]
+        sage: (-m)*n
+        [-23250]
+    """
+    A, denom_self = self._matrix._clear_denom()
+    B, denom_right = (<Matrix_cyclo_dense>right)._matrix._clear_denom()
+
+    # conservative but correct estimate: 2 is there to account for the
+    # sign of the entries
+    bound = 1 + 2 * A.height() * B.height() * self._ncols
+
+    n = self._base_ring._n()
+    p = previous_prime(MAX_MODULUS)
+    prod = 1
+    v = []
+    while prod <= bound:
+        while (n >= 2 and p % n != 1) or denom_self % p == 0 or denom_right % p == 0:
+            if p == 2:
+                raise RuntimeError("we ran out of primes in matrix multiplication.")
+            p = previous_prime(p)
+        prod *= p
+        Amodp, _ = self._reductions(p)
+        Bmodp, _ = right._reductions(p)
+        _, S = self._reduction_matrix(p)
+        X = Amodp[0]._matrix_from_rows_of_matrices([Amodp[i] * Bmodp[i] for i in range(len(Amodp))])
+        v.append(S*X)
+        p = previous_prime(p)
+    M = matrix(ZZ, self._base_ring.degree(), self._nrows*right.ncols())
+    _lift_crt(M, v)
+    d = denom_self * denom_right
+    if d == 1:
+        M = M.change_ring(QQ)
+    else:
+        M = (1/d)*M
+    cdef Matrix_cyclo_dense C = Matrix_cyclo_dense.__new__(Matrix_cyclo_dense,
+                MatrixSpace(self._base_ring, self._nrows, right.ncols()),
+                                                           None, None, None)
+    C._matrix = M
+    return C
+
+
+def _charpoly_multimodular(Matrix_cyclo_dense self, var='x', proof=None):
+    """
+    Compute the characteristic polynomial of ``self`` using a
+    multimodular algorithm.
+
+    INPUT:
+
+    - ``proof`` -- boolean (default: global flag); if ``False``, compute
+      using primes `p_i` until the lift modulo all primes up to `p_i` is
+      the same as the lift modulo all primes up to `p_{i+3}` or the bound
+      is reached
+
+    EXAMPLES::
+
+        sage: K.<z> = CyclotomicField(3)
+        sage: A = matrix(3, [-z, 2*z + 1, 1/2*z + 2, 1, -1/2, 2*z + 2, -2*z - 2, -2*z - 2, 2*z - 1])
+        sage: A._charpoly_multimodular()
+        x^3 + (-z + 3/2)*x^2 + (17/2*z + 9/2)*x - 9/2*z - 23/2
+        sage: A._charpoly_multimodular('T')
+        T^3 + (-z + 3/2)*T^2 + (17/2*z + 9/2)*T - 9/2*z - 23/2
+        sage: A._charpoly_multimodular('T', proof=False)
+        T^3 + (-z + 3/2)*T^2 + (17/2*z + 9/2)*T - 9/2*z - 23/2
+
+    TESTS:
+
+    We test a degenerate case::
+
+        sage: A = matrix(CyclotomicField(1),2,[1,2,3,4]); A.charpoly()
+        x^2 - 5*x - 2
+    """
+    cdef Matrix_cyclo_dense A
+    A = Matrix_cyclo_dense.__new__(Matrix_cyclo_dense, self.parent(),
+                                   None, None, None)
+
+    proof = get_proof_flag(proof, "linear_algebra")
+
+    n = self._base_ring._n()
+    p = previous_prime(MAX_MODULUS)
+    prod = 1
+    v = []
+    #A, denom = self._matrix._clear_denom()
+    # TODO: this might be stupidly slow
+    denom = self._matrix.denominator()
+    A._matrix = <Matrix_rational_dense>(denom*self._matrix)
+    bound = A._charpoly_bound()
+    L_last = 0
+    while prod <= bound:
+        while (n >= 2  and p % n != 1) or denom % p == 0:
+            if p == 2:
+                raise RuntimeError("we ran out of primes in multimodular charpoly algorithm.")
+            p = previous_prime(p)
+
+        X = A._charpoly_mod(p)
+        v.append(X)
+        prod *= p
+        p = previous_prime(p)
+
+        # if we've used enough primes as determined by bound, or
+        # if we've used 3 primes, we check to see if the result is
+        # the same.
+        if prod >= bound or (not proof and (len(v) % 3 == 0)):
+            M = matrix(ZZ, self._base_ring.degree(), self._nrows+1)
+            L = _lift_crt(M, v)
+            if not proof and L == L_last:
+                break
+            L_last = L
+
+    # Now each column of L encodes a coefficient of the output polynomial,
+    # with column 0 being the constant coefficient.
+    K = self.base_ring()
+    R = K[var]
+    coeffs = [K(w.list()) for w in L.columns()]
+    f = R(coeffs)
+
+    # Rescale to account for denominator, if necessary
+    if denom != 1:
+        x = R.gen()
+        f = f(x * denom) * (1 / (denom**f.degree()))
+
+    return f
+
+
+def _echelon_form_multimodular(Matrix_cyclo_dense self, num_primes=10, height_guess=None):
+    """
+    Use a multimodular algorithm to find the echelon form of ``self``.
+
+    INPUT:
+
+    - ``num_primes`` -- number of primes to work modulo
+
+    - ``height_guess`` -- guess for the height of the echelon form of self
+
+    OUTPUT: matrix in reduced row echelon form
+
+    EXAMPLES::
+
+        sage: W.<z> = CyclotomicField(3)
+        sage: A = matrix(W, 2, 3, [1+z, 2/3, 9*z+7, -3 + 4*z, z, -7*z]); A
+        [  z + 1     2/3 9*z + 7]
+        [4*z - 3       z    -7*z]
+        sage: A._echelon_form_multimodular(10)
+        [                  1                   0  -192/97*z - 361/97]
+        [                  0                   1 1851/97*z + 1272/97]
+
+    TESTS:
+
+    We test a degenerate case::
+
+        sage: A = matrix(CyclotomicField(5),0); A
+        []
+        sage: A._echelon_form_multimodular(10)
+        []
+        sage: A.pivots()
+        ()
+
+        sage: A = matrix(CyclotomicField(13), 2, 3, [5, 1, 2, 46307, 46307*4, 46307])
+        sage: A._echelon_form_multimodular()
+        [   1    0 7/19]
+        [   0    1 3/19]
+    """
+    cdef Matrix_cyclo_dense res
+    cdef bint is_square
+
+    verbose("entering _echelon_form_multimodular",
+            level=echelon_verbose_level)
+
+    denom = self._matrix.denominator()
+    A = denom * self
+
+    # This bound is chosen somewhat arbitrarily. Changing it affects the
+    # runtime, not the correctness of the result.
+    if height_guess is None:
+        height_guess = (A.coefficient_bound() + 100) * 1000000
+
+    # This is all setup to keep track of various data
+    # in the loop below.
+    p = previous_prime(MAX_MODULUS)
+    found = 0
+    prod = 1
+    n = self._base_ring._n()
+    height_bound = self._ncols * height_guess * A.coefficient_bound() + 1
+    mod_p_ech_ls = []
+    max_pivots = tuple()
+    is_square = self._nrows == self._ncols
+
+    verbose("using height bound %s" % height_bound,
+            level=echelon_verbose_level)
+
+    while True:
+        # Generate primes to use, and find echelon form
+        # modulo those primes.
+        while found < num_primes or prod <= height_bound:
+            if (n == 1) or p % n == 1:
+                try:
+                    mod_p_ech, piv_ls = A._echelon_form_one_prime(p)
+                except ValueError:
+                    # This means that we chose a prime which divides
+                    # the denominator of the echelon form of self, so
+                    # just skip it and continue
+                    p = previous_prime(p)
+                    continue
+                # if we have the identity, just return it, and
+                # we're done.
+                if is_square and len(piv_ls) == self._nrows:
+                    self.cache('pivots', tuple(range(self._nrows)))
+                    return self.parent().identity_matrix()
+                if piv_ls > max_pivots:
+                    mod_p_ech_ls = [mod_p_ech]
+                    max_pivots = piv_ls
+                    # add this to the list of primes
+                    prod = p
+                    found = 1
+                elif piv_ls == max_pivots:
+                    mod_p_ech_ls.append(mod_p_ech)
+                    # add this to the list of primes
+                    prod *= p
+                    found += 1
+                else:
+                    # this means that the rank profile mod this
+                    # prime is worse than those that came before,
+                    # so we just loop
+                    p = previous_prime(p)
+                    continue
+
+            p = previous_prime(p)
+
+        if found > num_primes:
+            num_primes = found
+
+        verbose("computed echelon form mod %s primes" % num_primes,
+                level=echelon_verbose_level)
+        verbose("current product of primes used: %s" % prod,
+                level=echelon_verbose_level)
+
+        # Use CRT to lift back to ZZ
+        mat_over_ZZ = matrix(ZZ, self._base_ring.degree(),
+                             self._nrows * self._ncols)
+        _lift_crt(mat_over_ZZ, mod_p_ech_ls)
+        # note: saving the CRT intermediate MultiModularBasis does
+        # not seem to affect the runtime at all
+
+        # Attempt to use rational reconstruction to find
+        # our echelon form
+        try:
+            verbose("attempting rational reconstruction ...",
+                    level=echelon_verbose_level)
+            res = Matrix_cyclo_dense.__new__(Matrix_cyclo_dense,
+                                             self.parent(),
+                                             None, None, None)
+            res._matrix = <Matrix_rational_dense>matrix_integer_dense_rational_reconstruction(mat_over_ZZ, prod)
+
+        except ValueError:
+            # If a ValueError is raised here, it means that the
+            # rational reconstruction failed. In this case, add
+            # on a few more primes, and try again.
+
+            num_primes += echelon_primes_increment
+            verbose("rational reconstruction failed, trying with %s primes"%num_primes, level=echelon_verbose_level)
+            continue
+
+        verbose("rational reconstruction succeeded with %s primes!"%num_primes, level=echelon_verbose_level)
+
+        if ((res * res.denominator()).coefficient_bound() *
+            self.coefficient_bound() * self.ncols()) > prod:
+            # In this case, we don't know the result to sufficient
+            # "precision" (here precision is just the modulus,
+            # prod) to guarantee its correctness, so loop.
+
+            num_primes += echelon_primes_increment
+            verbose("height not sufficient to determine echelon form",
+                    level=echelon_verbose_level)
+            continue
+
+        verbose("found echelon form with %s primes, whose product is %s"%(num_primes, prod), level=echelon_verbose_level)
+        self.cache('pivots', max_pivots)
+        return res

--- a/src/sage/matrix/matrix_integer_dense.pxd
+++ b/src/sage/matrix/matrix_integer_dense.pxd
@@ -30,6 +30,3 @@ cdef class Matrix_integer_dense(Matrix_dense):
             Py_ssize_t nrows, Py_ssize_t ncols) except NULL
 
     cdef Matrix_integer_dense _new(self, Py_ssize_t nrows, Py_ssize_t ncols)
-
-
-cpdef _lift_crt(Matrix_integer_dense M, residues, moduli=*)

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -86,18 +86,6 @@ from sage.misc.randstate cimport randstate, current_randstate
 from sage.misc.superseded import deprecated_function_alias
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
 
-#########################################################
-# PARI C library
-from cypari2.gen cimport Gen
-from cypari2.stack cimport clear_stack, new_gen
-from cypari2.paridecl cimport *
-from sage.libs.pari import pari
-from sage.libs.pari.convert_gmp cimport INT_to_mpz
-from sage.libs.pari.convert_flint cimport (_new_GEN_from_fmpz_mat_t,
-           _new_GEN_from_fmpz_mat_t_rotate90, integer_matrix)
-from sage.libs.pari.convert_sage_matrix import gen_to_sage_matrix
-#########################################################
-
 from sage.arith.multi_modular cimport MultiModularBasis
 
 from sage.libs.flint.fmpz cimport *
@@ -3316,15 +3304,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 U = Ufplll.to_matrix(self.new_matrix(Ufplll.nrows, Ufplll.ncols))
 
         elif algorithm == 'pari':
-            # call pari with flag=4: kernel+image
-            # pari uses column convention: need to transpose the matrices
-            A = integer_matrix(self._matrix, 1)
-            K, T = A.qflll(4)
-            r = ZZ(T.length())
-            # TODO: there is no optimized matrix converter pari -> sage
-            U = gen_to_sage_matrix(pari.matconcat([K, T]).mattranspose())
-            R = U * self
-
+            from .matrix_integer_pari import _lll_pari
+            R, U = _lll_pari(self)
         else:
             raise TypeError("algorithm %s not supported"%algorithm)
 
@@ -3858,7 +3839,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 raise RuntimeError("you must pass the proof=False option to the determinant command to use LinBox's det algorithm")
             d = self._det_linbox()
         elif algorithm == 'pari':
-            d = self._det_pari()
+            from .matrix_integer_pari import _det_pari
+            d = _det_pari(self)
         elif algorithm == 'ntl':
             d = self._det_ntl()
         else:
@@ -3891,34 +3873,6 @@ cdef class Matrix_integer_dense(Matrix_dense):
         fmpz_get_mpz(ans.value, tmp)
         fmpz_clear(tmp)
         return ans
-
-    def _det_pari(self, int flag=0):
-        """
-        Determinant of this matrix using Gauss-Bareiss. If (optional)
-        flag is set to 1, use classical Gaussian elimination.
-
-        For efficiency purposes, this det is computed entirely on the
-        PARI stack then the PARI stack is cleared. This function is
-        most useful for very small matrices.
-
-        EXAMPLES::
-
-            sage: matrix(ZZ, 0)._det_pari()
-            1
-            sage: matrix(ZZ, 0)._det_pari(1)
-            1
-            sage: matrix(ZZ, 3, [1..9])._det_pari()
-            0
-            sage: matrix(ZZ, 3, [1..9])._det_pari(1)
-            0
-        """
-        sig_on()
-        cdef GEN d = det0(pari_GEN(self), flag)
-        # now convert d to a Sage integer e
-        cdef Integer e = Integer.__new__(Integer)
-        INT_to_mpz(e.value, d)
-        clear_stack()
-        return e
 
     def _det_ntl(self):
         """
@@ -5795,88 +5749,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: type(pari(a))
             <class 'cypari2.gen.Gen'>
         """
-        return integer_matrix(self._matrix, 0)
-
-    def _rank_pari(self):
-        """
-        Rank of this matrix, computed using PARI.  The computation is
-        done entirely on the PARI stack, then the PARI stack is
-        cleared.  This function is most useful for very small
-        matrices.
-
-        EXAMPLES::
-
-            sage: matrix(ZZ,3,[1..9])._rank_pari()
-            2
-        """
-        sig_on()
-        cdef long r = rank(pari_GEN(self))
-        clear_stack()
-        return r
-
-    def _hnf_pari(self, int flag=0, bint include_zero_rows=True):
-        """
-        Hermite normal form of this matrix, computed using PARI.
-
-        INPUT:
-
-        - ``flag`` -- 0 (default), 1, 3 or 4 (see docstring for
-          ``pari.mathnf``)
-
-        - ``include_zero_rows`` -- boolean; if ``False``, do not include
-          any of the zero rows at the bottom of the matrix in the output
-
-        .. NOTE::
-
-            In no cases is the transformation matrix returned by this
-            function.
-
-        EXAMPLES::
-
-            sage: matrix(ZZ,3,[1..9])._hnf_pari()
-            [1 2 3]
-            [0 3 6]
-            [0 0 0]
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(1)
-            [1 2 3]
-            [0 3 6]
-            [0 0 0]
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(3)
-            [1 2 3]
-            [0 3 6]
-            [0 0 0]
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(4)
-            [1 2 3]
-            [0 3 6]
-            [0 0 0]
-
-        Check that ``include_zero_rows=False`` works correctly::
-
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(0, include_zero_rows=False)
-            [1 2 3]
-            [0 3 6]
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(1, include_zero_rows=False)
-            [1 2 3]
-            [0 3 6]
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(3, include_zero_rows=False)
-            [1 2 3]
-            [0 3 6]
-            sage: matrix(ZZ,3,[1..9])._hnf_pari(4, include_zero_rows=False)
-            [1 2 3]
-            [0 3 6]
-
-        Check that :issue:`12346` is fixed::
-
-            sage: pari('mathnf(Mat([0,1]), 4)')
-            [Mat(1), [1, 0; 0, 1]]
-        """
-        sig_on()
-        A = _new_GEN_from_fmpz_mat_t_rotate90(self._matrix)
-        H = mathnf0(A, flag)
-        if typ(H) == t_VEC:
-            H = gel(H, 1)
-        GenH = new_gen(H)
-        return extract_hnf_from_pari_matrix(self, GenH, include_zero_rows)
+        from .matrix_integer_pari import _pari
+        return _pari(self)
 
     def p_minimal_polynomials(self, p, s_max=None):
         r"""
@@ -5999,41 +5873,6 @@ cdef class Matrix_integer_dense(Matrix_dense):
         """
         from sage.matrix.compute_J_ideal import ComputeMinimalPolynomials
         return ComputeMinimalPolynomials(self).integer_valued_polynomials_generators()
-
-
-cdef inline GEN pari_GEN(Matrix_integer_dense B) noexcept:
-    r"""
-    Create the PARI GEN object on the stack defined by the integer
-    matrix B. This is used internally by the function for conversion
-    of matrices to PARI.
-
-    For internal use only; this directly uses the PARI stack.
-    One should call ``sig_on()`` before and ``sig_off()`` after.
-    """
-    cdef GEN A = _new_GEN_from_fmpz_mat_t(B._matrix)
-    return A
-
-
-cdef extract_hnf_from_pari_matrix(Matrix_integer_dense self, Gen H, bint include_zero_rows):
-    cdef mpz_t tmp
-    mpz_init(tmp)
-
-    # Figure out how many columns we got back.
-    cdef long H_nc = glength(H.g)  # number of columns
-    # Now get the resulting Hermite form matrix back to Sage, suitably re-arranged.
-    cdef Matrix_integer_dense B
-    if include_zero_rows:
-        B = self.new_matrix()
-    else:
-        B = self.new_matrix(nrows=H_nc)
-    cdef long i, j
-    for i in range(self._ncols):
-        for j in range(H_nc):
-            sig_check()
-            INT_to_mpz(tmp, gcoeff(H.g, i+1, H_nc-j))
-            fmpz_set_mpz(fmpz_mat_entry(B._matrix,j,self._ncols-i-1),tmp)
-    mpz_clear(tmp)
-    return B
 
 
 cdef _clear_columns(Matrix_integer_dense A, pivots, Py_ssize_t n):

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1533,38 +1533,22 @@ cdef class Matrix_integer_dense(Matrix_dense):
         return Matrix_mod2_dense(MS, self, True, True)
 
     cdef _mod_int_c(self, mod_int p):
-        from sage.matrix.matrix_modn_dense_float import MAX_MODULUS as MAX_MODULUS_FLOAT
-        from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_MODULUS_DOUBLE
-
-        cdef Py_ssize_t i, j
-
-        cdef float* res_row_f
-        cdef Matrix_modn_dense_float res_f
-
-        cdef double* res_row_d
-        cdef Matrix_modn_dense_double res_d
-
         if p == 2:
             return self._mod_two()
-        elif p < MAX_MODULUS_FLOAT:
-            res_f = Matrix_modn_dense_float.__new__(Matrix_modn_dense_float,
-                                                    matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False), None, None, None, zeroed_alloc=False)
-            for i from 0 <= i < self._nrows:
-                res_row_f = res_f._matrix[i]
-                for j from 0 <= j < self._ncols:
-                    res_row_f[j] = <float>fmpz_fdiv_ui(fmpz_mat_entry(self._matrix,i,j), p)
-            return res_f
 
-        elif p < MAX_MODULUS_DOUBLE:
-            res_d = Matrix_modn_dense_double.__new__(Matrix_modn_dense_double,
-                                                     matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False), None, None, None, zeroed_alloc=False)
-            for i from 0 <= i < self._nrows:
-                res_row_d = res_d._matrix[i]
-                for j from 0 <= j < self._ncols:
-                    res_row_d[j] = <double>fmpz_fdiv_ui(fmpz_mat_entry(self._matrix,i,j), p)
-            return res_d
-        else:
-            raise ValueError("p to big.")
+        from sage.matrix.matrix_modn_dense_float import MAX_MODULUS as MAX_MODULUS_FLOAT
+
+        if p < MAX_MODULUS_FLOAT:
+            from .matrix_integer_linbox import _Matrix_modn_dense_float
+            return _Matrix_modn_dense_float(self, p)
+
+        from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_MODULUS_DOUBLE
+
+        if p < MAX_MODULUS_DOUBLE:
+            from .matrix_integer_linbox import _Matrix_modn_dense_double
+            return _Matrix_modn_dense_double(self, p)
+
+        raise ValueError("p to big.")
 
     def _reduce(self, moduli):
         from sage.matrix.matrix_modn_dense_float import MAX_MODULUS as MAX_MODULUS_FLOAT

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1,8 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
-# distutils: extra_compile_args = M4RI_CFLAGS -std=c++11
-# distutils: libraries = gmp m CBLAS_LIBRARIES
-# distutils: library_dirs = CBLAS_LIBDIR
-# distutils: include_dirs = M4RI_INCDIR CBLAS_INCDIR
+# sage_setup: distribution = sagemath-flint
 """
 Dense matrices over the integer ring
 

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1297,7 +1297,12 @@ cdef class Matrix_integer_dense(Matrix_dense):
         cdef Polynomial_integer_dense_flint g
 
         if algorithm is None:
-            algorithm = 'linbox'
+            try:
+                from .matrix_integer_linbox import _charpoly_linbox
+            except ImportError:
+                algorithm = 'flint'
+            else:
+                algorithm = 'linbox'
 
         cache_key = 'charpoly_%s' % algorithm
         g = self.fetch(cache_key)
@@ -1383,7 +1388,12 @@ cdef class Matrix_integer_dense(Matrix_dense):
         cdef Polynomial_integer_dense_flint g
 
         if algorithm is None:
-            algorithm = 'linbox'
+            try:
+                from .matrix_integer_linbox import _minpoly_linbox
+            except ImportError:
+                algorithm = 'generic'
+            else:
+                algorithm = 'linbox'
 
         key = 'minpoly_%s'%(algorithm)
         g = self.fetch(key)
@@ -2558,12 +2568,22 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 if h < 100:
                     algorithm = 'pari'
                 else:
-                    algorithm = 'padic'
+                    try:
+                        from .matrix_integer_iml import _rational_kernel_iml
+                    except ImportError:
+                        algorithm = 'flint'
+                    else:
+                        algorithm = 'padic'
             elif self._nrows <= self._ncols + 3:
                 # the padic algorithm is much better for bigger
                 # matrices if there are nearly more columns than rows
                 # (that is its forte)
-                algorithm = 'padic'
+                try:
+                    from .matrix_integer_iml import _rational_kernel_iml
+                except ImportError:
+                    algorithm = 'flint'
+                else:
+                    algorithm = 'padic'
             else:
                 algorithm = 'pari'
 

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -674,7 +674,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: A * A.transpose()
             [ 5 14]
             [14 50]
-            sage: A._multiply_linbox(A.transpose())
+            sage: A._multiply_linbox(A.transpose())                                     # needs sage.libs.linbox
             [ 5 14]
             [14 50]
 
@@ -683,7 +683,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         This fixes a bug found in :issue:`17094`::
 
             sage: A = identity_matrix(ZZ, 3)
-            sage: A._multiply_linbox(A)
+            sage: A._multiply_linbox(A)                                                 # needs sage.libs.linbox
             [1 0 0]
             [0 1 0]
             [0 0 1]
@@ -705,6 +705,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: from sage.matrix.matrix_integer_linbox import _multiply_linbox
             sage: for _ in range(100):
             ....:     nrows = randint(0, 10)
@@ -1252,14 +1253,14 @@ cdef class Matrix_integer_dense(Matrix_dense):
             x^2 - 3*x - 2
             sage: A.charpoly('y')
             y^2 - 3*y - 2
-            sage: A._cache['charpoly_linbox']
+            sage: A._cache['charpoly_linbox']                                           # needs sage.libs.linbox
             x^2 - 3*x - 2
 
         Test corner cases::
 
             sage: matrix([5]).charpoly('z', 'flint')
             z - 5
-            sage: matrix([5]).charpoly('z', 'linbox')
+            sage: matrix([5]).charpoly('z', 'linbox')                                   # needs sage.libs.linbox
             z - 5
             sage: matrix([5]).charpoly('z', 'generic')
             z - 5
@@ -1267,21 +1268,21 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
             sage: matrix([]).charpoly('y', 'flint')
             1
-            sage: matrix([]).charpoly('y', 'linbox')
+            sage: matrix([]).charpoly('y', 'linbox')                                    # needs sage.libs.linbox
             1
             sage: matrix([]).charpoly('y', 'generic')
             1
 
             sage: matrix([0]).charpoly('x', 'flint')
             x
-            sage: matrix([0]).charpoly('x', 'linbox')
+            sage: matrix([0]).charpoly('x', 'linbox')                                   # needs sage.libs.linbox
             x
             sage: matrix([0]).charpoly('x', 'generic')
             x
 
         Consistency on random inputs::
 
-            sage: for _ in range(100):
+            sage: for _ in range(100):                                                  # needs sage.libs.linbox
             ....:     dim = randint(1, 20)
             ....:     m  = random_matrix(ZZ, dim)
             ....:     m._clear_cache(); ans_flint = m.charpoly(algorithm='flint')
@@ -1340,7 +1341,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             x^3 - 105*x^2 - 630*x
 
             sage: A = Mat(ZZ, 6)([k^2 for k in range(36)])
-            sage: A.minpoly(algorithm='linbox')
+            sage: A.minpoly(algorithm='linbox')                                         # needs sage.libs.linbox
             x^4 - 2695*x^3 - 257964*x^2 + 1693440*x
             sage: A.minpoly(algorithm='generic')
             x^4 - 2695*x^3 - 257964*x^2 + 1693440*x
@@ -1356,24 +1357,24 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Corner cases::
 
-            sage: matrix([5]).minpoly('z', 'linbox')
+            sage: matrix([5]).minpoly('z', 'linbox')                                    # needs sage.libs.linbox
             z - 5
             sage: matrix([5]).minpoly('z', 'generic')
             z - 5
 
-            sage: matrix([]).minpoly('y', 'linbox')
+            sage: matrix([]).minpoly('y', 'linbox')                                     # needs sage.libs.linbox
             1
             sage: matrix([]).minpoly('y', 'generic')
             1
 
-            sage: matrix(ZZ, 2).minpoly('x', 'linbox')
+            sage: matrix(ZZ, 2).minpoly('x', 'linbox')                                  # needs sage.libs.linbox
             x
             sage: matrix(ZZ, 2).minpoly('x', 'generic')
             x
 
         Consistency on random inputs::
 
-            sage: for _ in range(100):
+            sage: for _ in range(100):                                                  # needs sage.libs.linbox
             ....:     dim = randint(1, 20)
             ....:     m  = random_matrix(ZZ, dim)
             ....:     m._clear_cache(); ans_generic = m.minpoly(algorithm='generic')
@@ -1469,10 +1470,10 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
             sage: M = Matrix(ZZ, 2, 3, range(5,11))
             sage: N = Matrix(ZZ, 3, 2, range(15,21))
-            sage: M._multiply_multi_modular(N)
+            sage: M._multiply_multi_modular(N)                                          # needs sage.libs.linbox
             [310 328]
             [463 490]
-            sage: M._multiply_multi_modular(-N)
+            sage: M._multiply_multi_modular(-N)                                         # needs sage.libs.linbox
             [-310 -328]
             [-463 -490]
         """
@@ -1758,19 +1759,19 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Illustrate using various algorithms.::
 
-            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='pari')
+            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='pari')                    # needs sage.libs.pari
             [1 2 3]
             [0 3 6]
             [0 0 0]
-            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='pari0')
+            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='pari0')                   # needs sage.libs.pari
             [1 2 3]
             [0 3 6]
             [0 0 0]
-            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='pari4')
+            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='pari4')                   # needs sage.libs.linbox
             [1 2 3]
             [0 3 6]
             [0 0 0]
-            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='padic')
+            sage: matrix(ZZ,3,[1..9]).hermite_form(algorithm='padic')                   # needs sage.libs.linbox
             [1 2 3]
             [0 3 6]
             [0 0 0]
@@ -1809,7 +1810,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             ....:             (-1, 1, -1, -2, 1, -1, -1, -1, -1, 7),
             ....:             (-2, -1, -1, 1, 1, -2, 1, 0, 2, -4)]).stack(
             ....:             200 * identity_matrix(ZZ, 10))
-            sage: matrix(ZZ,m).hermite_form(algorithm='pari', include_zero_rows=False)
+            sage: matrix(ZZ,m).hermite_form(algorithm='pari', include_zero_rows=False)      # needs sage.libs.pari
             [  1   0   2   0  13   5   1 166  72  69]
             [  0   1   1   0  20   4  15 195  65 190]
             [  0   0   4   0  24   5  23  22  51 123]
@@ -1820,7 +1821,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             [  0   0   0   0   0   0   0 200   0   0]
             [  0   0   0   0   0   0   0   0 200   0]
             [  0   0   0   0   0   0   0   0   0 200]
-            sage: matrix(ZZ,m).hermite_form(algorithm='padic', include_zero_rows=False)
+            sage: matrix(ZZ,m).hermite_form(algorithm='padic', include_zero_rows=False)     # needs sage.libs.linbox
             [  1   0   2   0  13   5   1 166  72  69]
             [  0   1   1   0  20   4  15 195  65 190]
             [  0   0   4   0  24   5  23  22  51 123]
@@ -2476,6 +2477,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             ....:                 [0, 1, 0, 1, 9, 7],
             ....:                 [4, 7, 6, 5, 1, 4]])
 
+            sage: # needs sage.libs.pari
             sage: result = A._right_kernel_matrix(algorithm='pari')
             sage: result[0]
             'computed-pari-int'
@@ -2485,7 +2487,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: A*X.transpose() == zero_matrix(ZZ, 4, 2)
             True
 
-            sage: result = A._right_kernel_matrix(algorithm='padic')
+            sage: result = A._right_kernel_matrix(algorithm='padic')                        # needs sage.libs.linbox
             sage: result[0]
             'computed-iml-int'
             sage: X = result[1]; X
@@ -3564,6 +3566,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: matrix(ZZ, 4, 6, 0)._rank_linbox()
             0
             sage: matrix(ZZ, 3, 4, range(12))._rank_linbox()
@@ -3645,6 +3648,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         ::
 
+            sage: # needs sage.libs.linbox
             sage: A = matrix(ZZ,5,[1,2,3,4,5,4,6,3,2,1,7,9,7,5,2,1,4,6,7,8,3,2,4,6,7])
             sage: A.determinant(algorithm='linbox')
             Traceback (most recent call last):
@@ -3658,13 +3662,13 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Try the other algorithms on the same example::
 
-            sage: A._clear_cache(); A.determinant(algorithm='padic')
+            sage: A._clear_cache(); A.determinant(algorithm='padic')                    # needs sage.libs.linbox
             -21
-            sage: A._clear_cache(); A.determinant(algorithm='pari')
+            sage: A._clear_cache(); A.determinant(algorithm='pari')                     # needs sage.libs.pari
             -21
             sage: A._clear_cache(); A.determinant(algorithm='ntl')
             -21
-            sage: A._clear_cache(); A.determinant(algorithm='padic')
+            sage: A._clear_cache(); A.determinant(algorithm='padic')                    # needs sage.libs.linbox
             -21
 
         A bigger example::
@@ -3688,6 +3692,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Check consistency::
 
+            sage: # needs sage.libs.linbox sage.libs.pari
             sage: all(matrix(ZZ, 0).det(algorithm=algo).is_one() for algo in ['flint', 'padic', 'pari', 'ntl'])
             True
             sage: for _ in range(100):
@@ -3754,7 +3759,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         TESTS::
 
-            sage: matrix(ZZ, 0)._det_linbox()
+            sage: matrix(ZZ, 0)._det_linbox()                                           # needs sage.libs.linbox
             1
         """
         from .matrix_integer_linbox import _det_linbox
@@ -3771,6 +3776,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: matrix(ZZ, 0)._det_pari()
             1
             sage: matrix(ZZ, 0)._det_pari(1)
@@ -3789,6 +3795,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.ntl
             sage: matrix(ZZ, 0)._det_ntl()
             1
             sage: matrix(ZZ, 3, [1..9])._det_ntl()

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -69,7 +69,6 @@ from sage.libs.gmp.mpz cimport *
 
 from sage.modules.vector_integer_dense cimport Vector_integer_dense
 
-from sage.misc.timing import cputime
 from sage.misc.verbose import verbose, get_verbose
 
 from sage.arith.misc import previous_prime
@@ -1475,28 +1474,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
             [-310 -328]
             [-463 -490]
         """
-        cdef Integer h
-        cdef Matrix_integer_dense left = <Matrix_integer_dense>self
-        cdef int i, k
-
-        nr = left._nrows
-        nc = right._ncols
-
-        cdef Matrix_integer_dense result
-
-        h = left.height() * right.height() * left.ncols()
-        verbose('multiplying matrices of height %s and %s'%(left.height(),right.height()))
-        mm = MultiModularBasis(h)
-        res = left._reduce(mm)
-        res_right = right._reduce(mm)
-        k = len(mm)
-        for i in range(k):  # yes, I could do this with zip, but to conserve memory...
-            t = cputime()
-            res[i] *= res_right[i]
-            verbose('multiplied matrices modulo a prime (%s/%s)'%(i+1,k), t)
-        result = left.new_matrix(nr,nc)
-        _lift_crt(result, res, mm)  # changes result
-        return result
+        from .matrix_integer_linbox import _multiply_multi_modular
+        return _multiply_multi_modular(self, right)
 
     def _mod_int(self, modulus):
         """
@@ -5818,105 +5797,3 @@ cdef _clear_columns(Matrix_integer_dense A, pivots, Py_ssize_t n):
     fmpz_clear(c)
     fmpz_clear(t)
     sig_off()
-
-
-cpdef _lift_crt(Matrix_integer_dense M, residues, moduli=None):
-    """
-    INPUT:
-
-    - ``M`` -- a ``Matrix_integer_dense``; will be modified to hold
-      the output
-
-    - ``residues`` -- list of ``Matrix_modn_dense_template``; the
-      matrix to reconstruct modulo primes
-
-    OUTPUT: the matrix whose reductions modulo primes are the input ``residues``
-
-    TESTS::
-
-        sage: from sage.matrix.matrix_integer_dense import _lift_crt
-        sage: T1 = Matrix(Zmod(5), 4, 4, [1, 4, 4, 0, 2, 0, 1, 4, 2, 0, 4, 1, 1, 4, 0, 3])
-        sage: T2 = Matrix(Zmod(7), 4, 4, [1, 4, 6, 0, 2, 0, 1, 2, 4, 0, 6, 6, 1, 6, 0, 5])
-        sage: T3 = Matrix(Zmod(11), 4, 4, [1, 4, 10, 0, 2, 0, 1, 9, 8, 0, 10, 6, 1, 10, 0, 9])
-        sage: _lift_crt(Matrix(ZZ, 4, 4), [T1, T2, T3])
-        [ 1  4 -1  0]
-        [ 2  0  1  9]
-        [-3  0 -1  6]
-        [ 1 -1  0 -2]
-
-        sage: from sage.arith.multi_modular import MultiModularBasis
-        sage: mm = MultiModularBasis([5,7,11])
-        sage: _lift_crt(Matrix(ZZ, 4, 4), [T1, T2, T3], mm)
-        [ 1  4 -1  0]
-        [ 2  0  1  9]
-        [-3  0 -1  6]
-        [ 1 -1  0 -2]
-
-    The modulus must be smaller than the maximum for the multi-modular
-    reconstruction (using ``mod_int``) and also smaller than the limit
-    for ``Matrix_modn_dense_double`` to be able to represent the
-    ``residues`` ::
-
-        sage: from sage.arith.multi_modular import MAX_MODULUS as MAX_multi_modular
-        sage: from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_modn_dense_double
-        sage: MAX_MODULUS = min(MAX_multi_modular, MAX_modn_dense_double)
-        sage: p0 = previous_prime(MAX_MODULUS)
-        sage: p1 = previous_prime(p0)
-        sage: mmod = [matrix(GF(p0), [[-1, 0, 1, 0, 0, 1, 1, 0, 0, 0, p0-1, p0-2]]),
-        ....:         matrix(GF(p1), [[-1, 0, 1, 0, 0, 1, 1, 0, 0, 0, p1-1, p1-2]])]
-        sage: _lift_crt(Matrix(ZZ, 1, 12), mmod)
-        [-1  0  1  0  0  1  1  0  0  0 -1 -2]
-    """
-
-    cdef size_t i, j, k
-    cdef Py_ssize_t nr, n
-    cdef mpz_t *tmp = <mpz_t *>sig_malloc(sizeof(mpz_t) * M._ncols)
-    n = len(residues)
-    if n == 0:   # special case: obviously residues[0] wouldn't make sense here.
-        return M
-    nr = residues[0].nrows()
-    nc = residues[0].ncols()
-
-    if moduli is None:
-        moduli = MultiModularBasis([m.base_ring().order() for m in residues])
-    else:
-        if len(residues) != len(moduli):
-            raise IndexError("Number of residues (%s) does not match number of moduli (%s)"%(len(residues), len(moduli)))
-
-    cdef MultiModularBasis mm
-    mm = moduli
-
-    for b in residues:
-        if not (isinstance(b, Matrix_modn_dense_float) or
-                isinstance(b, Matrix_modn_dense_double)):
-            raise TypeError("Can only perform CRT on list of matrices mod n.")
-
-    cdef mod_int **row_list
-    row_list = <mod_int**>sig_malloc(sizeof(mod_int*) * n)
-    if row_list == NULL:
-        raise MemoryError("out of memory allocating multi-modular coefficient list")
-
-    sig_on()
-    for k in range(n):
-        row_list[k] = <mod_int *>sig_malloc(sizeof(mod_int) * nc)
-        if row_list[k] == NULL:
-            raise MemoryError("out of memory allocating multi-modular coefficient list")
-
-    for j in range(M._ncols):
-        mpz_init(tmp[j])
-
-    for i in range(nr):
-        for k in range(n):
-            (<Matrix_modn_dense_template>residues[k])._copy_row_to_mod_int_array(row_list[k],i)
-        mm.mpz_crt_vec(tmp, row_list, nc)
-        for j in range(nc):
-            M.set_unsafe_mpz(i,j,tmp[j])
-
-    for k in range(n):
-        sig_free(row_list[k])
-    for j in range(M._ncols):
-        mpz_clear(tmp[j])
-    sig_free(row_list)
-    sig_free(tmp)
-    sig_off()
-    return M

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -3537,16 +3537,26 @@ cdef class Matrix_integer_dense(Matrix_dense):
             return r
         elif algorithm == 'modp':
             # Can very quickly detect full rank by working modulo p.
-            r = self._rank_modp()
-            if r == self._nrows or r == self._ncols:
-                self.cache('rank', r)
-                return r
+            try:
+                r = self._rank_modp()
+            except ImportError:
+                pass
+            else:
+                if r == self._nrows or r == self._ncols:
+                    self.cache('rank', r)
+                    return r
         # Algorithm is 'linbox' or detecting full rank didn't work --
         # use LinBox's general algorithm.
-        from .matrix_integer_linbox import _rank_linbox
-        r = _rank_linbox(self)
-        self.cache('rank', r)
-        return r
+        try:
+            from .matrix_integer_linbox import _rank_linbox
+        except ImportError:
+            pass
+        else:
+            r = _rank_linbox(self)
+            self.cache('rank', r)
+            return r
+        # Fall back to generic
+        return Matrix.rank(self)
 
     def _rank_linbox(self):
         """

--- a/src/sage/matrix/matrix_integer_dense_hnf.py
+++ b/src/sage/matrix/matrix_integer_dense_hnf.py
@@ -368,7 +368,8 @@ def solve_system_with_difficult_last_row(B, a):
     # 3. We next delete the last row of B and find a basis vector k
     #    for the 1-dimensional kernel.
     D = B.matrix_from_rows(range(C.nrows()-1))
-    N = D._rational_kernel_iml()
+    from .matrix_integer_iml import _rational_kernel_iml
+    N = _rational_kernel_iml(D)
     if N.ncols() != 1:
         verbose("Try difficult solve again with different random vector")
         return solve_system_with_difficult_last_row(B, a)

--- a/src/sage/matrix/matrix_integer_dense_hnf.py
+++ b/src/sage/matrix/matrix_integer_dense_hnf.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 """
 Modular algorithm to compute Hermite normal forms of integer matrices
 

--- a/src/sage/matrix/matrix_integer_dense_saturation.py
+++ b/src/sage/matrix/matrix_integer_dense_saturation.py
@@ -56,7 +56,7 @@ def p_saturation(A, p, proof=True):
             try:
                 # Faster than change_ring
                 A = H._reduce(p)
-            except OverflowError:
+            except (OverflowError, ImportError):
                 # fall back to generic GF(p) matrices
                 A = H.change_ring(GF(p))
         assert A.nrows() <= A.ncols()

--- a/src/sage/matrix/matrix_integer_dense_saturation.py
+++ b/src/sage/matrix/matrix_integer_dense_saturation.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 """
 Saturation over ZZ
 """

--- a/src/sage/matrix/matrix_integer_iml.pyx
+++ b/src/sage/matrix/matrix_integer_iml.pyx
@@ -1,0 +1,314 @@
+# sage_setup: distribution = sagemath-linbox
+# distutils: libraries = iml
+
+from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
+from cysignals.memory cimport sig_malloc, sig_free, check_allocarray
+
+from sage.libs.flint.fmpz cimport *
+from sage.libs.flint.fmpz_mat cimport *
+from sage.libs.gmp.mpz cimport *
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.misc.verbose import verbose
+from sage.rings.integer cimport Integer
+
+
+########## iml -- integer matrix library ###########
+from sage.libs.iml cimport *
+
+def _rational_kernel_iml(Matrix_integer_dense self):
+    """
+    Return the rational (left) kernel of this matrix.
+
+    OUTPUT:
+
+    A matrix ``K`` such that ``self * K = 0``, and the number of columns of
+    K equals the nullity of ``self``.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_iml import _rational_kernel_iml
+        sage: m = matrix(ZZ, 5, 5, [1+i+i^2 for i in range(25)])
+        sage: _rational_kernel_iml(m)
+        [ 1  3]
+        [-3 -8]
+        [ 3  6]
+        [-1  0]
+        [ 0 -1]
+
+        sage: V1 = _rational_kernel_iml(m).column_space().change_ring(QQ)
+        sage: V2 = m._rational_kernel_flint().column_space().change_ring(QQ)
+        sage: assert V1 == V2
+    """
+    if self._nrows == 0 or self._ncols == 0:
+        return self.matrix_space(self._ncols, 0).zero_matrix()
+
+    cdef long dim
+    cdef unsigned long i,j,k
+    cdef mpz_t *mp_N
+    time = verbose('computing null space of %s x %s matrix using IML'%(self._nrows, self._ncols))
+    cdef mpz_t * m = fmpz_mat_to_mpz_array(self._matrix)
+    sig_on()
+    dim = nullspaceMP(self._nrows, self._ncols, m, &mp_N)
+    sig_off()
+    # Now read the answer as a matrix.
+    cdef Matrix_integer_dense M
+    M = self._new(self._ncols, dim)
+    k = 0
+    for i in range(self._ncols):
+        for j in range(dim):
+            fmpz_set_mpz(fmpz_mat_entry(M._matrix, i, j), mp_N[k])
+            k += 1
+    mpz_array_clear(m, self._nrows * self._ncols)
+    mpz_array_clear(mp_N, dim * self._ncols)
+    verbose("finished computing null space", time)
+    return M
+
+
+def _invert_iml(Matrix_integer_dense self, use_nullspace=False, check_invertible=True):
+    """
+    Invert this matrix using IML. The output matrix is an integer
+    matrix and a denominator.
+
+    INPUT:
+
+    - ``self`` -- an invertible matrix
+
+    - ``use_nullspace`` -- boolean (default: ``False``); whether to
+      use nullspace algorithm, which is slower, but doesn't require
+      checking that the matrix is invertible as a precondition
+
+    - ``check_invertible`` -- boolean (default: ``True``); whether to
+      check that the matrix is invertible
+
+    OUTPUT: `A`, `d` such that ``A*self == d``
+
+    - ``A`` -- a matrix over ZZ
+
+    - ``d`` -- integer
+
+    ALGORITHM: Uses IML's `p`-adic nullspace function.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_iml import _invert_iml
+        sage: a = matrix(ZZ,3,[1,2,5, 3,7,8, 2,2,1])
+        sage: b, d = _invert_iml(a); b,d
+        (
+        [  9  -8  19]
+        [-13   9  -7]
+        [  8  -2  -1], 23
+        )
+        sage: a*b
+        [23  0  0]
+        [ 0 23  0]
+        [ 0  0 23]
+
+    AUTHORS:
+
+    - William Stein
+    """
+    if self._nrows != self._ncols:
+        raise TypeError("self must be a square matrix.")
+
+    P = self.parent()
+    time = verbose('computing inverse of %s x %s matrix using IML'%(self._nrows, self._ncols))
+    if use_nullspace:
+        A = self.augment(P.identity_matrix())
+        K = A._rational_kernel_iml()
+        d = -K[self._nrows,0]
+        if K.ncols() != self._ncols or d == 0:
+            raise ZeroDivisionError("input matrix must be nonsingular")
+        B = K[:self._nrows]
+        verbose("finished computing inverse using IML", time)
+        return B, d
+    else:
+        if check_invertible and self.rank() != self._nrows:
+            raise ZeroDivisionError("input matrix must be nonsingular")
+        return _solve_iml(self, P.identity_matrix(), right=True)
+
+
+def _solve_iml(Matrix_integer_dense self, Matrix_integer_dense B, right=True):
+    """
+    Let A equal ``self`` be a square matrix. Given B return an integer
+    matrix C and an integer d such that ``self`` ``C*A == d*B`` if right is
+    False or ``A*C == d*B`` if right is True.
+
+    OUTPUT:
+
+    - ``C`` -- integer matrix
+
+    - ``d`` -- integer denominator
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_iml import _solve_iml
+        sage: A = matrix(ZZ,4,4,[0, 1, -2, -1, -1, 1, 0, 2, 2, 2, 2, -1, 0, 2, 2, 1])
+        sage: B = matrix(ZZ,3,4, [-1, 1, 1, 0, 2, 0, -2, -1, 0, -2, -2, -2])
+        sage: C, d = _solve_iml(A, B, right=False); C
+        [  6 -18 -15  27]
+        [  0  24  24 -36]
+        [  4 -12  -6  -2]
+
+    ::
+
+        sage: d
+        12
+
+    ::
+
+        sage: C*A == d*B
+        True
+
+    ::
+
+        sage: A = matrix(ZZ,4,4,[0, 1, -2, -1, -1, 1, 0, 2, 2, 2, 2, -1, 0, 2, 2, 1])
+        sage: B = matrix(ZZ,4,3, [-1, 1, 1, 0, 2, 0, -2, -1, 0, -2, -2, -2])
+        sage: C, d = _solve_iml(A, B)
+        sage: C
+        [ 12  40  28]
+        [-12  -4  -4]
+        [ -6 -25 -16]
+        [ 12  34  16]
+
+    ::
+
+        sage: d
+        12
+
+    ::
+
+        sage: A*C == d*B
+        True
+
+    Test wrong dimensions::
+
+        sage: A = random_matrix(ZZ, 4, 4)
+        sage: B = random_matrix(ZZ, 2, 3)
+        sage: _solve_iml(B, A)
+        Traceback (most recent call last):
+        ...
+        ValueError: self must be a square matrix
+        sage: _solve_iml(A, B, right=False)
+        Traceback (most recent call last):
+        ...
+        ArithmeticError: B's number of columns must match self's number of rows
+        sage: _solve_iml(A, B, right=True)
+        Traceback (most recent call last):
+        ...
+        ArithmeticError: B's number of rows must match self's number of columns
+
+    Check that this can be interrupted properly (:issue:`15453`)::
+
+        sage: A = random_matrix(ZZ, 2000, 2000)
+        sage: B = random_matrix(ZZ, 2000, 2000)
+        sage: t0 = walltime()
+        sage: alarm(2); _solve_iml(A, B)  # long time
+        Traceback (most recent call last):
+        ...
+        AlarmInterrupt
+        sage: t = walltime(t0)
+        sage: t < 10 or t
+        True
+
+    ALGORITHM: Uses IML.
+
+    AUTHORS:
+
+    - Martin Albrecht
+    """
+    cdef unsigned long i, j, k
+    cdef mpz_t *mp_N
+    cdef mpz_t mp_D
+    cdef Matrix_integer_dense M
+    cdef Integer D
+
+    if self._nrows != self._ncols:
+        # This is *required* by the IML function we call below.
+        raise ValueError("self must be a square matrix")
+
+    if self._nrows == 1:
+        return B, self[0,0]
+
+    cdef SOLU_POS solu_pos
+
+    if right:
+        if self._ncols != B._nrows:
+            raise ArithmeticError("B's number of rows must match self's number of columns")
+
+        n = self._ncols
+        m = B._ncols
+
+        P = self.matrix_space(n, m)
+        if self._nrows == 0 or self._ncols == 0:
+            return P.zero_matrix(), Integer(1)
+
+        if m == 0 or n == 0:
+            return self.new_matrix(nrows = n, ncols = m), Integer(1)
+
+        solu_pos = RightSolu
+
+    else: # left
+        if self._nrows != B._ncols:
+            raise ArithmeticError("B's number of columns must match self's number of rows")
+
+        n = self._ncols
+        m = B._nrows
+
+        P = self.matrix_space(m, n)
+        if self._nrows == 0 or self._ncols == 0:
+            return P.zero_matrix(), Integer(1)
+
+        if m == 0 or n == 0:
+            return self.new_matrix(nrows = m, ncols = n), Integer(1)
+
+        solu_pos = LeftSolu
+
+    sig_check()
+    verbose("Initializing mp_N and mp_D")
+    mp_N = <mpz_t *> sig_malloc( n * m * sizeof(mpz_t) )
+    for i in range(n * m):
+        mpz_init(mp_N[i])
+    mpz_init(mp_D)
+    verbose("Done with initializing mp_N and mp_D")
+    cdef mpz_t * mself = fmpz_mat_to_mpz_array(self._matrix)
+    cdef mpz_t * mB = fmpz_mat_to_mpz_array(B._matrix)
+    try:
+        verbose('Calling solver n = %s, m = %s'%(n,m))
+        sig_on()
+        nonsingSolvLlhsMM(solu_pos, n, m, mself, mB, mp_N, mp_D)
+        sig_off()
+        M = self._new(P.nrows(), P.ncols())
+        k = 0
+        for i from 0 <= i < M._nrows:
+            for j from 0 <= j < M._ncols:
+                fmpz_set_mpz(fmpz_mat_entry(M._matrix,i,j), mp_N[k])
+                k += 1
+        D = Integer.__new__(Integer)
+        mpz_set(D.value, mp_D)
+        return M, D
+    finally:
+        mpz_clear(mp_D)
+        mpz_array_clear(mself, self.nrows() * self.ncols())
+        mpz_array_clear(mB, B.nrows() * B.ncols())
+        mpz_array_clear(mp_N, n*m)
+
+
+cdef inline mpz_t * fmpz_mat_to_mpz_array(fmpz_mat_t m) except? NULL:
+    cdef mpz_t * entries = <mpz_t *>check_allocarray(fmpz_mat_nrows(m), sizeof(mpz_t) * fmpz_mat_ncols(m))
+    cdef size_t i, j
+    cdef size_t k = 0
+    sig_on()
+    for i in range(fmpz_mat_nrows(m)):
+        for j in range(fmpz_mat_ncols(m)):
+            mpz_init(entries[k])
+            fmpz_get_mpz(entries[k], fmpz_mat_entry(m, i, j))
+            k += 1
+    sig_off()
+    return entries
+
+
+cdef inline void mpz_array_clear(mpz_t * a, size_t length) noexcept:
+    cdef size_t i
+    for i in range(length):
+        mpz_clear(a[i])
+    sig_free(a)

--- a/src/sage/matrix/matrix_integer_linbox.pxd
+++ b/src/sage/matrix/matrix_integer_linbox.pxd
@@ -1,0 +1,5 @@
+# sage_setup: distribution = sagemath-linbox
+
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+
+cpdef _lift_crt(Matrix_integer_dense M, residues, moduli=*)

--- a/src/sage/matrix/matrix_integer_linbox.pyx
+++ b/src/sage/matrix/matrix_integer_linbox.pyx
@@ -1,0 +1,119 @@
+# sage_setup: distribution = sagemath-linbox
+
+from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
+
+from sage.ext.stdsage cimport PY_NEW
+from sage.libs.flint.fmpz cimport *
+from sage.libs.flint.fmpz_mat cimport *
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.rings.integer cimport Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+
+######### linbox interface ##########
+from sage.libs.linbox.linbox_flint_interface cimport *
+
+
+def _multiply_linbox(Matrix_integer_dense self, Matrix_integer_dense right):
+    """
+    Multiply matrices over ZZ using linbox.
+
+    .. WARNING::
+
+       This is very slow right now, i.e., linbox is very slow.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_linbox import _multiply_linbox
+        sage: A = matrix(ZZ, 2, 3, range(6))
+        sage: A * A.transpose()
+        [ 5 14]
+        [14 50]
+        sage: _multiply_linbox(A, A.transpose())
+        [ 5 14]
+        [14 50]
+
+    TESTS:
+
+    This fixes a bug found in :issue:`17094`::
+
+        sage: A = identity_matrix(ZZ, 3)
+        sage: _multiply_linbox(A, A)
+        [1 0 0]
+        [0 1 0]
+        [0 0 1]
+    """
+    cdef Matrix_integer_dense ans
+    cdef Matrix_integer_dense left = <Matrix_integer_dense> self
+
+    ans = self._new(left._nrows, right._ncols)
+
+    sig_on()
+    linbox_fmpz_mat_mul(ans._matrix, left._matrix, right._matrix)
+    sig_off()
+
+    return ans
+
+
+def _charpoly_linbox(Matrix_integer_dense self, var):
+    g = (<Polynomial_integer_dense_flint> PolynomialRing(ZZ, names=var).gen())._new()
+    sig_on()
+    linbox_fmpz_mat_charpoly(g._poly, self._matrix)
+    sig_off()
+    return g
+
+
+def _minpoly_linbox(Matrix_integer_dense self, var):
+    g = (<Polynomial_integer_dense_flint> PolynomialRing(ZZ, names=var).gen())._new()
+    sig_on()
+    linbox_fmpz_mat_minpoly(g._poly, self._matrix)
+    sig_off()
+    return g
+
+
+def _rank_linbox(Matrix_integer_dense self):
+    """
+    Compute the rank of this matrix using Linbox.
+
+    TESTS::
+
+        sage: from sage.matrix.matrix_integer_linbox import _rank_linbox
+        sage: _rank_linbox(matrix(ZZ, 4, 6, 0))
+        0
+        sage: _rank_linbox(matrix(ZZ, 3, 4, range(12)))
+        2
+        sage: _rank_linbox(matrix(ZZ, 5, 10, [1+i+i^2 for i in range(50)]))
+        3
+    """
+    sig_on()
+    cdef size_t r = linbox_fmpz_mat_rank(self._matrix)
+    sig_off()
+    return Integer(r)
+
+
+def _det_linbox(Matrix_integer_dense self):
+    """
+    Compute the determinant of this matrix using Linbox.
+
+    TESTS::
+
+        sage: from sage.matrix.matrix_integer_linbox import _det_linbox
+        sage: _det_linbox(matrix(ZZ, 0))
+        1
+    """
+    if self._nrows != self._ncols:
+        raise ArithmeticError("self must be a square matrix")
+    if self._nrows == 0:
+        return ZZ.one()
+
+    cdef fmpz_t tmp
+    fmpz_init(tmp)
+    sig_on()
+    linbox_fmpz_mat_det(tmp, self._matrix)
+    sig_off()
+
+    cdef Integer ans = PY_NEW(Integer)
+    fmpz_get_mpz(ans.value, tmp)
+    fmpz_clear(tmp)
+    return ans

--- a/src/sage/matrix/matrix_integer_linbox.pyx
+++ b/src/sage/matrix/matrix_integer_linbox.pyx
@@ -2,10 +2,17 @@
 
 from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
 
+import sage.matrix.matrix_space as matrix_space
+
+from sage.ext.mod_int cimport *
 from sage.ext.stdsage cimport PY_NEW
 from sage.libs.flint.fmpz cimport *
 from sage.libs.flint.fmpz_mat cimport *
 from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.matrix.matrix_modn_dense_float cimport Matrix_modn_dense_template
+from sage.matrix.matrix_modn_dense_float cimport Matrix_modn_dense_float
+from sage.matrix.matrix_modn_dense_double cimport Matrix_modn_dense_double
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
@@ -117,3 +124,33 @@ def _det_linbox(Matrix_integer_dense self):
     fmpz_get_mpz(ans.value, tmp)
     fmpz_clear(tmp)
     return ans
+
+
+def _Matrix_modn_dense_float(Matrix_integer_dense self, mod_int p):
+    cdef Py_ssize_t i, j
+
+    cdef float* res_row_f
+    cdef Matrix_modn_dense_float res_f
+
+    res_f = Matrix_modn_dense_float.__new__(Matrix_modn_dense_float,
+                                            matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False), None, None, None, zeroed_alloc=False)
+    for i from 0 <= i < self._nrows:
+        res_row_f = res_f._matrix[i]
+        for j from 0 <= j < self._ncols:
+            res_row_f[j] = <float>fmpz_fdiv_ui(fmpz_mat_entry(self._matrix,i,j), p)
+    return res_f
+
+
+def _Matrix_modn_dense_double(Matrix_integer_dense self, mod_int p):
+    cdef Py_ssize_t i, j
+
+    cdef double* res_row_d
+    cdef Matrix_modn_dense_double res_d
+
+    res_d = Matrix_modn_dense_double.__new__(Matrix_modn_dense_double,
+                                             matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False), None, None, None, zeroed_alloc=False)
+    for i from 0 <= i < self._nrows:
+        res_row_d = res_d._matrix[i]
+        for j from 0 <= j < self._ncols:
+            res_row_d[j] = <double>fmpz_fdiv_ui(fmpz_mat_entry(self._matrix,i,j), p)
+    return res_d

--- a/src/sage/matrix/matrix_integer_linbox.pyx
+++ b/src/sage/matrix/matrix_integer_linbox.pyx
@@ -1,17 +1,22 @@
 # sage_setup: distribution = sagemath-linbox
 
 from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
+from cysignals.memory cimport sig_malloc, sig_free, check_allocarray
 
 import sage.matrix.matrix_space as matrix_space
 
+from sage.arith.multi_modular cimport MultiModularBasis
 from sage.ext.mod_int cimport *
 from sage.ext.stdsage cimport PY_NEW
 from sage.libs.flint.fmpz cimport *
 from sage.libs.flint.fmpz_mat cimport *
+from sage.libs.gmp.mpz cimport *
 from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
 from sage.matrix.matrix_modn_dense_float cimport Matrix_modn_dense_template
 from sage.matrix.matrix_modn_dense_float cimport Matrix_modn_dense_float
 from sage.matrix.matrix_modn_dense_double cimport Matrix_modn_dense_double
+from sage.misc.timing import cputime
+from sage.misc.verbose import verbose
 from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring import ZZ
@@ -154,3 +159,144 @@ def _Matrix_modn_dense_double(Matrix_integer_dense self, mod_int p):
         for j from 0 <= j < self._ncols:
             res_row_d[j] = <double>fmpz_fdiv_ui(fmpz_mat_entry(self._matrix,i,j), p)
     return res_d
+
+
+def _multiply_multi_modular(Matrix_integer_dense self, Matrix_integer_dense right):
+    """
+    Multiply this matrix by ``left`` using a multi modular algorithm.
+
+    EXAMPLES::
+
+        sage: M = Matrix(ZZ, 2, 3, range(5,11))
+        sage: N = Matrix(ZZ, 3, 2, range(15,21))
+        sage: M._multiply_multi_modular(N)
+        [310 328]
+        [463 490]
+        sage: M._multiply_multi_modular(-N)
+        [-310 -328]
+        [-463 -490]
+    """
+    cdef Integer h
+    cdef Matrix_integer_dense left = <Matrix_integer_dense>self
+    cdef int i, k
+
+    nr = left._nrows
+    nc = right._ncols
+
+    cdef Matrix_integer_dense result
+
+    h = left.height() * right.height() * left.ncols()
+    verbose('multiplying matrices of height %s and %s'%(left.height(),right.height()))
+    mm = MultiModularBasis(h)
+    res = left._reduce(mm)
+    res_right = right._reduce(mm)
+    k = len(mm)
+    for i in range(k):  # yes, I could do this with zip, but to conserve memory...
+        t = cputime()
+        res[i] *= res_right[i]
+        verbose('multiplied matrices modulo a prime (%s/%s)'%(i+1,k), t)
+    result = left.new_matrix(nr,nc)
+    _lift_crt(result, res, mm)  # changes result
+    return result
+
+
+cpdef _lift_crt(Matrix_integer_dense M, residues, moduli=None):
+    """
+    INPUT:
+
+    - ``M`` -- a ``Matrix_integer_dense``; will be modified to hold
+      the output
+
+    - ``residues`` -- list of ``Matrix_modn_dense_template``; the
+      matrix to reconstruct modulo primes
+
+    OUTPUT: the matrix whose reductions modulo primes are the input ``residues``
+
+    TESTS::
+
+        sage: from sage.matrix.matrix_integer_linbox import _lift_crt
+        sage: T1 = Matrix(Zmod(5), 4, 4, [1, 4, 4, 0, 2, 0, 1, 4, 2, 0, 4, 1, 1, 4, 0, 3])
+        sage: T2 = Matrix(Zmod(7), 4, 4, [1, 4, 6, 0, 2, 0, 1, 2, 4, 0, 6, 6, 1, 6, 0, 5])
+        sage: T3 = Matrix(Zmod(11), 4, 4, [1, 4, 10, 0, 2, 0, 1, 9, 8, 0, 10, 6, 1, 10, 0, 9])
+        sage: _lift_crt(Matrix(ZZ, 4, 4), [T1, T2, T3])
+        [ 1  4 -1  0]
+        [ 2  0  1  9]
+        [-3  0 -1  6]
+        [ 1 -1  0 -2]
+
+        sage: from sage.arith.multi_modular import MultiModularBasis
+        sage: mm = MultiModularBasis([5,7,11])
+        sage: _lift_crt(Matrix(ZZ, 4, 4), [T1, T2, T3], mm)
+        [ 1  4 -1  0]
+        [ 2  0  1  9]
+        [-3  0 -1  6]
+        [ 1 -1  0 -2]
+
+    The modulus must be smaller than the maximum for the multi-modular
+    reconstruction (using ``mod_int``) and also smaller than the limit
+    for ``Matrix_modn_dense_double`` to be able to represent the
+    ``residues`` ::
+
+        sage: from sage.arith.multi_modular import MAX_MODULUS as MAX_multi_modular
+        sage: from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_modn_dense_double
+        sage: MAX_MODULUS = min(MAX_multi_modular, MAX_modn_dense_double)
+        sage: p0 = previous_prime(MAX_MODULUS)
+        sage: p1 = previous_prime(p0)
+        sage: mmod = [matrix(GF(p0), [[-1, 0, 1, 0, 0, 1, 1, 0, 0, 0, p0-1, p0-2]]),
+        ....:         matrix(GF(p1), [[-1, 0, 1, 0, 0, 1, 1, 0, 0, 0, p1-1, p1-2]])]
+        sage: _lift_crt(Matrix(ZZ, 1, 12), mmod)
+        [-1  0  1  0  0  1  1  0  0  0 -1 -2]
+    """
+
+    cdef size_t i, j, k
+    cdef Py_ssize_t nr, n
+    cdef mpz_t *tmp = <mpz_t *>sig_malloc(sizeof(mpz_t) * M._ncols)
+    n = len(residues)
+    if n == 0:   # special case: obviously residues[0] wouldn't make sense here.
+        return M
+    nr = residues[0].nrows()
+    nc = residues[0].ncols()
+
+    if moduli is None:
+        moduli = MultiModularBasis([m.base_ring().order() for m in residues])
+    else:
+        if len(residues) != len(moduli):
+            raise IndexError("Number of residues (%s) does not match number of moduli (%s)"%(len(residues), len(moduli)))
+
+    cdef MultiModularBasis mm
+    mm = moduli
+
+    for b in residues:
+        if not (isinstance(b, Matrix_modn_dense_float) or
+                isinstance(b, Matrix_modn_dense_double)):
+            raise TypeError("Can only perform CRT on list of matrices mod n.")
+
+    cdef mod_int **row_list
+    row_list = <mod_int**>sig_malloc(sizeof(mod_int*) * n)
+    if row_list == NULL:
+        raise MemoryError("out of memory allocating multi-modular coefficient list")
+
+    sig_on()
+    for k in range(n):
+        row_list[k] = <mod_int *>sig_malloc(sizeof(mod_int) * nc)
+        if row_list[k] == NULL:
+            raise MemoryError("out of memory allocating multi-modular coefficient list")
+
+    for j in range(M._ncols):
+        mpz_init(tmp[j])
+
+    for i in range(nr):
+        for k in range(n):
+            (<Matrix_modn_dense_template>residues[k])._copy_row_to_mod_int_array(row_list[k],i)
+        mm.mpz_crt_vec(tmp, row_list, nc)
+        for j in range(nc):
+            M.set_unsafe_mpz(i,j,tmp[j])
+
+    for k in range(n):
+        sig_free(row_list[k])
+    for j in range(M._ncols):
+        mpz_clear(tmp[j])
+    sig_free(row_list)
+    sig_free(tmp)
+    sig_off()
+    return M

--- a/src/sage/matrix/matrix_integer_pari.pyx
+++ b/src/sage/matrix/matrix_integer_pari.pyx
@@ -1,0 +1,186 @@
+# sage_setup: distribution = sagemath-linbox
+
+from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
+
+from sage.libs.flint.fmpz cimport *
+from sage.libs.flint.fmpz_mat cimport *
+from sage.libs.gmp.mpz cimport *
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.rings.integer cimport Integer
+from sage.rings.integer_ring import ZZ
+
+# PARI C library
+from cypari2.gen cimport Gen
+from cypari2.stack cimport clear_stack, new_gen
+from cypari2.paridecl cimport *
+from sage.libs.pari import pari
+from sage.libs.pari.convert_gmp cimport INT_to_mpz
+from sage.libs.pari.convert_flint cimport (_new_GEN_from_fmpz_mat_t,
+           _new_GEN_from_fmpz_mat_t_rotate90, integer_matrix)
+from sage.libs.pari.convert_sage_matrix import gen_to_sage_matrix
+
+
+def _pari(Matrix_integer_dense self):
+    return integer_matrix(self._matrix, 0)
+
+
+def _det_pari(Matrix_integer_dense self, int flag=0):
+    """
+    Determinant of this matrix using Gauss-Bareiss. If (optional)
+    flag is set to 1, use classical Gaussian elimination.
+
+    For efficiency purposes, this det is computed entirely on the
+    PARI stack then the PARI stack is cleared. This function is
+    most useful for very small matrices.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_pari import _det_pari
+        sage: _det_pari(matrix(ZZ, 0))
+        1
+        sage: _det_pari(matrix(ZZ, 0), 1)
+        1
+        sage: _det_pari(matrix(ZZ, 3, [1..9]))
+        0
+        sage: _det_pari(matrix(ZZ, 3, [1..9]), 1)
+        0
+    """
+    sig_on()
+    cdef GEN d = det0(pari_GEN(self), flag)
+    # now convert d to a Sage integer e
+    cdef Integer e = Integer.__new__(Integer)
+    INT_to_mpz(e.value, d)
+    clear_stack()
+    return e
+
+
+def _lll_pari(Matrix_integer_dense self):
+    # call pari with flag=4: kernel+image
+    # pari uses column convention: need to transpose the matrices
+    A = integer_matrix(self._matrix, 1)
+    K, T = A.qflll(4)
+    r = ZZ(T.length())
+    # TODO: there is no optimized matrix converter pari -> sage
+    U = gen_to_sage_matrix(pari.matconcat([K, T]).mattranspose())
+    R = U * self
+    return R, U, r
+
+
+def _rank_pari(Matrix_integer_dense self):
+    """
+    Rank of this matrix, computed using PARI.  The computation is
+    done entirely on the PARI stack, then the PARI stack is
+    cleared.  This function is most useful for very small
+    matrices.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_pari import _rank_pari
+        sage: _rank_pari(matrix(ZZ,3,[1..9]))
+        2
+    """
+    sig_on()
+    cdef long r = rank(pari_GEN(self))
+    clear_stack()
+    return r
+
+
+def _hnf_pari(Matrix_integer_dense self, int flag=0, bint include_zero_rows=True):
+    """
+    Hermite normal form of this matrix, computed using PARI.
+
+    INPUT:
+
+    - ``flag`` -- 0 (default), 1, 3 or 4 (see docstring for
+      ``pari.mathnf``)
+
+    - ``include_zero_rows`` -- boolean; if ``False``, do not include
+      any of the zero rows at the bottom of the matrix in the output
+
+    .. NOTE::
+
+        In no cases is the transformation matrix returned by this
+        function.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_pari import _hnf_pari
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]))
+        [1 2 3]
+        [0 3 6]
+        [0 0 0]
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 1)
+        [1 2 3]
+        [0 3 6]
+        [0 0 0]
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 3)
+        [1 2 3]
+        [0 3 6]
+        [0 0 0]
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 4)
+        [1 2 3]
+        [0 3 6]
+        [0 0 0]
+
+    Check that ``include_zero_rows=False`` works correctly::
+
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 0, include_zero_rows=False)
+        [1 2 3]
+        [0 3 6]
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 1, include_zero_rows=False)
+        [1 2 3]
+        [0 3 6]
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 3, include_zero_rows=False)
+        [1 2 3]
+        [0 3 6]
+        sage: _hnf_pari(matrix(ZZ,3,[1..9]), 4, include_zero_rows=False)
+        [1 2 3]
+        [0 3 6]
+
+    Check that :issue:`12346` is fixed::
+
+        sage: pari('mathnf(Mat([0,1]), 4)')
+        [Mat(1), [1, 0; 0, 1]]
+    """
+    sig_on()
+    A = _new_GEN_from_fmpz_mat_t_rotate90(self._matrix)
+    H = mathnf0(A, flag)
+    if typ(H) == t_VEC:
+        H = gel(H, 1)
+    GenH = new_gen(H)
+    return extract_hnf_from_pari_matrix(self, GenH, include_zero_rows)
+
+
+cdef inline GEN pari_GEN(Matrix_integer_dense B) noexcept:
+    r"""
+    Create the PARI GEN object on the stack defined by the integer
+    matrix B. This is used internally by the function for conversion
+    of matrices to PARI.
+
+    For internal use only; this directly uses the PARI stack.
+    One should call ``sig_on()`` before and ``sig_off()`` after.
+    """
+    cdef GEN A = _new_GEN_from_fmpz_mat_t(B._matrix)
+    return A
+
+
+cdef extract_hnf_from_pari_matrix(Matrix_integer_dense self, Gen H, bint include_zero_rows):
+    cdef mpz_t tmp
+    mpz_init(tmp)
+
+    # Figure out how many columns we got back.
+    cdef long H_nc = glength(H.g)  # number of columns
+    # Now get the resulting Hermite form matrix back to Sage, suitably re-arranged.
+    cdef Matrix_integer_dense B
+    if include_zero_rows:
+        B = self.new_matrix()
+    else:
+        B = self.new_matrix(nrows=H_nc)
+    cdef long i, j
+    for i in range(self._ncols):
+        for j in range(H_nc):
+            sig_check()
+            INT_to_mpz(tmp, gcoeff(H.g, i+1, H_nc-j))
+            fmpz_set_mpz(fmpz_mat_entry(B._matrix,j,self._ncols-i-1),tmp)
+    mpz_clear(tmp)
+    return B

--- a/src/sage/matrix/matrix_integer_pari.pyx
+++ b/src/sage/matrix/matrix_integer_pari.pyx
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 
 from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
 

--- a/src/sage/matrix/matrix_integer_sparse.pyx
+++ b/src/sage/matrix/matrix_integer_sparse.pyx
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 r"""
 Sparse integer matrices
 

--- a/src/sage/matrix/matrix_integer_sparse.pyx
+++ b/src/sage/matrix/matrix_integer_sparse.pyx
@@ -673,11 +673,12 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
             sage: M = MatrixSpace(ZZ, 3, sparse=True)
             sage: m = M([1,0,1,0,2,0,2,0,2])
-            sage: m._rank_linbox()
+            sage: m._rank_linbox()                                                      # needs sage.libs.linbox
             2
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: MatrixSpace(ZZ, 0, 0, sparse=True)()._rank_linbox()
             0
             sage: MatrixSpace(ZZ, 1, 0, sparse=True)()._rank_linbox()
@@ -703,20 +704,19 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
         EXAMPLES::
 
             sage: M = MatrixSpace(ZZ, 2, 2, sparse=True)
-            sage: M([2,0,1,1])._det_linbox()
+            sage: M([2,0,1,1])._det_linbox()                                            # needs sage.libs.linbox
             2
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: MatrixSpace(ZZ, 0, 0, sparse=True)()._det_linbox()
             1
             sage: MatrixSpace(ZZ, 1, 1, sparse=True)()._det_linbox()
             0
-
             sage: m = diagonal_matrix(ZZ, [2] * 46)
             sage: m._det_linbox() == 2**46
             True
-
             sage: m = diagonal_matrix(ZZ, [3] * 100)
             sage: m._det_linbox() == 3**100
             True
@@ -754,7 +754,7 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
         TESTS::
 
-            sage: matrix(ZZ, 0, 0, sparse=True).charpoly(algorithm='linbox')
+            sage: matrix(ZZ, 0, 0, sparse=True).charpoly(algorithm='linbox')            # needs sage.libs.linbox
             1
             sage: matrix(ZZ, 0, 0, sparse=True).charpoly(algorithm='generic')
             1
@@ -787,11 +787,12 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
         EXAMPLES::
 
             sage: m = matrix(ZZ, 2, [2,1,1,1], sparse=True)
-            sage: m._charpoly_linbox()
+            sage: m._charpoly_linbox()                                                  # needs sage.libs.linbox
             x^2 - 3*x + 1
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: matrix(ZZ, 0, 0, sparse=True)._charpoly_linbox()
             1
             sage: matrix(ZZ, 1, 1, sparse=True)._charpoly_linbox()
@@ -827,7 +828,7 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
         TESTS::
 
-            sage: matrix(ZZ, 0, 0, sparse=True).minpoly(algorithm='linbox')
+            sage: matrix(ZZ, 0, 0, sparse=True).minpoly(algorithm='linbox')             # needs sage.libs.linbox
             1
             sage: matrix(ZZ, 0, 0, sparse=True).minpoly(algorithm='generic')
             1
@@ -860,11 +861,12 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
         EXAMPLES::
 
             sage: m = matrix(ZZ, 2, [2,1,1,1], sparse=True)
-            sage: m._minpoly_linbox()
+            sage: m._minpoly_linbox()                                                   # needs sage.libs.linbox
             x^2 - 3*x + 1
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: matrix(ZZ, 0, 0, sparse=True)._minpoly_linbox()
             1
             sage: matrix(ZZ, 1, 1, sparse=True)._minpoly_linbox()
@@ -976,11 +978,11 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.linbox
             sage: m = matrix(ZZ, 4, sparse=True)
             sage: m[0,0] = m[1,2] = m[2,0] = m[3,3] = 2
             sage: m[0,2] = m[1,1] = -1
             sage: m[2,3] = m[3,0] = -3
-
             sage: b0 = vector((1,1,1,1))
             sage: m._solve_vector_linbox(b0)
             ((-1, -7, -3, -1), 1)
@@ -992,7 +994,6 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             ((-1, -7, -3, -1), 1)
             sage: m._solve_vector_linbox(b0, 'blackbox')
             ((-1, -7, -3, -1), 1)
-
             sage: b1 = vector((1,2,3,4))
             sage: m._solve_vector_linbox(b1)
             ((-18, -92, -41, -17), 5)
@@ -1004,13 +1005,13 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             ((-18, -92, -41, -17), 5)
             sage: m._solve_vector_linbox(b1, 'blackbox')
             ((-18, -92, -41, -17), 5)
-
             sage: a1, d1 = m._solve_vector_linbox(b1)
             sage: d1 * b1 == m * a1
             True
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: algos = ["default", "dense_elimination", "sparse_elimination",
             ....:          "blackbox", "wiedemann"]
             sage: for i in range(20):
@@ -1037,6 +1038,7 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.linbox
             sage: m = matrix(ZZ, [[1,2],[1,0]], sparse=True)
             sage: b = matrix(ZZ, 2, 4, [1,0,2,0,1,1,2,0], sparse=False)
             sage: u, d = m._solve_matrix_linbox(b)
@@ -1045,7 +1047,6 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             [ 0 -1  0  0]
             sage: m * u == b * diagonal_matrix(d)
             True
-
             sage: u, d = m._solve_matrix_linbox([[1,3,4],[0,1,0]])
             sage: u
             [0 1 0]
@@ -1055,13 +1056,13 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
         Test input::
 
+            sage: # needs sage.libs.linbox
             sage: m = matrix(ZZ, [[1,2],[1,0]], sparse=True)
             sage: b = matrix(ZZ, 3, 3, range(9))
             sage: m._solve_matrix_linbox(b)
             Traceback (most recent call last):
             ...
             ValueError: wrong matrix dimension
-
             sage: m._solve_matrix_linbox([[1,1],[2,3]], algorithm='hop')
             Traceback (most recent call last):
             ...
@@ -1069,9 +1070,9 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
 
         TESTS::
 
+            sage: # needs sage.libs.linbox
             sage: algos = ["default", "dense_elimination", "sparse_elimination",
             ....:          "blackbox", "wiedemann"]
-
             sage: for _ in range(10):
             ....:     dim = randint(2, 10)
             ....:     M = MatrixSpace(ZZ, dim, sparse=True)

--- a/src/sage/matrix/matrix_integer_sparse.pyx
+++ b/src/sage/matrix/matrix_integer_sparse.pyx
@@ -29,20 +29,8 @@ TESTS::
 from cysignals.memory cimport check_calloc, sig_free
 from cysignals.signals cimport sig_on, sig_off
 
-from cpython.long cimport PyLong_FromSize_t
-
 from sage.ext.stdsage cimport PY_NEW
 from sage.ext.mod_int cimport *
-
-cimport sage.libs.linbox.givaro as givaro
-cimport sage.libs.linbox.linbox as linbox
-from sage.libs.linbox.conversion cimport (
-    new_linbox_vector_integer_dense,
-    new_sage_vector_integer_dense,
-    new_linbox_matrix_integer_sparse,
-    METHOD_DEFAULT, METHOD_DENSE_ELIMINATION,
-    METHOD_SPARSE_ELIMINATION, METHOD_BLACKBOX,
-    METHOD_WIEDEMANN, get_method)
 
 from sage.data_structures.binary_search cimport *
 from sage.modules.vector_integer_sparse cimport *
@@ -57,10 +45,6 @@ from sage.matrix.matrix cimport Matrix
 
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
 from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
-from sage.libs.flint.fmpz cimport fmpz_set_mpz, fmpz_get_mpz
-from sage.libs.flint.fmpz_poly cimport fmpz_poly_fit_length, _fmpz_poly_set_length
-from sage.libs.flint.fmpz_poly_sage cimport fmpz_poly_set_coeff_mpz
-from sage.libs.flint.fmpz_mat cimport fmpz_mat_entry
 
 from sage.matrix.matrix_modn_sparse cimport Matrix_modn_sparse
 from sage.structure.element cimport Element
@@ -668,7 +652,8 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             return x
 
         if algorithm is None or algorithm == "linbox":
-            r = self._rank_linbox()
+            from .matrix_integer_sparse_linbox import _rank_linbox
+            r = _rank_linbox(self)
             self.cache("rank", r)
         elif algorithm == "generic":
             r = Matrix_sparse.rank(self)
@@ -677,97 +662,6 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             raise ValueError("no algorithm '%s'"%algorithm)
 
         return r
-
-    def _rank_linbox(self):
-        r"""
-        Compute the rank using linbox.
-
-        The result is not cached contrarily to the method ``rank``.
-
-        EXAMPLES::
-
-            sage: M = MatrixSpace(ZZ, 3, sparse=True)
-            sage: m = M([1,0,1,0,2,0,2,0,2])
-            sage: m._rank_linbox()
-            2
-
-        TESTS::
-
-            sage: MatrixSpace(ZZ, 0, 0, sparse=True)()._rank_linbox()
-            0
-            sage: MatrixSpace(ZZ, 1, 0, sparse=True)()._rank_linbox()
-            0
-            sage: MatrixSpace(ZZ, 0, 1, sparse=True)()._rank_linbox()
-            0
-            sage: MatrixSpace(ZZ, 1, 1, sparse=True)()._rank_linbox()
-            0
-        """
-        if self._nrows == 0 or self._ncols == 0:
-            return 0
-
-        cdef givaro.ZRing givZZ
-        cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
-        cdef size_t r = 0
-
-        sig_on()
-        linbox.rank(r, M[0])
-        sig_off()
-
-        del M
-
-        return PyLong_FromSize_t(r)
-
-    def _det_linbox(self):
-        r"""
-        Return the determinant computed with LinBox.
-
-        .. NOTE::
-
-            This method is much slower than converting to a dense matrix and
-            computing the determinant there. There is not much point in making
-            it available. See :issue:`28318`.
-
-        EXAMPLES::
-
-            sage: M = MatrixSpace(ZZ, 2, 2, sparse=True)
-            sage: M([2,0,1,1])._det_linbox()
-            2
-
-        TESTS::
-
-            sage: MatrixSpace(ZZ, 0, 0, sparse=True)()._det_linbox()
-            1
-            sage: MatrixSpace(ZZ, 1, 1, sparse=True)()._det_linbox()
-            0
-
-            sage: m = diagonal_matrix(ZZ, [2] * 46)
-            sage: m._det_linbox() == 2**46
-            True
-
-            sage: m = diagonal_matrix(ZZ, [3] * 100)
-            sage: m._det_linbox() == 3**100
-            True
-        """
-        if self._nrows != self._ncols:
-            raise ValueError("non square matrix")
-
-        if self._nrows == 0:
-            return Integer(1)
-
-        cdef givaro.ZRing givZZ
-        cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
-        cdef givaro.Integer D
-
-        sig_on()
-        linbox.det(D, M[0])
-        sig_off()
-
-        cdef Integer d = PY_NEW(Integer)
-        mpz_set(d.value, D.get_mpz_const())
-
-        del M
-
-        return d
 
     def charpoly(self, var='x', algorithm=None):
         r"""
@@ -817,60 +711,12 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             return g.change_variable_name(var)
 
         if algorithm == 'linbox':
-            g = self._charpoly_linbox()
+            from sage.matrix.matrix_integer_sparse_linbox import _charpoly_linbox
+            g = _charpoly_linbox(self)
         else:
             g = Matrix_sparse.charpoly(self, var, algorithm=algorithm)
 
         self.cache('charpoly', g)
-        return g
-
-    def _charpoly_linbox(self, var='x'):
-        r"""
-        Compute the charpoly using LinBox.
-
-        EXAMPLES::
-
-            sage: m = matrix(ZZ, 2, [2,1,1,1], sparse=True)
-            sage: m._charpoly_linbox()
-            x^2 - 3*x + 1
-
-        TESTS::
-
-            sage: matrix(ZZ, 0, 0, sparse=True)._charpoly_linbox()
-            1
-            sage: matrix(ZZ, 1, 1, sparse=True)._charpoly_linbox()
-            x
-        """
-        cdef mpz_t tmp
-        if self._nrows != self._ncols:
-            raise ArithmeticError('only valid for square matrix')
-
-        from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-        R = PolynomialRing(ZZ, names=var)
-
-        # TODO: bug in LinBox (got SIGSEGV)
-        if self._nrows == 0:
-            return R.one()
-
-        cdef givaro.ZRing givZZ
-        cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
-        cdef linbox.DensePolynomial_integer * p = new linbox.DensePolynomial_integer(givZZ, <size_t> self._nrows)
-        cdef Polynomial_integer_dense_flint g = (<Polynomial_integer_dense_flint> R.gen())._new()
-
-        sig_on()
-        linbox.charpoly(p[0], M[0])
-        sig_off()
-
-        cdef size_t i
-        fmpz_poly_fit_length(g._poly, p.size())
-        for i in range(p.size()):
-            tmp = p[0][i].get_mpz_const()
-            fmpz_poly_set_coeff_mpz(g._poly, i, tmp)
-        _fmpz_poly_set_length(g._poly, p.size())
-
-        del M
-        del p
-
         return g
 
     def minpoly(self, var='x', algorithm=None):
@@ -918,60 +764,12 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             return g.change_variable_name(var)
 
         if algorithm == 'linbox':
-            g = self._minpoly_linbox()
+            from .matrix_integer_sparse_linbox import _minpoly_linbox
+            g = _minpoly_linbox(self)
         else:
             g = Matrix_sparse.minpoly(self, var, algorithm=algorithm)
 
         self.cache('minpoly', g)
-        return g
-
-    def _minpoly_linbox(self, var='x'):
-        r"""
-        Compute the minpoly using LinBox.
-
-        EXAMPLES::
-
-            sage: m = matrix(ZZ, 2, [2,1,1,1], sparse=True)
-            sage: m._minpoly_linbox()
-            x^2 - 3*x + 1
-
-        TESTS::
-
-            sage: matrix(ZZ, 0, 0, sparse=True)._minpoly_linbox()
-            1
-            sage: matrix(ZZ, 1, 1, sparse=True)._minpoly_linbox()
-            x
-        """
-        if self._nrows != self._ncols:
-            raise ArithmeticError('only valid for square matrix')
-
-        from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-        R = PolynomialRing(ZZ, names=var)
-
-        # TODO: bug in LinBox (got SIGSEGV)
-        if self._nrows == 0:
-            return R.one()
-
-        cdef givaro.ZRing givZZ
-        cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
-        cdef linbox.DensePolynomial_integer * p = new linbox.DensePolynomial_integer(givZZ, <size_t> self._nrows)
-        cdef Polynomial_integer_dense_flint g = (<Polynomial_integer_dense_flint> R.gen())._new()
-
-        sig_on()
-        linbox.minpoly(p[0], M[0])
-        sig_off()
-
-        cdef size_t i
-        cdef mpz_t tmp
-        fmpz_poly_fit_length(g._poly, p.size())
-        for i in range(p.size()):
-            tmp = p[0][i].get_mpz_const()
-            fmpz_poly_set_coeff_mpz(g._poly, i, tmp)
-        _fmpz_poly_set_length(g._poly, p.size())
-
-        del M
-        del p
-
         return g
 
     def _solve_right_nonsingular_square(self, B, algorithm=None, check_rank=False):
@@ -1048,242 +846,10 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
             if isinstance(B, sage.structure.element.Matrix):
                 from sage.rings.rational_field import QQ
                 from sage.matrix.special import diagonal_matrix
-                m, d = self._solve_matrix_linbox(B, algorithm)
+                from sage.matrix.matrix_integer_sparse_linbox import _solve_matrix_linbox
+                m, d = _solve_matrix_linbox(self, B, algorithm)
                 return m  * diagonal_matrix([QQ((1,x)) for x in d])
             else:
-                v, d = self._solve_vector_linbox(B, algorithm)
+                from sage.matrix.matrix_integer_sparse_linbox import _solve_vector_linbox
+                v, d = _solve_vector_linbox(self, B, algorithm)
                 return v / d
-
-    def _solve_vector_linbox(self, v, algorithm=None):
-        r"""
-        Return a pair ``(a, d)`` so that ``d * b = m * a``.
-
-        If there is no solution a :exc:`ValueError` is raised.
-
-        INPUT:
-
-        - ``b`` -- dense integer vector
-
-        - ``algorithm`` -- (optional) either ``None``, ``'dense_elimination'``,
-          ``'sparse_elimination'``, ``'wiedemann'`` or ``'blackbox'``
-
-        OUTPUT: a pair ``(a, d)`` consisting of
-
-        - ``a`` -- dense integer vector
-
-        - ``d`` -- integer
-
-        EXAMPLES::
-
-            sage: m = matrix(ZZ, 4, sparse=True)
-            sage: m[0,0] = m[1,2] = m[2,0] = m[3,3] = 2
-            sage: m[0,2] = m[1,1] = -1
-            sage: m[2,3] = m[3,0] = -3
-
-            sage: b0 = vector((1,1,1,1))
-            sage: m._solve_vector_linbox(b0)
-            ((-1, -7, -3, -1), 1)
-            sage: m._solve_vector_linbox(b0, 'dense_elimination')
-            ((-1, -7, -3, -1), 1)
-            sage: m._solve_vector_linbox(b0, 'sparse_elimination')
-            ((-1, -7, -3, -1), 1)
-            sage: m._solve_vector_linbox(b0, 'wiedemann')
-            ((-1, -7, -3, -1), 1)
-            sage: m._solve_vector_linbox(b0, 'blackbox')
-            ((-1, -7, -3, -1), 1)
-
-            sage: b1 = vector((1,2,3,4))
-            sage: m._solve_vector_linbox(b1)
-            ((-18, -92, -41, -17), 5)
-            sage: m._solve_vector_linbox(b1, 'dense_elimination')
-            ((-18, -92, -41, -17), 5)
-            sage: m._solve_vector_linbox(b1, 'sparse_elimination')
-            ((-18, -92, -41, -17), 5)
-            sage: m._solve_vector_linbox(b1, 'wiedemann')
-            ((-18, -92, -41, -17), 5)
-            sage: m._solve_vector_linbox(b1, 'blackbox')
-            ((-18, -92, -41, -17), 5)
-
-            sage: a1, d1 = m._solve_vector_linbox(b1)
-            sage: d1 * b1 == m * a1
-            True
-
-        TESTS::
-
-            sage: algos = ["default", "dense_elimination", "sparse_elimination",
-            ....:          "blackbox", "wiedemann"]
-            sage: for i in range(20):
-            ....:     dim = randint(1, 30)
-            ....:     M = MatrixSpace(ZZ, dim, sparse=True)
-            ....:     density = min(1, 4/dim)
-            ....:     m = M.random_element(density=density)
-            ....:     while m.rank() != dim:
-            ....:         m = M.random_element(density=density)
-            ....:     U = m.column_space().dense_module()
-            ....:     for algo in algos:
-            ....:         u, d = m._solve_vector_linbox(U.zero(), algorithm=algo)
-            ....:         assert u.is_zero()
-            ....:         b = U.random_element()
-            ....:         x, d = m._solve_vector_linbox(b, algorithm=algo)
-            ....:         assert m * x == d * b
-        """
-        Vin = self.column_ambient_module(base_ring=None, sparse=False)
-        v = Vin(v)
-
-        if self._nrows == 0 or self._ncols == 0:
-            raise ValueError("not implemented for nrows=0 or ncols=0")
-
-        # LinBox "solve" is mostly broken for nonsquare or singular matrices.
-        # The conditions below could be removed once all LinBox issues has
-        # been solved.
-        if self._nrows != self._ncols or self.rank() != self._nrows:
-            raise ValueError("only available for full rank square matrices")
-
-        cdef givaro.ZRing givZZ
-        cdef linbox.SparseMatrix_integer * A = new_linbox_matrix_integer_sparse(givZZ, self)
-        cdef linbox.DenseVector_integer * b = new_linbox_vector_integer_dense(givZZ, v)
-        cdef linbox.DenseVector_integer * res = new linbox.DenseVector_integer(givZZ, <size_t> self._ncols)
-        cdef givaro.Integer D
-
-        method = get_method(algorithm)
-
-        sig_on()
-        if method == METHOD_DEFAULT:
-            linbox.solve(res[0], D, A[0], b[0])
-        elif method == METHOD_WIEDEMANN:
-            linbox.solve(res[0], D, A[0], b[0], linbox.Method.Wiedemann())
-        elif method == METHOD_DENSE_ELIMINATION:
-            linbox.solve(res[0], D, A[0], b[0], linbox.Method.DenseElimination())
-        elif method == METHOD_SPARSE_ELIMINATION:
-            linbox.solve(res[0], D, A[0], b[0], linbox.Method.SparseElimination())
-        elif method == METHOD_BLACKBOX:
-            linbox.solve(res[0], D, A[0], b[0], linbox.Method.Blackbox())
-        sig_off()
-
-        Vout = self.row_ambient_module(base_ring=None, sparse=False)
-        res_sage = new_sage_vector_integer_dense(Vout, res[0])
-        cdef Integer d = PY_NEW(Integer)
-        mpz_set(d.value, D.get_mpz_const())
-
-        del A
-        del b
-        del res
-
-        return (res_sage, d)
-
-    def _solve_matrix_linbox(self, mat, algorithm=None):
-        r"""
-        Solve the equation ``A x = mat`` where ``A`` is this matrix.
-
-        EXAMPLES::
-
-            sage: m = matrix(ZZ, [[1,2],[1,0]], sparse=True)
-            sage: b = matrix(ZZ, 2, 4, [1,0,2,0,1,1,2,0], sparse=False)
-            sage: u, d = m._solve_matrix_linbox(b)
-            sage: u
-            [ 1  2  2  0]
-            [ 0 -1  0  0]
-            sage: m * u == b * diagonal_matrix(d)
-            True
-
-            sage: u, d = m._solve_matrix_linbox([[1,3,4],[0,1,0]])
-            sage: u
-            [0 1 0]
-            [1 1 2]
-            sage: d
-            (2, 1, 1)
-
-        Test input::
-
-            sage: m = matrix(ZZ, [[1,2],[1,0]], sparse=True)
-            sage: b = matrix(ZZ, 3, 3, range(9))
-            sage: m._solve_matrix_linbox(b)
-            Traceback (most recent call last):
-            ...
-            ValueError: wrong matrix dimension
-
-            sage: m._solve_matrix_linbox([[1,1],[2,3]], algorithm='hop')
-            Traceback (most recent call last):
-            ...
-            ValueError: unknown algorithm
-
-        TESTS::
-
-            sage: algos = ["default", "dense_elimination", "sparse_elimination",
-            ....:          "blackbox", "wiedemann"]
-
-            sage: for _ in range(10):
-            ....:     dim = randint(2, 10)
-            ....:     M = MatrixSpace(ZZ, dim, sparse=True)
-            ....:     m = M.random_element(density=min(1,10/dim))
-            ....:     while m.rank() != dim:
-            ....:         m = M.random_element(density=min(1,10/dim))
-            ....:     b = random_matrix(ZZ, dim, 7)
-            ....:     Mb = b.parent()
-            ....:     for algo in algos:
-            ....:         u, d = m._solve_matrix_linbox(b, algo)
-            ....:         assert m * u == b * diagonal_matrix(d)
-        """
-        if self._nrows == 0 or self._ncols == 0:
-            raise ValueError("not implemented for nrows=0 or ncols=0")
-
-        from sage.matrix.constructor import matrix
-        from sage.modules.free_module_element import vector
-
-        cdef Matrix_integer_dense B
-        if not isinstance(mat, Matrix):
-            B = <Matrix_integer_dense?> matrix(ZZ, mat, sparse=False)
-        else:
-            B = <Matrix_integer_dense?> mat.change_ring(ZZ).dense_matrix()
-        if B._nrows != self._nrows:
-            raise ValueError("wrong matrix dimension")
-
-        # LinBox "solve" is mostly broken for singular matrices. The
-        # conditions below could be removed once all LinBox issues
-        # have been solved.
-        if self._nrows != self._ncols or self.rank() != self._nrows:
-            raise ValueError("only available for full rank square matrices")
-
-        cdef givaro.ZRing givZZ
-        cdef linbox.SparseMatrix_integer * A = new_linbox_matrix_integer_sparse(givZZ, self)
-        cdef linbox.DenseVector_integer * b = new linbox.DenseVector_integer(givZZ, <size_t> self._nrows)
-        cdef linbox.DenseVector_integer * res = new linbox.DenseVector_integer(givZZ, <size_t> self._ncols)
-        cdef givaro.Integer D
-
-        cdef int algo = get_method(algorithm)
-
-        cdef Matrix_integer_dense X = matrix(ZZ, A.coldim(), B.ncols(), sparse=False)  # solution
-        cdef Vector_integer_dense d = vector(ZZ, X.ncols(), sparse=False)  # multipliers
-
-        sig_on()
-        cdef size_t i, j
-        for i in range(X.ncols()):
-            # set b to the i-th column of B
-            for j in range(A.coldim()):
-                fmpz_get_mpz(<mpz_t> b.getEntry(j).get_mpz(), fmpz_mat_entry(B._matrix, j, i))
-
-            # solve the current row
-            if algo == METHOD_DEFAULT:
-                linbox.solve(res[0], D, A[0], b[0])
-            elif algo == METHOD_DENSE_ELIMINATION:
-                linbox.solve(res[0], D, A[0], b[0], linbox.Method.DenseElimination())
-            elif algo == METHOD_SPARSE_ELIMINATION:
-                linbox.solve(res[0], D, A[0], b[0], linbox.Method.SparseElimination())
-            elif algo == METHOD_BLACKBOX:
-                linbox.solve(res[0], D, A[0], b[0], linbox.Method.Blackbox())
-            elif algo == METHOD_WIEDEMANN:
-                linbox.solve(res[0], D, A[0], b[0], linbox.Method.Wiedemann())
-
-            # set i-th column of X to be res
-            for j in range(A.coldim()):
-                fmpz_set_mpz(fmpz_mat_entry(X._matrix, j, i), res[0].getEntry(j).get_mpz())
-
-            # compute common gcd
-            mpz_set(d._entries[i], D.get_mpz_const())
-        sig_off()
-
-        del A
-        del b
-        del res
-
-        return X, d

--- a/src/sage/matrix/matrix_integer_sparse_linbox.pyx
+++ b/src/sage/matrix/matrix_integer_sparse_linbox.pyx
@@ -1,0 +1,464 @@
+# sage_setup: distribution = sagemath-linbox
+
+from cpython.long cimport PyLong_FromSize_t
+
+from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
+
+from sage.ext.stdsage cimport PY_NEW
+from sage.libs.flint.fmpz cimport *
+from sage.libs.flint.fmpz_mat cimport *
+from sage.libs.flint.fmpz_poly_sage cimport fmpz_poly_set_coeff_mpz
+from sage.libs.flint.fmpz_poly cimport fmpz_poly_fit_length, _fmpz_poly_set_length
+from sage.libs.gmp.mpz cimport *
+from sage.matrix.matrix cimport Matrix
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.matrix.matrix_integer_sparse cimport Matrix_integer_sparse
+from sage.modules.vector_integer_dense cimport Vector_integer_dense
+from sage.rings.integer cimport Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
+
+cimport sage.libs.linbox.givaro as givaro
+cimport sage.libs.linbox.linbox as linbox
+from sage.libs.linbox.conversion cimport (
+    new_linbox_vector_integer_dense,
+    new_sage_vector_integer_dense,
+    new_linbox_matrix_integer_sparse,
+    METHOD_DEFAULT, METHOD_DENSE_ELIMINATION,
+    METHOD_SPARSE_ELIMINATION, METHOD_BLACKBOX,
+    METHOD_WIEDEMANN, get_method)
+
+
+def _rank_linbox(Matrix_integer_sparse self):
+    r"""
+    Compute the rank using linbox.
+
+    The result is not cached contrarily to the method ``rank``.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_sparse_linbox import _rank_linbox
+        sage: M = MatrixSpace(ZZ, 3, sparse=True)
+        sage: m = M([1,0,1,0,2,0,2,0,2])
+        sage: _rank_linbox(m)
+        2
+
+    TESTS::
+
+        sage: _rank_linbox(MatrixSpace(ZZ, 0, 0, sparse=True)())
+        0
+        sage: _rank_linbox(MatrixSpace(ZZ, 1, 0, sparse=True)())
+        0
+        sage: _rank_linbox(MatrixSpace(ZZ, 0, 1, sparse=True)())
+        0
+        sage: _rank_linbox(MatrixSpace(ZZ, 1, 1, sparse=True)())
+        0
+    """
+    if self._nrows == 0 or self._ncols == 0:
+        return 0
+
+    cdef givaro.ZRing givZZ
+    cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
+    cdef size_t r = 0
+
+    sig_on()
+    linbox.rank(r, M[0])
+    sig_off()
+
+    del M
+
+    return PyLong_FromSize_t(r)
+
+
+def _det_linbox(Matrix_integer_sparse self):
+    r"""
+    Return the determinant computed with LinBox.
+
+    .. NOTE::
+
+        This method is much slower than converting to a dense matrix and
+        computing the determinant there. There is not much point in making
+        it available. See :issue:`28318`.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_sparse_linbox import _det_linbox
+        sage: M = MatrixSpace(ZZ, 2, 2, sparse=True)
+        sage: _det_linbox(M([2,0,1,1]))
+        2
+
+    TESTS::
+
+        sage: _det_linbox(MatrixSpace(ZZ, 0, 0, sparse=True)())
+        1
+        sage: _det_linbox(MatrixSpace(ZZ, 1, 1, sparse=True)())
+        0
+
+        sage: m = diagonal_matrix(ZZ, [2] * 46)
+        sage: _det_linbox(m) == 2**46
+        True
+
+        sage: m = diagonal_matrix(ZZ, [3] * 100)
+        sage: _det_linbox(m) == 3**100
+        True
+    """
+    if self._nrows != self._ncols:
+        raise ValueError("non square matrix")
+
+    if self._nrows == 0:
+        return Integer(1)
+
+    cdef givaro.ZRing givZZ
+    cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
+    cdef givaro.Integer D
+
+    sig_on()
+    linbox.det(D, M[0])
+    sig_off()
+
+    cdef Integer d = PY_NEW(Integer)
+    mpz_set(d.value, D.get_mpz_const())
+
+    del M
+
+    return d
+
+
+def _charpoly_linbox(Matrix_integer_sparse self, var='x'):
+    r"""
+    Compute the charpoly using LinBox.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_sparse_linbox import _charpoly_linbox
+        sage: m = matrix(ZZ, 2, [2,1,1,1], sparse=True)
+        sage: _charpoly_linbox(m)
+        x^2 - 3*x + 1
+
+    TESTS::
+
+        sage: _charpoly_linbox(matrix(ZZ, 0, 0, sparse=True))
+        1
+        sage: _charpoly_linbox(matrix(ZZ, 1, 1, sparse=True))
+        x
+    """
+    cdef mpz_t tmp
+    if self._nrows != self._ncols:
+        raise ArithmeticError('only valid for square matrix')
+
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    R = PolynomialRing(ZZ, names=var)
+
+    # TODO: bug in LinBox (got SIGSEGV)
+    if self._nrows == 0:
+        return R.one()
+
+    cdef givaro.ZRing givZZ
+    cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
+    cdef linbox.DensePolynomial_integer * p = new linbox.DensePolynomial_integer(givZZ, <size_t> self._nrows)
+    cdef Polynomial_integer_dense_flint g = (<Polynomial_integer_dense_flint> R.gen())._new()
+
+    sig_on()
+    linbox.charpoly(p[0], M[0])
+    sig_off()
+
+    cdef size_t i
+    fmpz_poly_fit_length(g._poly, p.size())
+    for i in range(p.size()):
+        tmp = p[0][i].get_mpz_const()
+        fmpz_poly_set_coeff_mpz(g._poly, i, tmp)
+    _fmpz_poly_set_length(g._poly, p.size())
+
+    del M
+    del p
+
+    return g
+
+
+def _minpoly_linbox(Matrix_integer_sparse self, var='x'):
+    r"""
+    Compute the minpoly using LinBox.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_sparse_linbox import _minpoly_linbox
+        sage: m = matrix(ZZ, 2, [2,1,1,1], sparse=True)
+        sage: _minpoly_linbox(m)
+        x^2 - 3*x + 1
+
+    TESTS::
+
+        sage: _minpoly_linbox(matrix(ZZ, 0, 0, sparse=True))
+        1
+        sage: _minpoly_linbox(matrix(ZZ, 1, 1, sparse=True))
+        x
+    """
+    if self._nrows != self._ncols:
+        raise ArithmeticError('only valid for square matrix')
+
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    R = PolynomialRing(ZZ, names=var)
+
+    # TODO: bug in LinBox (got SIGSEGV)
+    if self._nrows == 0:
+        return R.one()
+
+    cdef givaro.ZRing givZZ
+    cdef linbox.SparseMatrix_integer * M = new_linbox_matrix_integer_sparse(givZZ, self)
+    cdef linbox.DensePolynomial_integer * p = new linbox.DensePolynomial_integer(givZZ, <size_t> self._nrows)
+    cdef Polynomial_integer_dense_flint g = (<Polynomial_integer_dense_flint> R.gen())._new()
+
+    sig_on()
+    linbox.minpoly(p[0], M[0])
+    sig_off()
+
+    cdef size_t i
+    cdef mpz_t tmp
+    fmpz_poly_fit_length(g._poly, p.size())
+    for i in range(p.size()):
+        tmp = p[0][i].get_mpz_const()
+        fmpz_poly_set_coeff_mpz(g._poly, i, tmp)
+    _fmpz_poly_set_length(g._poly, p.size())
+
+    del M
+    del p
+
+    return g
+
+
+def _solve_vector_linbox(Matrix_integer_sparse self, v, algorithm=None):
+    r"""
+    Return a pair ``(a, d)`` so that ``d * b = m * a``.
+
+    If there is no solution a :exc:`ValueError` is raised.
+
+    INPUT:
+
+    - ``b`` -- dense integer vector
+
+    - ``algorithm`` -- (optional) either ``None``, ``'dense_elimination'``,
+      ``'sparse_elimination'``, ``'wiedemann'`` or ``'blackbox'``
+
+    OUTPUT: a pair ``(a, d)`` consisting of
+
+    - ``a`` -- dense integer vector
+
+    - ``d`` -- integer
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_sparse_linbox import _solve_vector_linbox
+        sage: m = matrix(ZZ, 4, sparse=True)
+        sage: m[0,0] = m[1,2] = m[2,0] = m[3,3] = 2
+        sage: m[0,2] = m[1,1] = -1
+        sage: m[2,3] = m[3,0] = -3
+
+        sage: b0 = vector((1,1,1,1))
+        sage: _solve_vector_linbox(m, b0)
+        ((-1, -7, -3, -1), 1)
+        sage: _solve_vector_linbox(m, b0, 'dense_elimination')
+        ((-1, -7, -3, -1), 1)
+        sage: _solve_vector_linbox(m, b0, 'sparse_elimination')
+        ((-1, -7, -3, -1), 1)
+        sage: _solve_vector_linbox(m, b0, 'wiedemann')
+        ((-1, -7, -3, -1), 1)
+        sage: _solve_vector_linbox(m, b0, 'blackbox')
+        ((-1, -7, -3, -1), 1)
+
+        sage: b1 = vector((1,2,3,4))
+        sage: _solve_vector_linbox(m, b1)
+        ((-18, -92, -41, -17), 5)
+        sage: _solve_vector_linbox(m, b1, 'dense_elimination')
+        ((-18, -92, -41, -17), 5)
+        sage: _solve_vector_linbox(m, b1, 'sparse_elimination')
+        ((-18, -92, -41, -17), 5)
+        sage: _solve_vector_linbox(m, b1, 'wiedemann')
+        ((-18, -92, -41, -17), 5)
+        sage: _solve_vector_linbox(m, b1, 'blackbox')
+        ((-18, -92, -41, -17), 5)
+
+        sage: a1, d1 = _solve_vector_linbox(m, b1)
+        sage: d1 * b1 == m * a1
+        True
+
+    TESTS::
+
+        sage: algos = ["default", "dense_elimination", "sparse_elimination",
+        ....:          "blackbox", "wiedemann"]
+        sage: for i in range(20):
+        ....:     dim = randint(1, 30)
+        ....:     M = MatrixSpace(ZZ, dim, sparse=True)
+        ....:     density = min(1, 4/dim)
+        ....:     m = M.random_element(density=density)
+        ....:     while m.rank() != dim:
+        ....:         m = M.random_element(density=density)
+        ....:     U = m.column_space().dense_module()
+        ....:     for algo in algos:
+        ....:         u, d = _solve_vector_linbox(m, U.zero(), algorithm=algo)
+        ....:         assert u.is_zero()
+        ....:         b = U.random_element()
+        ....:         x, d = _solve_vector_linbox(m, b, algorithm=algo)
+        ....:         assert m * x == d * b
+    """
+    Vin = self.column_ambient_module(base_ring=None, sparse=False)
+    v = Vin(v)
+
+    if self._nrows == 0 or self._ncols == 0:
+        raise ValueError("not implemented for nrows=0 or ncols=0")
+
+    # LinBox "solve" is mostly broken for nonsquare or singular matrices.
+    # The conditions below could be removed once all LinBox issues has
+    # been solved.
+    if self._nrows != self._ncols or self.rank() != self._nrows:
+        raise ValueError("only available for full rank square matrices")
+
+    cdef givaro.ZRing givZZ
+    cdef linbox.SparseMatrix_integer * A = new_linbox_matrix_integer_sparse(givZZ, self)
+    cdef linbox.DenseVector_integer * b = new_linbox_vector_integer_dense(givZZ, v)
+    cdef linbox.DenseVector_integer * res = new linbox.DenseVector_integer(givZZ, <size_t> self._ncols)
+    cdef givaro.Integer D
+
+    method = get_method(algorithm)
+
+    sig_on()
+    if method == METHOD_DEFAULT:
+        linbox.solve(res[0], D, A[0], b[0])
+    elif method == METHOD_WIEDEMANN:
+        linbox.solve(res[0], D, A[0], b[0], linbox.Method.Wiedemann())
+    elif method == METHOD_DENSE_ELIMINATION:
+        linbox.solve(res[0], D, A[0], b[0], linbox.Method.DenseElimination())
+    elif method == METHOD_SPARSE_ELIMINATION:
+        linbox.solve(res[0], D, A[0], b[0], linbox.Method.SparseElimination())
+    elif method == METHOD_BLACKBOX:
+        linbox.solve(res[0], D, A[0], b[0], linbox.Method.Blackbox())
+    sig_off()
+
+    Vout = self.row_ambient_module(base_ring=None, sparse=False)
+    res_sage = new_sage_vector_integer_dense(Vout, res[0])
+    cdef Integer d = PY_NEW(Integer)
+    mpz_set(d.value, D.get_mpz_const())
+
+    del A
+    del b
+    del res
+
+    return (res_sage, d)
+
+
+def _solve_matrix_linbox(Matrix_integer_sparse self, mat, algorithm=None):
+    r"""
+    Solve the equation ``A x = mat`` where ``A`` is this matrix.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_integer_sparse_linbox import _solve_matrix_linbox
+        sage: m = matrix(ZZ, [[1,2],[1,0]], sparse=True)
+        sage: b = matrix(ZZ, 2, 4, [1,0,2,0,1,1,2,0], sparse=False)
+        sage: u, d = _solve_matrix_linbox(m, b)
+        sage: u
+        [ 1  2  2  0]
+        [ 0 -1  0  0]
+        sage: m * u == b * diagonal_matrix(d)
+        True
+
+        sage: u, d = _solve_matrix_linbox(m, [[1,3,4],[0,1,0]])
+        sage: u
+        [0 1 0]
+        [1 1 2]
+        sage: d
+        (2, 1, 1)
+
+    Test input::
+
+        sage: m = matrix(ZZ, [[1,2],[1,0]], sparse=True)
+        sage: b = matrix(ZZ, 3, 3, range(9))
+        sage: _solve_matrix_linbox(m, b)
+        Traceback (most recent call last):
+        ...
+        ValueError: wrong matrix dimension
+
+        sage: _solve_matrix_linbox(m, [[1,1],[2,3]], algorithm='hop')
+        Traceback (most recent call last):
+        ...
+        ValueError: unknown algorithm
+
+    TESTS::
+
+        sage: algos = ["default", "dense_elimination", "sparse_elimination",
+        ....:          "blackbox", "wiedemann"]
+
+        sage: for _ in range(10):
+        ....:     dim = randint(2, 10)
+        ....:     M = MatrixSpace(ZZ, dim, sparse=True)
+        ....:     m = M.random_element(density=min(1,10/dim))
+        ....:     while m.rank() != dim:
+        ....:         m = M.random_element(density=min(1,10/dim))
+        ....:     b = random_matrix(ZZ, dim, 7)
+        ....:     Mb = b.parent()
+        ....:     for algo in algos:
+        ....:         u, d = _solve_matrix_linbox(m, b, algo)
+        ....:         assert m * u == b * diagonal_matrix(d)
+    """
+    if self._nrows == 0 or self._ncols == 0:
+        raise ValueError("not implemented for nrows=0 or ncols=0")
+
+    from sage.matrix.constructor import matrix
+    from sage.modules.free_module_element import vector
+
+    cdef Matrix_integer_dense B
+    if not isinstance(mat, Matrix):
+        B = <Matrix_integer_dense?> matrix(ZZ, mat, sparse=False)
+    else:
+        B = <Matrix_integer_dense?> mat.change_ring(ZZ).dense_matrix()
+    if B._nrows != self._nrows:
+        raise ValueError("wrong matrix dimension")
+
+    # LinBox "solve" is mostly broken for singular matrices. The
+    # conditions below could be removed once all LinBox issues
+    # have been solved.
+    if self._nrows != self._ncols or self.rank() != self._nrows:
+        raise ValueError("only available for full rank square matrices")
+
+    cdef givaro.ZRing givZZ
+    cdef linbox.SparseMatrix_integer * A = new_linbox_matrix_integer_sparse(givZZ, self)
+    cdef linbox.DenseVector_integer * b = new linbox.DenseVector_integer(givZZ, <size_t> self._nrows)
+    cdef linbox.DenseVector_integer * res = new linbox.DenseVector_integer(givZZ, <size_t> self._ncols)
+    cdef givaro.Integer D
+
+    cdef int algo = get_method(algorithm)
+
+    cdef Matrix_integer_dense X = matrix(ZZ, A.coldim(), B.ncols(), sparse=False)  # solution
+    cdef Vector_integer_dense d = vector(ZZ, X.ncols(), sparse=False)  # multipliers
+
+    sig_on()
+    cdef size_t i, j
+    for i in range(X.ncols()):
+        # set b to the i-th column of B
+        for j in range(A.coldim()):
+            fmpz_get_mpz(<mpz_t> b.getEntry(j).get_mpz(), fmpz_mat_entry(B._matrix, j, i))
+
+        # solve the current row
+        if algo == METHOD_DEFAULT:
+            linbox.solve(res[0], D, A[0], b[0])
+        elif algo == METHOD_DENSE_ELIMINATION:
+            linbox.solve(res[0], D, A[0], b[0], linbox.Method.DenseElimination())
+        elif algo == METHOD_SPARSE_ELIMINATION:
+            linbox.solve(res[0], D, A[0], b[0], linbox.Method.SparseElimination())
+        elif algo == METHOD_BLACKBOX:
+            linbox.solve(res[0], D, A[0], b[0], linbox.Method.Blackbox())
+        elif algo == METHOD_WIEDEMANN:
+            linbox.solve(res[0], D, A[0], b[0], linbox.Method.Wiedemann())
+
+        # set i-th column of X to be res
+        for j in range(A.coldim()):
+            fmpz_set_mpz(fmpz_mat_entry(X._matrix, j, i), res[0].getEntry(j).get_mpz())
+
+        # compute common gcd
+        mpz_set(d._entries[i], D.get_mpz_const())
+    sig_off()
+
+    del A
+    del b
+    del res
+
+    return X, d

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -1552,6 +1552,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.linbox
             sage: A = random_matrix(GF(19), 10, 10)
             sage: B = copy(A)
             sage: char_p = A._charpoly_linbox()
@@ -1559,7 +1560,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             True
             sage: B == A              # A is not modified
             True
-
             sage: min_p = A.minimal_polynomial(proof=True)
             sage: min_p.divides(char_p)
             True
@@ -1768,6 +1768,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.linbox
             sage: A = random_matrix(GF(7), 10, 20)
             sage: B = copy(A)
             sage: A._echelonize_linbox()

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1459,17 +1459,22 @@ cdef class Matrix_rational_dense(Matrix_dense):
                 A.subdivide(self.subdivisions())
             return A
 
-        from sage.matrix.matrix_modn_dense_double import MAX_MODULUS
-        if isinstance(R, sage.rings.abc.IntegerModRing) and R.order() < MAX_MODULUS:
-            b = R.order()
-            A, d = self._clear_denom()
-            if not b.gcd(d).is_one():
-                raise TypeError("matrix denominator not coprime to modulus")
-            B = A._mod_int(b)
-            C = (1/(B.base_ring()(d))) * B
-            if self._subdivisions is not None:
-                C.subdivide(self.subdivisions())
-            return C
+        if isinstance(R, sage.rings.abc.IntegerModRing):
+            try:
+                from sage.matrix.matrix_modn_dense_double import MAX_MODULUS
+            except ImportError:
+                pass
+            else:
+                if R.order() < MAX_MODULUS:
+                    b = R.order()
+                    A, d = self._clear_denom()
+                    if not b.gcd(d).is_one():
+                        raise TypeError("matrix denominator not coprime to modulus")
+                    B = A._mod_int(b)
+                    C = (1/(B.base_ring()(d))) * B
+                    if self._subdivisions is not None:
+                        C.subdivide(self.subdivisions())
+                    return C
 
         # fallback to the generic version
         return Matrix_dense.change_ring(self, R)

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1097,7 +1097,12 @@ cdef class Matrix_rational_dense(Matrix_dense):
             return poly.change_variable_name(var)
 
         if algorithm is None:
-            algorithm = 'linbox'
+            try:
+                from .matrix_integer_linbox import _minpoly_linbox
+            except ImportError:
+                algorithm = 'generic'
+            else:
+                algorithm = 'linbox'
 
         if algorithm == 'linbox':
             A, denom = self._clear_denom()

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -77,8 +77,6 @@ from sage.misc.randstate cimport randstate, current_randstate
 from cysignals.signals cimport sig_on, sig_off
 from cysignals.memory cimport sig_malloc, sig_free
 
-from sage.arith.rational_reconstruction cimport mpq_rational_reconstruction
-
 from sage.libs.gmp.types cimport mpz_t, mpq_t
 from sage.libs.gmp.mpz cimport mpz_init, mpz_clear, mpz_cmp_si
 from sage.libs.gmp.mpq cimport mpq_init, mpq_clear, mpq_set_si, mpq_mul, mpq_add, mpq_set
@@ -101,7 +99,6 @@ from sage.rings.rational cimport Rational
 from sage.matrix.matrix cimport Matrix
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
 from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
-from sage.matrix.matrix_integer_linbox cimport _lift_crt
 from sage.structure.element cimport Element, Vector
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring import ZZ, IntegerRing_class
@@ -2160,25 +2157,8 @@ cdef class Matrix_rational_dense(Matrix_dense):
 #          return E
 
     def _lift_crt_rr(self, res, mm):
-        cdef Integer m
-        cdef Matrix_integer_dense ZA
-        cdef Matrix_rational_dense QA
-        cdef Py_ssize_t i, j
-        cdef mpz_t tmp
-        cdef mpq_t tmp2
-        mpz_init(tmp)
-        mpq_init(tmp2)
-        ZA = _lift_crt(res, mm)
-        QA = Matrix_rational_dense.__new__(Matrix_rational_dense, self.parent(), None, None, None)
-        m = mm.prod()
-        for i in range(ZA._nrows):
-            for j in range(ZA._ncols):
-                fmpz_get_mpz(tmp, fmpz_mat_entry(ZA._matrix,i,j))
-                mpq_rational_reconstruction(tmp2, tmp, m.value)
-                fmpq_set_mpq(fmpq_mat_entry(QA._matrix, i, j), tmp2)
-        mpz_clear(tmp)
-        mpq_clear(tmp2)
-        return QA
+        from .matrix_rational_linbox import _lift_crt_rr
+        return _lift_crt_rr(self, res, mm)
 
     def randomize(self, density=1, num_bound=2, den_bound=2,
                   distribution=None, nonzero=False):

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2719,7 +2719,75 @@ cdef class Matrix_rational_dense(Matrix_dense):
         from .matrix_rational_pari import _pari
         return _pari(self)
 
-    def row(Matrix_rational_dense self, Py_ssize_t i, from_list=False):
+    def _det_pari(self, int flag=0):
+        """
+        Return the determinant of this matrix computed using pari.
+
+        EXAMPLES::
+
+            sage: matrix(QQ,3,[1..9])._det_pari()
+            0
+            sage: matrix(QQ,3,[1..9])._det_pari(1)
+            0
+            sage: matrix(QQ,3,[0]+[2..9])._det_pari()
+            3
+        """
+        from .matrix_rational_pari import _det_pari
+        return _det_pari(self, flag)
+
+    def _rank_pari(self):
+        """
+        Return the rank of this matrix computed using pari.
+
+        EXAMPLES::
+
+            sage: matrix(QQ,3,[1..9])._rank_pari()
+            2
+            sage: matrix(QQ, 0, 0)._rank_pari()
+            0
+        """
+        from .matrix_rational_pari import _rank_pari
+        return _rank_pari(self)
+
+    def _multiply_pari(self, Matrix_rational_dense right):
+        """
+        Return the product of ``self`` and ``right``, computed using PARI.
+
+        EXAMPLES::
+
+            sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9])._multiply_pari(matrix(QQ,2,[1,2,3,4]))
+            [  -9/5 -34/15]
+            [ 25/12  59/18]
+
+        We verify that 0 rows or columns works::
+
+            sage: x = matrix(QQ,2,0); y = matrix(QQ,0,2); x*y
+            [0 0]
+            [0 0]
+            sage: matrix(ZZ, 0, 0) * matrix(QQ, 0, 5)
+            []
+        """
+        from .matrix_rational_pari import _multiply_pari
+        return _multiply_pari(self, right)
+
+    def _invert_pari(self):
+        """
+        Return the inverse of this matrix computed using PARI.
+
+        EXAMPLES::
+
+            sage: matrix(QQ,2,[1,2,3,4])._invert_pari()
+            [  -2    1]
+            [ 3/2 -1/2]
+            sage: matrix(QQ,2,[1,2,2,4])._invert_pari()
+            Traceback (most recent call last):
+            ...
+            PariError: impossible inverse in ginv: [1, 2; 2, 4]
+        """
+        from .matrix_rational_pari import _invert_pari
+        return _invert_pari(self)
+
+    def row(self, Py_ssize_t i, from_list=False):
         """
         Return the `i`-th row of this matrix as a dense vector.
 

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1008,7 +1008,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         Check consistency::
 
-            sage: for _ in range(100):
+            sage: for _ in range(100):                                                  # needs sage.libs.linbox
             ....:     dim = randint(0, 10)
             ....:     m = random_matrix(QQ, dim, num_bound=8, den_bound=8)
             ....:     p_flint = m.charpoly(algorithm='flint'); m._clear_cache()
@@ -1085,7 +1085,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         Check consistency::
 
-            sage: for _ in range(100):
+            sage: for _ in range(100):                                                  # needs sage.libs.linbox
             ....:     dim = randint(0, 10)
             ....:     m = random_matrix(QQ, dim, num_bound=8, den_bound=8)
             ....:     p_linbox = m.charpoly(algorithm='linbox'); m._clear_cache()
@@ -1536,6 +1536,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         ::
 
+            sage: # needs sage.libs.linbox
             sage: a = matrix(QQ, 4, range(16)); a[0,0] = 1/19; a[0,1] = 1/5
             sage: a.echelonize(algorithm='multimodular')
             sage: a
@@ -1549,7 +1550,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
         Echelonizing a matrix in place throws away the cache of
         the old matrix (:issue:`14506`)::
 
-            sage: for algo in ["flint", "padic", "multimodular", "classical"]:
+            sage: for algo in ["flint", "padic", "multimodular", "classical"]:          # needs sage.libs.linbox
             ....:      a = Matrix(QQ, [[1,2],[3,4]])
             ....:      _ = a.det()          # fills the cache
             ....:      _ = a._clear_denom() # fills the cache
@@ -1710,6 +1711,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.linbox
             sage: m = matrix(QQ, 4, range(16))
             sage: m._echelonize_padic()
             (0, 1)
@@ -1718,7 +1720,6 @@ cdef class Matrix_rational_dense(Matrix_dense):
             [ 0  1  2  3]
             [ 0  0  0  0]
             [ 0  0  0  0]
-
             sage: m = matrix(QQ, 4, 6, [-1,0,0,-2,-1,-2,-1,0,0,-2,-1,0,3,3,-2,0,0,3,-2,-3,1,1,-2,3])
             sage: m._echelonize_padic()
             (0, 1, 2, 5)
@@ -1789,6 +1790,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.linbox
             sage: m = matrix(QQ, 4, range(16))
             sage: m._echelonize_multimodular()
             (0, 1)

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1,8 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
-# distutils: extra_compile_args = -D_XPG6 M4RI_CFLAGS -std=c++11
-# distutils: libraries = iml m
-# distutils: include_dirs = M4RI_INCDIR
-# distutils: language = c++
+# sage_setup: distribution = sagemath-flint
 """
 Dense matrices over the rational field
 

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1564,7 +1564,12 @@ cdef class Matrix_rational_dense(Matrix_dense):
             if self._nrows <= 25 or self._ncols <= 25:
                 algorithm = 'flint'
             else:
-                algorithm = 'multimodular'
+                try:
+                    from sage.matrix.misc import matrix_rational_echelon_form_multimodular
+                except ImportError:
+                    algorithm = 'flint'
+                else:
+                    algorithm = 'multimodular'
 
         if algorithm == 'flint':
             pivots = self._echelonize_flint()

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1399,7 +1399,10 @@ cdef class Matrix_rational_dense(Matrix_dense):
             from sage.matrix.constructor import identity_matrix
             K = identity_matrix(QQ, self.ncols())
         else:
-            from .matrix_integer_iml import _rational_kernel_iml
+            try:
+                from .matrix_integer_iml import _rational_kernel_iml
+            except ImportError:
+                return self._right_kernel_matrix_over_field()
             A, _ = self._clear_denom()
             K = _rational_kernel_iml(A).transpose().change_ring(QQ)
         verbose("done computing right kernel matrix over the rationals for %sx%s matrix" % (self.nrows(), self.ncols()),level=1, t=tm)

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -100,7 +100,8 @@ from sage.structure.richcmp cimport rich_to_bool
 from sage.rings.rational cimport Rational
 from sage.matrix.matrix cimport Matrix
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
-from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense, _lift_crt
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.matrix.matrix_integer_linbox cimport _lift_crt
 from sage.structure.element cimport Element, Vector
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring import ZZ, IntegerRing_class

--- a/src/sage/matrix/matrix_rational_linbox.pyx
+++ b/src/sage/matrix/matrix_rational_linbox.pyx
@@ -1,0 +1,36 @@
+# sage_setup: distribution = sagemath-linbox
+
+from sage.arith.rational_reconstruction cimport mpq_rational_reconstruction
+from sage.libs.flint.fmpq cimport fmpq_is_zero, fmpq_set_mpq, fmpq_canonicalise
+from sage.libs.flint.fmpq_mat cimport fmpq_mat_entry_num, fmpq_mat_entry_den, fmpq_mat_entry
+from sage.libs.flint.fmpz cimport fmpz_init, fmpz_clear, fmpz_set_mpz, fmpz_one, fmpz_get_mpz, fmpz_add, fmpz_mul, fmpz_sub, fmpz_mul_si, fmpz_mul_si, fmpz_mul_si, fmpz_divexact, fmpz_lcm
+from sage.libs.flint.fmpz_mat cimport *
+from sage.libs.gmp.mpz cimport mpz_init, mpz_clear, mpz_cmp_si
+from sage.libs.gmp.mpq cimport mpq_init, mpq_clear, mpq_set_si, mpq_mul, mpq_add, mpq_set
+from sage.libs.gmp.types cimport mpz_t, mpq_t
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.matrix.matrix_rational_dense cimport Matrix_rational_dense
+from sage.matrix.matrix_integer_linbox cimport _lift_crt
+from sage.rings.integer cimport Integer
+
+
+def _lift_crt_rr(Matrix_rational_dense self, res, mm):
+    cdef Integer m
+    cdef Matrix_integer_dense ZA
+    cdef Matrix_rational_dense QA
+    cdef Py_ssize_t i, j
+    cdef mpz_t tmp
+    cdef mpq_t tmp2
+    mpz_init(tmp)
+    mpq_init(tmp2)
+    ZA = _lift_crt(res, mm)
+    QA = Matrix_rational_dense.__new__(Matrix_rational_dense, self.parent(), None, None, None)
+    m = mm.prod()
+    for i in range(ZA._nrows):
+        for j in range(ZA._ncols):
+            fmpz_get_mpz(tmp, fmpz_mat_entry(ZA._matrix,i,j))
+            mpq_rational_reconstruction(tmp2, tmp, m.value)
+            fmpq_set_mpq(fmpq_mat_entry(QA._matrix, i, j), tmp2)
+    mpz_clear(tmp)
+    mpq_clear(tmp2)
+    return QA

--- a/src/sage/matrix/matrix_rational_pari.pyx
+++ b/src/sage/matrix/matrix_rational_pari.pyx
@@ -1,0 +1,159 @@
+# sage_setup: distribution = sagemath-linbox
+
+from cysignals.signals cimport sig_on, sig_off
+from cysignals.memory cimport sig_malloc, sig_free
+
+from sage.libs.flint.fmpq cimport *
+from sage.libs.flint.fmpq_mat cimport *
+from sage.libs.gmp.mpq cimport mpq_init, mpq_clear, mpq_set_si, mpq_mul, mpq_add, mpq_set
+from sage.matrix.matrix_rational_dense cimport Matrix_rational_dense
+from sage.modules.vector_rational_dense cimport Vector_rational_dense
+from sage.rings.rational cimport Rational
+
+# ########################################################
+# PARI C library
+from sage.libs.pari.all import PariError
+from sage.libs.pari.convert_gmp cimport INTFRAC_to_mpq
+from sage.libs.pari.convert_flint cimport rational_matrix, _new_GEN_from_fmpq_mat_t
+from cypari2.stack cimport clear_stack
+from cypari2.paridecl cimport *
+# ########################################################
+
+
+def _pari(Matrix_rational_dense self):
+    """
+    Return pari version of this matrix.
+
+    EXAMPLES::
+
+        sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9]).__pari__()
+        [1/5, -2/3; 3/4, 4/9]
+    """
+    return rational_matrix(self._matrix, False)
+
+
+def _det_pari(Matrix_rational_dense self, int flag=0):
+    """
+    Return the determinant of this matrix computed using pari.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_rational_pari import _det_pari
+        sage: _det_pari(matrix(QQ, 3, [1..9]))
+        0
+        sage: _det_pari(matrix(QQ, 3, [1..9]), 1)
+        0
+        sage: _det_pari(matrix(QQ, 3, [0] + [2..9]))
+        3
+    """
+    sig_on()
+    cdef GEN d = det0(_new_GEN_from_fmpq_mat_t(self._matrix), flag)
+    # now convert d to a Sage rational
+    cdef Rational e = <Rational> Rational.__new__(Rational)
+    INTFRAC_to_mpq(e.value, d)
+    clear_stack()
+    return e
+
+
+def _rank_pari(Matrix_rational_dense self):
+    """
+    Return the rank of this matrix computed using pari.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_rational_pari import _rank_pari
+        sage: _rank_pari(matrix(QQ, 3, [1..9]))
+        2
+        sage: _rank_pari(matrix(QQ, 0, 0))
+        0
+    """
+    sig_on()
+    cdef long r = rank(_new_GEN_from_fmpq_mat_t(self._matrix))
+    clear_stack()
+    return r
+
+
+def _multiply_pari(Matrix_rational_dense self, Matrix_rational_dense right):
+    """
+    Return the product of ``self`` and ``right``, computed using PARI.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_rational_pari import _multiply_pari
+        sage: _multiply_pari(matrix(QQ,2,[1/5,-2/3,3/4,4/9]), matrix(QQ,2,[1,2,3,4]))
+        [  -9/5 -34/15]
+        [ 25/12  59/18]
+
+    We verify that 0 rows or columns works::
+
+        sage: x = matrix(QQ,2,0); y = matrix(QQ,0,2); x*y
+        [0 0]
+        [0 0]
+        sage: matrix(ZZ, 0, 0) * matrix(QQ, 0, 5)
+        []
+    """
+    if self._ncols != right._nrows:
+        raise ArithmeticError("self must be a square matrix")
+    if not self._ncols*self._nrows or not right._ncols*right._nrows:
+        # pari doesn't work in case of 0 rows or columns
+        # This case is easy, since the answer must be the 0 matrix.
+        return self.matrix_space(self._nrows, right._ncols).zero_matrix().__copy__()
+    sig_on()
+    cdef GEN M = gmul(_new_GEN_from_fmpq_mat_t(self._matrix),
+                      _new_GEN_from_fmpq_mat_t(right._matrix))
+    A = new_matrix_from_pari_GEN(self.matrix_space(self._nrows, right._ncols), M)
+    clear_stack()
+    return A
+
+
+def _invert_pari(Matrix_rational_dense self):
+    """
+    Return the inverse of this matrix computed using PARI.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_rational_pari import _invert_pari
+        sage: _invert_pari(matrix(QQ, 2, [1,2,3,4]))
+        [  -2    1]
+        [ 3/2 -1/2]
+        sage: _invert_pari(matrix(QQ, 2, [1,2,2,4]))
+        Traceback (most recent call last):
+        ...
+        PariError: impossible inverse in ginv: [1, 2; 2, 4]
+    """
+    if self._nrows != self._ncols:
+        raise ValueError("self must be a square matrix")
+    cdef GEN M, d
+
+    sig_on()
+    M = _new_GEN_from_fmpq_mat_t(self._matrix)
+    d = ginv(M)
+    # Convert matrix back to Sage.
+    A = new_matrix_from_pari_GEN(self._parent, d)
+    clear_stack()
+    return A
+
+
+cdef new_matrix_from_pari_GEN(parent, GEN d):
+    """
+    Given a PARI GEN with ``t_INT`` or ``t_FRAC entries, create a
+    :class:`Matrix_rational_dense` from it.
+
+    EXAMPLES::
+
+        sage: from sage.matrix.matrix_rational_pari import _multiply_pari
+        sage: _multiply_pari(matrix(QQ, 2, [1..4]), matrix(QQ, 2, [2..5]))  # indirect doctest
+        [10 13]
+        [22 29]
+    """
+    cdef Py_ssize_t i, j
+    cdef Matrix_rational_dense B = Matrix_rational_dense.__new__(
+        Matrix_rational_dense, parent, None, None, None)
+    cdef mpq_t tmp
+    mpq_init(tmp)
+    for i in range(B._nrows):
+        for j in range(B._ncols):
+            INTFRAC_to_mpq(tmp, gcoeff(d, i+1, j+1))
+            fmpq_set_mpq(fmpq_mat_entry(B._matrix, i, j), tmp)
+    mpq_clear(tmp)
+    return B

--- a/src/sage/matrix/matrix_rational_pari.pyx
+++ b/src/sage/matrix/matrix_rational_pari.pyx
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 
 from cysignals.signals cimport sig_on, sig_off
 from cysignals.memory cimport sig_malloc, sig_free

--- a/src/sage/matrix/matrix_rational_sparse.pyx
+++ b/src/sage/matrix/matrix_rational_sparse.pyx
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-linbox
+# sage_setup: distribution = sagemath-flint
 """
 Sparse rational matrices
 

--- a/src/sage/rings/number_field/S_unit_solver.py
+++ b/src/sage/rings/number_field/S_unit_solver.py
@@ -58,7 +58,6 @@ AUTHORS:
 
 
 from sage.rings.infinity import Infinity
-from sage.symbolic.ring import SR
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.real_mpfr import RealField, RR
@@ -71,6 +70,7 @@ from sage.rings.finite_rings.integer_mod_ring import Integers
 from sage.rings.finite_rings.integer_mod import mod
 from sage.rings.padics.factory import Qp
 from sage.combinat.combination import Combinations
+from sage.rings.polynomial.polynomial_ring import polygen
 from sage.misc.misc_c import prod
 from sage.arith.functions import lcm
 from sage.arith.misc import gcd, CRT, factorial
@@ -671,7 +671,7 @@ def Yu_bound(SUK, v, prec=106):
     else:
         # K and v don't satisfy the theorem hypotheses, and we must move to a quadratic extension L.
         # For justification of this next bound, see [AKMRVW].
-        x = SR.var('x')
+        x = polygen(ZZ, 'x')
         if p == 2:
             L_over_K = K.extension(x**2 + x + 1, 'xi0')
         else:

--- a/src/sage/rings/number_field/number_field_base.pyx
+++ b/src/sage/rings/number_field/number_field_base.pyx
@@ -311,7 +311,7 @@ cdef class NumberField(Field):
 
         The bound of course also works for the rational numbers::
 
-            sage: QQ.minkowski_bound()
+            sage: QQ.minkowski_bound()                                                  # needs sage.symbolic
             1
         """
         _, s = self.signature()

--- a/src/sage/rings/valuation/augmented_valuation.py
+++ b/src/sage/rings/valuation/augmented_valuation.py
@@ -1065,7 +1065,7 @@ class FinalAugmentedValuation(AugmentedValuation_base, FinalInductiveValuation):
             sage: R.<x> = K[]
             sage: v0 = GaussValuation(R, valuations.TrivialValuation(K))
             sage: v = v0.augmentation(x^2 + x + 2, 1)
-            sage: v.lift(v.reduce(x)) == x
+            sage: v.lift(v.reduce(x)) == x                                              # needs sage.libs.singular
             True
         """
         F = self.residue_ring().coerce(F)

--- a/src/sage/rings/valuation/valuation.py
+++ b/src/sage/rings/valuation/valuation.py
@@ -609,7 +609,7 @@ class DiscreteValuation(DiscretePseudoValuation):
 
         Another problematic case::
 
-            sage: # needs sage.rings.number_field sage.rings.padics
+            sage: # needs sage.geometry.polyhedron sage.rings.number_field sage.rings.padics
             sage: R.<x> = QQ[]
             sage: Delta = (x^12 + 20*x^11 + 154*x^10 + 664*x^9 + 1873*x^8 + 3808*x^7 + 5980*x^6
             ....:           + 7560*x^5 + 7799*x^4 + 6508*x^3 + 4290*x^2 + 2224*x + 887)


### PR DESCRIPTION
Moving these modules to **sagemath-flint** (from **sagemath-linbox**).

Methods depending on Linbox, IML, Pari are split out to separate Cython modules, which are imported at runtime when needed.