### PR TITLE
pkgs/sagemath-symbolics: Remove pari dependency

### DIFF
--- a/pkgs/sagemath-symbolics/known-test-failures.json
+++ b/pkgs/sagemath-symbolics/known-test-failures.json
@@ -10,23 +10,19 @@
         "ntests": 67
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra": {
-        "ntests": 167
+        "ntests": 160
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_element": {
-        "ntests": 98
-    },
-    "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_ideal": {
-        "ntests": 42
+        "ntests": 92
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_morphism": {
-        "ntests": 59
+        "ntests": 49
     },
     "sage.algebras.finite_gca": {
         "ntests": 88
     },
     "sage.algebras.octonion_algebra": {
-        "failed": true,
-        "ntests": 217
+        "ntests": 208
     },
     "sage.algebras.orlik_solomon": {
         "ntests": 67
@@ -41,15 +37,12 @@
     "sage.all__sagemath_modules": {
         "ntests": 4
     },
-    "sage.all__sagemath_pari": {
-        "ntests": 3
-    },
     "sage.arith.functions": {
         "ntests": 36
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1025
+        "ntests": 719
     },
     "sage.arith.numerical_approx": {
         "ntests": 3
@@ -68,10 +61,10 @@
     },
     "sage.calculus.calculus": {
         "failed": true,
-        "ntests": 444
+        "ntests": 434
     },
     "sage.calculus.desolvers": {
-        "ntests": 233
+        "ntests": 220
     },
     "sage.calculus.interpolation": {
         "ntests": 66
@@ -105,7 +98,7 @@
         "ntests": 9
     },
     "sage.categories.additive_magmas": {
-        "ntests": 157
+        "ntests": 153
     },
     "sage.categories.additive_monoids": {
         "ntests": 16
@@ -123,7 +116,7 @@
         "ntests": 8
     },
     "sage.categories.algebras": {
-        "ntests": 23
+        "ntests": 21
     },
     "sage.categories.algebras_with_basis": {
         "ntests": 10
@@ -144,7 +137,7 @@
         "ntests": 42
     },
     "sage.categories.category": {
-        "ntests": 417
+        "ntests": 413
     },
     "sage.categories.category_cy_helper": {
         "ntests": 27
@@ -159,6 +152,7 @@
         "ntests": 328
     },
     "sage.categories.chain_complexes": {
+        "failed": true,
         "ntests": 18
     },
     "sage.categories.coalgebras_with_basis": {
@@ -168,7 +162,7 @@
         "ntests": 6
     },
     "sage.categories.commutative_additive_groups": {
-        "ntests": 21
+        "ntests": 17
     },
     "sage.categories.commutative_additive_monoids": {
         "ntests": 5
@@ -186,11 +180,10 @@
         "ntests": 7
     },
     "sage.categories.commutative_rings": {
-        "failed": true,
-        "ntests": 99
+        "ntests": 64
     },
     "sage.categories.complete_discrete_valuation": {
-        "ntests": 61
+        "ntests": 8
     },
     "sage.categories.complex_reflection_groups": {
         "ntests": 12
@@ -208,7 +201,7 @@
         "ntests": 20
     },
     "sage.categories.discrete_valuation": {
-        "ntests": 53
+        "ntests": 33
     },
     "sage.categories.distributive_magmas_and_additive_magmas": {
         "ntests": 12
@@ -217,11 +210,7 @@
         "ntests": 11
     },
     "sage.categories.domains": {
-        "ntests": 13
-    },
-    "sage.categories.drinfeld_modules": {
-        "failed": true,
-        "ntests": 226
+        "ntests": 6
     },
     "sage.categories.dual": {
         "ntests": 1
@@ -292,9 +281,6 @@
     "sage.categories.examples.semigroups_cython": {
         "ntests": 47
     },
-    "sage.categories.examples.sets_cat": {
-        "ntests": 155
-    },
     "sage.categories.examples.sets_with_grading": {
         "ntests": 14
     },
@@ -302,7 +288,7 @@
         "ntests": 27
     },
     "sage.categories.fields": {
-        "ntests": 128
+        "ntests": 101
     },
     "sage.categories.filtered_algebras": {
         "ntests": 4
@@ -324,7 +310,7 @@
         "ntests": 22
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "ntests": 38
+        "ntests": 15
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -342,8 +328,7 @@
         "ntests": 2
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
-        "failed": true,
-        "ntests": 137
+        "ntests": 125
     },
     "sage.categories.finite_dimensional_nilpotent_lie_algebras_with_basis": {
         "ntests": 12
@@ -355,7 +340,7 @@
         "ntests": 123
     },
     "sage.categories.finite_fields": {
-        "ntests": 14
+        "ntests": 12
     },
     "sage.categories.finite_lattice_posets": {
         "ntests": 7
@@ -385,7 +370,7 @@
         "ntests": 8
     },
     "sage.categories.functor": {
-        "ntests": 135
+        "ntests": 126
     },
     "sage.categories.gcd_domains": {
         "ntests": 5
@@ -448,7 +433,7 @@
         "ntests": 15
     },
     "sage.categories.homset": {
-        "ntests": 200
+        "ntests": 187
     },
     "sage.categories.homsets": {
         "ntests": 56
@@ -463,7 +448,7 @@
         "ntests": 13
     },
     "sage.categories.integral_domains": {
-        "ntests": 21
+        "ntests": 27
     },
     "sage.categories.isomorphic_objects": {
         "ntests": 2
@@ -526,7 +511,7 @@
         "ntests": 133
     },
     "sage.categories.modules_with_basis": {
-        "ntests": 411
+        "ntests": 459
     },
     "sage.categories.monoid_algebras": {
         "ntests": 4
@@ -535,10 +520,10 @@
         "ntests": 65
     },
     "sage.categories.morphism": {
-        "ntests": 128
+        "ntests": 120
     },
     "sage.categories.noetherian_rings": {
-        "ntests": 17
+        "ntests": 16
     },
     "sage.categories.number_fields": {
         "ntests": 17
@@ -565,17 +550,17 @@
         "ntests": 134
     },
     "sage.categories.principal_ideal_domains": {
-        "ntests": 27
+        "ntests": 26
     },
     "sage.categories.pushout": {
         "failed": true,
-        "ntests": 793
+        "ntests": 685
     },
     "sage.categories.quantum_group_representations": {
         "ntests": 10
     },
     "sage.categories.quotient_fields": {
-        "ntests": 103
+        "ntests": 53
     },
     "sage.categories.quotients": {
         "ntests": 2
@@ -593,7 +578,7 @@
         "ntests": 9
     },
     "sage.categories.rings": {
-        "ntests": 202
+        "ntests": 182
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -611,7 +596,7 @@
         "ntests": 9
     },
     "sage.categories.sets_cat": {
-        "ntests": 405
+        "ntests": 396
     },
     "sage.categories.sets_with_grading": {
         "ntests": 22
@@ -668,7 +653,7 @@
         "ntests": 4
     },
     "sage.categories.unique_factorization_domains": {
-        "ntests": 43
+        "ntests": 38
     },
     "sage.categories.unital_algebras": {
         "ntests": 22
@@ -679,113 +664,26 @@
     "sage.categories.with_realizations": {
         "ntests": 32
     },
-    "sage.coding.abstract_code": {
-        "ntests": 136
-    },
-    "sage.coding.bch_code": {
-        "ntests": 82
-    },
-    "sage.coding.binary_code": {
-        "ntests": 336
-    },
     "sage.coding.bounds_catalog": {
         "ntests": 1
-    },
-    "sage.coding.channel": {
-        "ntests": 116
     },
     "sage.coding.channels_catalog": {
         "ntests": 1
     },
     "sage.coding.code_bounds": {
-        "ntests": 27
-    },
-    "sage.coding.code_constructions": {
-        "failed": true,
-        "ntests": 111
+        "ntests": 15
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
     },
-    "sage.coding.cyclic_code": {
-        "failed": true,
-        "ntests": 274
-    },
-    "sage.coding.databases": {
-        "ntests": 1
-    },
-    "sage.coding.decoder": {
-        "ntests": 62
-    },
     "sage.coding.decoders_catalog": {
         "ntests": 1
-    },
-    "sage.coding.encoder": {
-        "ntests": 72
     },
     "sage.coding.encoders_catalog": {
         "ntests": 1
     },
-    "sage.coding.extended_code": {
-        "ntests": 81
-    },
-    "sage.coding.gabidulin_code": {
-        "ntests": 235
-    },
-    "sage.coding.golay_code": {
-        "ntests": 46
-    },
-    "sage.coding.goppa_code": {
-        "failed": true,
-        "ntests": 114
-    },
-    "sage.coding.grs_code": {
-        "failed": true,
-        "ntests": 529
-    },
-    "sage.coding.guruswami_sudan.interpolation": {
-        "failed": true,
-        "ntests": 47
-    },
-    "sage.coding.guruswami_sudan.utils": {
-        "ntests": 17
-    },
-    "sage.coding.hamming_code": {
-        "ntests": 18
-    },
-    "sage.coding.information_set_decoder": {
-        "ntests": 172
-    },
-    "sage.coding.kasami_codes": {
-        "failed": true,
-        "ntests": 40
-    },
-    "sage.coding.linear_code": {
-        "failed": true,
-        "ntests": 314
-    },
-    "sage.coding.linear_code_no_metric": {
-        "ntests": 230
-    },
-    "sage.coding.linear_rank_metric": {
-        "ntests": 138
-    },
-    "sage.coding.parity_check_code": {
-        "ntests": 48
-    },
-    "sage.coding.punctured_code": {
-        "failed": true,
-        "ntests": 111
-    },
-    "sage.coding.reed_muller_code": {
-        "ntests": 168
-    },
     "sage.coding.source_coding.huffman": {
         "ntests": 59
-    },
-    "sage.coding.subfield_subcode": {
-        "failed": true,
-        "ntests": 65
     },
     "sage.combinat.backtrack": {
         "ntests": 27
@@ -794,8 +692,7 @@
         "ntests": 68
     },
     "sage.combinat.combinat": {
-        "failed": true,
-        "ntests": 225
+        "ntests": 186
     },
     "sage.combinat.combinat_cython": {
         "ntests": 21
@@ -813,7 +710,7 @@
         "ntests": 65
     },
     "sage.combinat.free_module": {
-        "ntests": 367
+        "ntests": 358
     },
     "sage.combinat.integer_lists.base": {
         "ntests": 116
@@ -840,20 +737,20 @@
         "ntests": 13
     },
     "sage.combinat.partition": {
-        "ntests": 1149
+        "ntests": 1082
     },
     "sage.combinat.partitions": {
         "ntests": 69
     },
     "sage.combinat.permutation": {
-        "failed": true,
-        "ntests": 1015
+        "ntests": 1013
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
     },
     "sage.combinat.q_analogues": {
-        "ntests": 116
+        "failed": true,
+        "ntests": 104
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -984,19 +881,19 @@
         "ntests": 2
     },
     "sage.combinat.tuple": {
-        "ntests": 33
+        "ntests": 30
     },
     "sage.cpython.atexit": {
         "ntests": 19
     },
     "sage.cpython.debug": {
-        "ntests": 13
+        "ntests": 12
     },
     "sage.cpython.dict_del_by_value": {
         "ntests": 21
     },
     "sage.cpython.getattr": {
-        "ntests": 65
+        "ntests": 64
     },
     "sage.cpython.string.pxd": {
         "ntests": 8
@@ -1007,51 +904,27 @@
     "sage.cpython.wrapperdescr": {
         "ntests": 11
     },
-    "sage.crypto.block_cipher.des": {
-        "ntests": 156
-    },
-    "sage.crypto.block_cipher.present": {
-        "ntests": 138
-    },
     "sage.crypto.boolean_function": {
-        "ntests": 183
+        "ntests": 172
     },
     "sage.crypto.key_exchange.catalog": {
         "ntests": 1
     },
     "sage.crypto.key_exchange.diffie_hellman": {
-        "ntests": 38
+        "ntests": 35
     },
     "sage.crypto.key_exchange.key_exchange_scheme": {
         "ntests": 14
     },
     "sage.crypto.lattice": {
         "failed": true,
-        "ntests": 14
-    },
-    "sage.crypto.lfsr": {
-        "ntests": 29
+        "ntests": 12
     },
     "sage.crypto.mq.mpolynomialsystemgenerator": {
         "ntests": 29
     },
-    "sage.crypto.mq.rijndael_gf": {
-        "failed": true,
-        "ntests": 326
-    },
-    "sage.crypto.mq.sr": {
-        "failed": true,
-        "ntests": 331
-    },
-    "sage.crypto.sbox": {
-        "failed": true,
-        "ntests": 271
-    },
-    "sage.crypto.sboxes": {
-        "ntests": 27
-    },
     "sage.data_structures.bitset": {
-        "ntests": 430
+        "ntests": 419
     },
     "sage.data_structures.blas_dict": {
         "ntests": 61
@@ -1065,9 +938,6 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
-    "sage.databases.conway": {
-        "ntests": 42
-    },
     "sage.databases.sql_db": {
         "ntests": 230
     },
@@ -1075,7 +945,7 @@
         "ntests": 19
     },
     "sage.doctest.external": {
-        "ntests": 45
+        "ntests": 41
     },
     "sage.doctest.fixtures": {
         "ntests": 59
@@ -1088,7 +958,7 @@
         "ntests": 21
     },
     "sage.doctest.parsing": {
-        "ntests": 273
+        "ntests": 271
     },
     "sage.doctest.reporting": {
         "ntests": 126
@@ -1097,7 +967,7 @@
         "ntests": 15
     },
     "sage.doctest.sources": {
-        "ntests": 343
+        "ntests": 341
     },
     "sage.doctest.test": {
         "ntests": 23
@@ -1116,9 +986,6 @@
     },
     "sage.ext.fast_eval": {
         "ntests": 1
-    },
-    "sage.ext.memory": {
-        "ntests": 3
     },
     "sage.features": {
         "ntests": 132
@@ -1163,8 +1030,7 @@
         "ntests": 6
     },
     "sage.features.fricas": {
-        "failed": true,
-        "ntests": 6
+        "ntests": 4
     },
     "sage.features.frobby": {
         "ntests": 3
@@ -1179,7 +1045,7 @@
         "ntests": 3
     },
     "sage.features.graph_generators": {
-        "ntests": 14
+        "ntests": 16
     },
     "sage.features.graphviz": {
         "ntests": 16
@@ -1206,7 +1072,7 @@
         "ntests": 20
     },
     "sage.features.kenzo": {
-        "ntests": 4
+        "ntests": 6
     },
     "sage.features.latex": {
         "ntests": 30
@@ -1244,6 +1110,9 @@
     "sage.features.pandoc": {
         "ntests": 4
     },
+    "sage.features.pari": {
+        "ntests": 3
+    },
     "sage.features.pdf2svg": {
         "ntests": 4
     },
@@ -1266,10 +1135,10 @@
         "ntests": 21
     },
     "sage.features.sagemath": {
-        "ntests": 138
+        "ntests": 130
     },
     "sage.features.sat": {
-        "ntests": 14
+        "ntests": 12
     },
     "sage.features.singular": {
         "ntests": 4
@@ -1305,19 +1174,19 @@
         "ntests": 56
     },
     "sage.functions.error": {
-        "ntests": 22
+        "ntests": 19
     },
     "sage.functions.exp_integral": {
-        "ntests": 66
+        "ntests": 59
     },
     "sage.functions.gamma": {
-        "ntests": 53
+        "ntests": 31
     },
     "sage.functions.generalized": {
         "ntests": 20
     },
     "sage.functions.hyperbolic": {
-        "ntests": 31
+        "ntests": 30
     },
     "sage.functions.hypergeometric": {
         "ntests": 10
@@ -1326,25 +1195,25 @@
         "ntests": 91
     },
     "sage.functions.log": {
-        "ntests": 42
+        "ntests": 29
     },
     "sage.functions.min_max": {
         "ntests": 3
     },
     "sage.functions.orthogonal_polys": {
-        "ntests": 99
+        "ntests": 91
     },
     "sage.functions.other": {
-        "ntests": 98
+        "ntests": 92
     },
     "sage.functions.special": {
-        "ntests": 27
+        "ntests": 26
     },
     "sage.functions.spike_function": {
         "ntests": 24
     },
     "sage.functions.transcendental": {
-        "ntests": 22
+        "ntests": 14
     },
     "sage.functions.trig": {
         "ntests": 43
@@ -1386,7 +1255,7 @@
     },
     "sage.groups.abelian_gps.abelian_group": {
         "failed": true,
-        "ntests": 215
+        "ntests": 216
     },
     "sage.groups.abelian_gps.abelian_group_element": {
         "ntests": 22
@@ -1402,6 +1271,7 @@
         "ntests": 77
     },
     "sage.groups.additive_abelian.additive_abelian_wrapper": {
+        "failed": true,
         "ntests": 69
     },
     "sage.groups.additive_abelian.qmodnz": {
@@ -1411,16 +1281,16 @@
         "ntests": 73
     },
     "sage.groups.affine_gps.affine_group": {
-        "ntests": 57
+        "ntests": 51
     },
     "sage.groups.affine_gps.euclidean_group": {
-        "ntests": 33
+        "ntests": 30
     },
     "sage.groups.affine_gps.group_element": {
-        "ntests": 90
+        "ntests": 99
     },
     "sage.groups.generic": {
-        "ntests": 163
+        "ntests": 71
     },
     "sage.groups.group": {
         "ntests": 41
@@ -1432,23 +1302,22 @@
         "ntests": 13
     },
     "sage.groups.matrix_gps.linear": {
-        "ntests": 44
+        "ntests": 33
     },
     "sage.groups.matrix_gps.matrix_group": {
-        "failed": true,
-        "ntests": 47
+        "ntests": 42
     },
     "sage.groups.matrix_gps.named_group": {
-        "ntests": 18
+        "ntests": 15
     },
     "sage.groups.matrix_gps.orthogonal": {
         "ntests": 40
     },
     "sage.groups.matrix_gps.symplectic": {
-        "ntests": 24
+        "ntests": 23
     },
     "sage.groups.matrix_gps.unitary": {
-        "ntests": 26
+        "ntests": 6
     },
     "sage.groups.old": {
         "ntests": 30
@@ -1458,9 +1327,6 @@
     },
     "sage.groups.perm_gps.partn_ref.data_structures": {
         "ntests": 4
-    },
-    "sage.groups.perm_gps.partn_ref.refinement_binary": {
-        "ntests": 75
     },
     "sage.groups.perm_gps.partn_ref.refinement_lists": {
         "ntests": 3
@@ -1476,7 +1342,7 @@
     },
     "sage.homology.chain_complex": {
         "failed": true,
-        "ntests": 246
+        "ntests": 241
     },
     "sage.homology.chain_complex_morphism": {
         "ntests": 37
@@ -1485,44 +1351,38 @@
         "ntests": 78
     },
     "sage.homology.homology_group": {
-        "ntests": 18
+        "ntests": 17
     },
     "sage.homology.koszul_complex": {
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
+        "failed": true,
         "ntests": 5
     },
     "sage.interfaces.abc": {
         "ntests": 8
     },
-    "sage.interfaces.fricas": {
-        "ntests": 276
-    },
-    "sage.interfaces.genus2reduction": {
-        "ntests": 23
-    },
-    "sage.interfaces.gp": {
-        "ntests": 139
-    },
     "sage.interfaces.magma": {
+        "failed": true,
         "ntests": 83
     },
     "sage.interfaces.maple": {
         "ntests": 19
     },
     "sage.interfaces.mathematica": {
-        "ntests": 25
+        "ntests": 24
     },
     "sage.interfaces.mathics": {
-        "ntests": 30
+        "ntests": 29
     },
     "sage.interfaces.maxima": {
+        "failed": true,
         "ntests": 191
     },
     "sage.interfaces.maxima_abstract": {
         "failed": true,
-        "ntests": 237
+        "ntests": 231
     },
     "sage.interfaces.maxima_lib": {
         "ntests": 225
@@ -1531,7 +1391,7 @@
         "ntests": 39
     },
     "sage.interfaces.quit": {
-        "ntests": 14
+        "ntests": 7
     },
     "sage.interfaces.sagespawn": {
         "ntests": 34
@@ -1540,7 +1400,7 @@
         "ntests": 319
     },
     "sage.interfaces.sympy_wrapper": {
-        "ntests": 28
+        "ntests": 27
     },
     "sage.interfaces.tab_completion": {
         "ntests": 13
@@ -1570,19 +1430,19 @@
         "ntests": 84
     },
     "sage.libs.flint.nmod_poly_linkage.pxi": {
-        "ntests": 205
+        "ntests": 101
     },
     "sage.libs.flint.qsieve": {
         "ntests": 2
     },
     "sage.libs.flint.qsieve_sage": {
-        "ntests": 4
+        "ntests": 1
     },
     "sage.libs.flint.ulong_extras": {
         "ntests": 2
     },
     "sage.libs.flint.ulong_extras_sage": {
-        "ntests": 3
+        "ntests": 2
     },
     "sage.libs.gsl.array": {
         "ntests": 22
@@ -1595,19 +1455,6 @@
     },
     "sage.libs.ntl.ntl_GF2": {
         "ntests": 50
-    },
-    "sage.libs.ntl.ntl_GF2E": {
-        "ntests": 70
-    },
-    "sage.libs.ntl.ntl_GF2EContext": {
-        "ntests": 20
-    },
-    "sage.libs.ntl.ntl_GF2EX": {
-        "ntests": 31
-    },
-    "sage.libs.ntl.ntl_GF2X": {
-        "failed": true,
-        "ntests": 112
     },
     "sage.libs.ntl.ntl_GF2X_linkage.pxi": {
         "ntests": 86
@@ -1633,14 +1480,11 @@
     "sage.libs.ntl.ntl_ZZ_pEX": {
         "ntests": 304
     },
-    "sage.libs.ntl.ntl_ZZ_pEX_linkage.pxi": {
-        "ntests": 79
-    },
     "sage.libs.ntl.ntl_ZZ_pX": {
         "ntests": 279
     },
     "sage.libs.ntl.ntl_lzz_p": {
-        "ntests": 48
+        "ntests": 45
     },
     "sage.libs.ntl.ntl_lzz_pContext": {
         "ntests": 21
@@ -1651,40 +1495,6 @@
     "sage.libs.ntl.ntl_mat_GF2": {
         "ntests": 107
     },
-    "sage.libs.ntl.ntl_mat_GF2E": {
-        "ntests": 132
-    },
-    "sage.libs.ntl.ntl_mat_ZZ": {
-        "failed": true,
-        "ntests": 119
-    },
-    "sage.libs.pari": {
-        "ntests": 33
-    },
-    "sage.libs.pari.convert_flint": {
-        "ntests": 2
-    },
-    "sage.libs.pari.convert_gmp": {
-        "ntests": 16
-    },
-    "sage.libs.pari.convert_sage": {
-        "ntests": 85
-    },
-    "sage.libs.pari.convert_sage_complex_double": {
-        "ntests": 21
-    },
-    "sage.libs.pari.convert_sage_matrix": {
-        "ntests": 19
-    },
-    "sage.libs.pari.convert_sage_real_double": {
-        "ntests": 2
-    },
-    "sage.libs.pari.convert_sage_real_mpfr": {
-        "ntests": 7
-    },
-    "sage.libs.pari.tests": {
-        "ntests": 652
-    },
     "sage.manifolds.calculus_method": {
         "ntests": 86
     },
@@ -1692,10 +1502,10 @@
         "ntests": 58
     },
     "sage.manifolds.chart": {
-        "ntests": 547
+        "ntests": 539
     },
     "sage.manifolds.chart_func": {
-        "ntests": 838
+        "ntests": 832
     },
     "sage.manifolds.continuous_map": {
         "ntests": 411
@@ -1761,7 +1571,8 @@
         "ntests": 115
     },
     "sage.manifolds.differentiable.manifold": {
-        "ntests": 564
+        "failed": true,
+        "ntests": 563
     },
     "sage.manifolds.differentiable.manifold_homset": {
         "ntests": 283
@@ -1833,7 +1644,7 @@
         "ntests": 294
     },
     "sage.manifolds.manifold": {
-        "ntests": 497
+        "ntests": 495
     },
     "sage.manifolds.manifold_homset": {
         "ntests": 92
@@ -1887,41 +1698,39 @@
         "ntests": 28
     },
     "sage.matrix.action": {
-        "ntests": 105
+        "ntests": 100
     },
     "sage.matrix.args": {
-        "ntests": 168
+        "ntests": 156
     },
     "sage.matrix.berlekamp_massey": {
-        "ntests": 7
+        "ntests": 6
     },
-    "sage.matrix.compute_J_ideal": {
-        "failed": true,
-        "ntests": 99
+    "sage.matrix.change_ring": {
+        "ntests": 4
     },
     "sage.matrix.constructor": {
-        "ntests": 152
+        "ntests": 151
     },
     "sage.matrix.docs": {
         "ntests": 55
     },
     "sage.matrix.echelon_matrix": {
-        "ntests": 12
+        "ntests": 9
     },
     "sage.matrix.matrix0": {
         "failed": true,
-        "ntests": 795
+        "ntests": 754
     },
     "sage.matrix.matrix1": {
-        "failed": true,
-        "ntests": 405
+        "ntests": 387
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 1948
+        "ntests": 1688
     },
     "sage.matrix.matrix_cdv": {
-        "ntests": 10
+        "ntests": 3
     },
     "sage.matrix.matrix_complex_ball_dense": {
         "ntests": 115
@@ -1933,7 +1742,7 @@
         "ntests": 33
     },
     "sage.matrix.matrix_double_dense": {
-        "ntests": 146
+        "ntests": 137
     },
     "sage.matrix.matrix_double_sparse": {
         "ntests": 23
@@ -1942,7 +1751,22 @@
         "ntests": 51
     },
     "sage.matrix.matrix_generic_sparse": {
-        "ntests": 91
+        "ntests": 90
+    },
+    "sage.matrix.matrix_integer_dense": {
+        "failed": true,
+        "ntests": 577
+    },
+    "sage.matrix.matrix_integer_dense_hnf": {
+        "failed": true,
+        "ntests": 125
+    },
+    "sage.matrix.matrix_integer_dense_saturation": {
+        "ntests": 44
+    },
+    "sage.matrix.matrix_integer_sparse": {
+        "failed": true,
+        "ntests": 98
     },
     "sage.matrix.matrix_laurent_mpolynomial_dense": {
         "failed": true,
@@ -1953,7 +1777,7 @@
     },
     "sage.matrix.matrix_modn_dense_template.pxi": {
         "failed": true,
-        "ntests": 560
+        "ntests": 445
     },
     "sage.matrix.matrix_numpy_dense": {
         "ntests": 61
@@ -1962,17 +1786,25 @@
         "ntests": 8
     },
     "sage.matrix.matrix_polynomial_dense": {
-        "ntests": 535
+        "ntests": 516
+    },
+    "sage.matrix.matrix_rational_dense": {
+        "failed": true,
+        "ntests": 312
+    },
+    "sage.matrix.matrix_rational_sparse": {
+        "failed": true,
+        "ntests": 56
     },
     "sage.matrix.matrix_real_double_dense": {
         "ntests": 10
     },
     "sage.matrix.matrix_space": {
         "failed": true,
-        "ntests": 402
+        "ntests": 382
     },
     "sage.matrix.matrix_sparse": {
-        "ntests": 162
+        "ntests": 157
     },
     "sage.matrix.matrix_symbolic_dense": {
         "ntests": 207
@@ -1988,17 +1820,18 @@
     },
     "sage.matrix.special": {
         "failed": true,
-        "ntests": 431
+        "ntests": 414
     },
     "sage.matrix.strassen": {
         "failed": true,
         "ntests": 69
     },
     "sage.matrix.symplectic_basis": {
+        "failed": true,
         "ntests": 46
     },
     "sage.matrix.tests": {
-        "ntests": 15
+        "ntests": 13
     },
     "sage.matroids.advanced": {
         "ntests": 1
@@ -2010,19 +1843,17 @@
         "ntests": 147
     },
     "sage.matroids.circuit_closures_matroid": {
-        "ntests": 83
+        "ntests": 71
     },
     "sage.matroids.circuits_matroid": {
-        "ntests": 119
-    },
-    "sage.matroids.constructor": {
         "ntests": 107
     },
-    "sage.matroids.database_collections": {
-        "ntests": 8
+    "sage.matroids.constructor": {
+        "ntests": 99
     },
     "sage.matroids.database_matroids": {
-        "ntests": 517
+        "failed": true,
+        "ntests": 349
     },
     "sage.matroids.dual_matroid": {
         "ntests": 77
@@ -2030,15 +1861,13 @@
     "sage.matroids.extension": {
         "ntests": 48
     },
-    "sage.matroids.lean_matrix": {
-        "ntests": 282
-    },
     "sage.matroids.linear_matroid": {
         "failed": true,
-        "ntests": 618
+        "ntests": 542
     },
     "sage.matroids.matroid": {
-        "ntests": 845
+        "failed": true,
+        "ntests": 828
     },
     "sage.matroids.minor_matroid": {
         "ntests": 73
@@ -2053,7 +1882,7 @@
         "ntests": 40
     },
     "sage.matroids.unpickling": {
-        "ntests": 64
+        "ntests": 57
     },
     "sage.matroids.utilities": {
         "ntests": 45
@@ -2078,7 +1907,7 @@
     },
     "sage.misc.cachefunc": {
         "failed": true,
-        "ntests": 719
+        "ntests": 640
     },
     "sage.misc.call": {
         "ntests": 26
@@ -2103,7 +1932,7 @@
         "ntests": 53
     },
     "sage.misc.decorators": {
-        "ntests": 127
+        "ntests": 129
     },
     "sage.misc.defaults": {
         "ntests": 14
@@ -2138,7 +1967,7 @@
         "ntests": 32
     },
     "sage.misc.functional": {
-        "ntests": 216
+        "ntests": 179
     },
     "sage.misc.html": {
         "ntests": 64
@@ -2153,8 +1982,7 @@
         "ntests": 63
     },
     "sage.misc.latex": {
-        "failed": true,
-        "ntests": 217
+        "ntests": 216
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -2170,16 +1998,16 @@
     },
     "sage.misc.lazy_import": {
         "failed": true,
-        "ntests": 276
+        "ntests": 274
     },
     "sage.misc.lazy_import_cache": {
         "ntests": 8
     },
     "sage.misc.lazy_list": {
-        "ntests": 237
+        "ntests": 208
     },
     "sage.misc.lazy_string": {
-        "ntests": 137
+        "ntests": 129
     },
     "sage.misc.map_threaded": {
         "ntests": 1
@@ -2194,7 +2022,7 @@
         "ntests": 155
     },
     "sage.misc.misc_c": {
-        "ntests": 121
+        "ntests": 120
     },
     "sage.misc.mrange": {
         "ntests": 96
@@ -2224,7 +2052,7 @@
         "ntests": 135
     },
     "sage.misc.prandom": {
-        "ntests": 72
+        "ntests": 70
     },
     "sage.misc.python": {
         "ntests": 7
@@ -2249,7 +2077,7 @@
         "ntests": 11
     },
     "sage.misc.sage_eval": {
-        "ntests": 34
+        "ntests": 28
     },
     "sage.misc.sage_input": {
         "ntests": 727
@@ -2258,17 +2086,17 @@
         "ntests": 41
     },
     "sage.misc.sage_timeit": {
-        "ntests": 34
+        "ntests": 33
     },
     "sage.misc.sage_timeit_class": {
-        "ntests": 6
+        "ntests": 5
     },
     "sage.misc.sage_unittest": {
         "ntests": 88
     },
     "sage.misc.sagedoc": {
         "failed": true,
-        "ntests": 88
+        "ntests": 87
     },
     "sage.misc.sageinspect": {
         "ntests": 280
@@ -2302,7 +2130,7 @@
         "ntests": 18
     },
     "sage.misc.timing": {
-        "ntests": 29
+        "ntests": 25
     },
     "sage.misc.trace": {
         "ntests": 4
@@ -2317,10 +2145,7 @@
         "ntests": 49
     },
     "sage.misc.weak_dict": {
-        "ntests": 281
-    },
-    "sage.modular.modform.eis_series_cython": {
-        "ntests": 6
+        "ntests": 247
     },
     "sage.modular.modsym.apply": {
         "ntests": 6
@@ -2331,41 +2156,37 @@
     },
     "sage.modules.fg_pid.fgp_module": {
         "failed": true,
-        "ntests": 0
+        "ntests": 420
     },
     "sage.modules.fg_pid.fgp_morphism": {
         "failed": true,
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "ntests": 160
+        "ntests": 155
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1445
+        "ntests": 1425
     },
     "sage.modules.free_module_element": {
-        "failed": true,
-        "ntests": 822
+        "ntests": 785
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
     },
     "sage.modules.free_module_morphism": {
-        "failed": true,
-        "ntests": 154
+        "ntests": 153
     },
     "sage.modules.free_quadratic_module": {
-        "failed": true,
-        "ntests": 306
+        "ntests": 304
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
         "failed": true,
-        "ntests": 0
+        "ntests": 90
     },
     "sage.modules.matrix_morphism": {
-        "failed": true,
-        "ntests": 387
+        "ntests": 383
     },
     "sage.modules.misc": {
         "ntests": 20
@@ -2374,13 +2195,14 @@
         "ntests": 41
     },
     "sage.modules.module_functors": {
+        "failed": true,
         "ntests": 57
     },
     "sage.modules.multi_filtered_vector_space": {
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "ntests": 124
+        "ntests": 120
     },
     "sage.modules.real_double_vector": {
         "ntests": 2
@@ -2394,7 +2216,7 @@
     },
     "sage.modules.torsion_quadratic_module": {
         "failed": true,
-        "ntests": 153
+        "ntests": 141
     },
     "sage.modules.tutorial_free_modules": {
         "ntests": 43
@@ -2412,7 +2234,7 @@
         "ntests": 43
     },
     "sage.modules.vector_modn_dense": {
-        "ntests": 74
+        "ntests": 57
     },
     "sage.modules.vector_numpy_dense": {
         "ntests": 41
@@ -2430,7 +2252,7 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "ntests": 144
+        "ntests": 138
     },
     "sage.modules.vector_symbolic_dense": {
         "ntests": 28
@@ -2451,7 +2273,7 @@
         "ntests": 47
     },
     "sage.parallel.decorate": {
-        "ntests": 85
+        "ntests": 78
     },
     "sage.parallel.map_reduce": {
         "ntests": 284
@@ -2475,83 +2297,46 @@
         "ntests": 239
     },
     "sage.probability.random_variable": {
-        "ntests": 19
+        "ntests": 17
     },
     "sage.quadratic_forms.binary_qf": {
-        "ntests": 355
-    },
-    "sage.quadratic_forms.bqf_class_group": {
-        "ntests": 158
+        "ntests": 258
     },
     "sage.quadratic_forms.constructions": {
         "ntests": 4
     },
     "sage.quadratic_forms.count_local_2": {
-        "ntests": 23
+        "ntests": 16
     },
     "sage.quadratic_forms.extras": {
         "failed": true,
-        "ntests": 17
-    },
-    "sage.quadratic_forms.genera.genus": {
-        "failed": true,
-        "ntests": 494
-    },
-    "sage.quadratic_forms.genera.normal_form": {
-        "failed": true,
-        "ntests": 275
-    },
-    "sage.quadratic_forms.qfsolve": {
-        "ntests": 38
+        "ntests": 16
     },
     "sage.quadratic_forms.quadratic_form": {
-        "ntests": 194
-    },
-    "sage.quadratic_forms.quadratic_form__automorphisms": {
-        "ntests": 47
+        "failed": true,
+        "ntests": 176
     },
     "sage.quadratic_forms.quadratic_form__count_local_2": {
         "ntests": 19
     },
     "sage.quadratic_forms.quadratic_form__equivalence_testing": {
-        "ntests": 72
+        "ntests": 38
     },
     "sage.quadratic_forms.quadratic_form__evaluate": {
         "ntests": 9
     },
-    "sage.quadratic_forms.quadratic_form__genus": {
-        "ntests": 10
-    },
     "sage.quadratic_forms.quadratic_form__local_density_congruence": {
-        "ntests": 134
-    },
-    "sage.quadratic_forms.quadratic_form__local_density_interfaces": {
-        "ntests": 18
+        "ntests": 129
     },
     "sage.quadratic_forms.quadratic_form__local_field_invariants": {
-        "ntests": 141
-    },
-    "sage.quadratic_forms.quadratic_form__local_normal_form": {
-        "ntests": 18
-    },
-    "sage.quadratic_forms.quadratic_form__mass": {
-        "ntests": 4
-    },
-    "sage.quadratic_forms.quadratic_form__mass__Conway_Sloane_masses": {
-        "ntests": 53
-    },
-    "sage.quadratic_forms.quadratic_form__mass__Siegel_densities": {
-        "ntests": 9
+        "failed": true,
+        "ntests": 103
     },
     "sage.quadratic_forms.quadratic_form__neighbors": {
-        "failed": true,
-        "ntests": 31
+        "ntests": 23
     },
     "sage.quadratic_forms.quadratic_form__reduction_theory": {
         "ntests": 17
-    },
-    "sage.quadratic_forms.quadratic_form__siegel_product": {
-        "ntests": 13
     },
     "sage.quadratic_forms.quadratic_form__split_local_covering": {
         "failed": true,
@@ -2559,10 +2344,10 @@
     },
     "sage.quadratic_forms.quadratic_form__ternary_Tornaria": {
         "failed": true,
-        "ntests": 97
+        "ntests": 58
     },
     "sage.quadratic_forms.quadratic_form__theta": {
-        "ntests": 18
+        "ntests": 13
     },
     "sage.quadratic_forms.quadratic_form__variable_substitutions": {
         "ntests": 23
@@ -2570,14 +2355,12 @@
     "sage.quadratic_forms.random_quadraticform": {
         "ntests": 13
     },
-    "sage.quadratic_forms.special_values": {
-        "ntests": 15
-    },
     "sage.quadratic_forms.ternary": {
-        "ntests": 111
+        "ntests": 97
     },
     "sage.quadratic_forms.ternary_qf": {
-        "ntests": 309
+        "failed": true,
+        "ntests": 286
     },
     "sage.repl.attach": {
         "ntests": 135
@@ -2609,11 +2392,11 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 104
+        "ntests": 105
     },
     "sage.repl.ipython_extension": {
         "failed": true,
-        "ntests": 80
+        "ntests": 78
     },
     "sage.repl.ipython_kernel.install": {
         "failed": true,
@@ -2691,139 +2474,77 @@
         "ntests": 36
     },
     "sage.rings.abc": {
-        "ntests": 65
-    },
-    "sage.rings.algebraic_closure_finite_field": {
-        "failed": true,
-        "ntests": 213
+        "ntests": 55
     },
     "sage.rings.bernmm": {
-        "ntests": 25
-    },
-    "sage.rings.bernoulli_mod_p": {
-        "ntests": 26
+        "ntests": 13
     },
     "sage.rings.big_oh": {
-        "ntests": 22
+        "ntests": 12
     },
     "sage.rings.complex_arb": {
-        "ntests": 588
+        "ntests": 567
     },
     "sage.rings.complex_conversion": {
         "ntests": 3
     },
     "sage.rings.complex_double": {
-        "ntests": 302
+        "ntests": 271
     },
     "sage.rings.complex_interval": {
         "ntests": 256
     },
     "sage.rings.complex_interval_field": {
-        "ntests": 125
+        "ntests": 123
     },
     "sage.rings.complex_mpc": {
-        "ntests": 389
+        "ntests": 366
     },
     "sage.rings.complex_mpfr": {
-        "ntests": 500
+        "ntests": 444
     },
     "sage.rings.continued_fraction": {
-        "ntests": 166
+        "ntests": 165
     },
     "sage.rings.continued_fraction_gosper": {
         "ntests": 21
     },
+    "sage.rings.convert.mpfi": {
+        "ntests": 52
+    },
     "sage.rings.derivation": {
-        "ntests": 403
+        "ntests": 381
     },
     "sage.rings.factorint": {
-        "ntests": 24
-    },
-    "sage.rings.factorint_flint": {
-        "ntests": 10
-    },
-    "sage.rings.factorint_pari": {
-        "ntests": 3
-    },
-    "sage.rings.fast_arith": {
-        "ntests": 20
+        "ntests": 8
     },
     "sage.rings.finite_rings.conway_polynomials": {
-        "ntests": 57
-    },
-    "sage.rings.finite_rings.element_base": {
-        "failed": true,
-        "ntests": 238
-    },
-    "sage.rings.finite_rings.element_ntl_gf2e": {
-        "failed": true,
-        "ntests": 176
-    },
-    "sage.rings.finite_rings.element_pari_ffelt": {
-        "failed": true,
-        "ntests": 278
-    },
-    "sage.rings.finite_rings.finite_field_base": {
-        "failed": true,
-        "ntests": 325
-    },
-    "sage.rings.finite_rings.finite_field_constructor": {
-        "failed": true,
-        "ntests": 110
-    },
-    "sage.rings.finite_rings.finite_field_ntl_gf2e": {
-        "failed": true,
-        "ntests": 61
-    },
-    "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "ntests": 41
+        "ntests": 16
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
-        "ntests": 40
-    },
-    "sage.rings.finite_rings.galois_group": {
-        "ntests": 19
-    },
-    "sage.rings.finite_rings.hom_finite_field": {
-        "failed": true,
-        "ntests": 201
+        "ntests": 26
     },
     "sage.rings.finite_rings.hom_prime_finite_field": {
-        "ntests": 21
-    },
-    "sage.rings.finite_rings.homset": {
-        "failed": true,
-        "ntests": 67
-    },
-    "sage.rings.finite_rings.integer_mod": {
-        "ntests": 580
-    },
-    "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 340
-    },
-    "sage.rings.finite_rings.maps_finite_field": {
-        "ntests": 31
-    },
-    "sage.rings.finite_rings.residue_field": {
-        "failed": true,
-        "ntests": 117
-    },
-    "sage.rings.finite_rings.residue_field_ntl_gf2e": {
         "ntests": 10
     },
-    "sage.rings.finite_rings.residue_field_pari_ffelt": {
-        "ntests": 8
+    "sage.rings.finite_rings.integer_mod": {
+        "ntests": 486
+    },
+    "sage.rings.finite_rings.integer_mod_ring": {
+        "ntests": 269
+    },
+    "sage.rings.finite_rings.residue_field": {
+        "ntests": 12
     },
     "sage.rings.fraction_field": {
         "failed": true,
-        "ntests": 216
+        "ntests": 190
     },
     "sage.rings.fraction_field_FpT": {
-        "ntests": 371
+        "ntests": 359
     },
     "sage.rings.fraction_field_element": {
-        "failed": true,
-        "ntests": 188
+        "ntests": 170
     },
     "sage.rings.function_field.constructor": {
         "ntests": 26
@@ -2835,459 +2556,232 @@
         "ntests": 19
     },
     "sage.rings.function_field.differential": {
-        "ntests": 67
+        "ntests": 51
     },
     "sage.rings.function_field.element": {
-        "ntests": 112
+        "ntests": 99
     },
     "sage.rings.function_field.element_rational": {
-        "ntests": 83
+        "ntests": 63
     },
     "sage.rings.function_field.extensions": {
-        "ntests": 3
+        "ntests": 1
     },
     "sage.rings.function_field.function_field": {
-        "ntests": 91
+        "ntests": 75
     },
     "sage.rings.function_field.function_field_rational": {
-        "failed": true,
-        "ntests": 127
+        "ntests": 104
     },
     "sage.rings.function_field.hermite_form_polynomial": {
         "ntests": 21
     },
     "sage.rings.function_field.ideal": {
-        "ntests": 113
+        "ntests": 77
     },
     "sage.rings.function_field.ideal_rational": {
-        "ntests": 150
+        "ntests": 76
     },
     "sage.rings.function_field.maps": {
-        "ntests": 59
+        "ntests": 55
     },
     "sage.rings.function_field.order": {
-        "ntests": 27
+        "ntests": 26
     },
     "sage.rings.function_field.order_basis": {
         "ntests": 35
     },
     "sage.rings.function_field.order_rational": {
-        "failed": true,
-        "ntests": 103
+        "ntests": 60
     },
     "sage.rings.function_field.place": {
-        "ntests": 18
-    },
-    "sage.rings.function_field.place_rational": {
-        "failed": true,
-        "ntests": 23
-    },
-    "sage.rings.function_field.valuation": {
-        "failed": true,
-        "ntests": 224
+        "ntests": 16
     },
     "sage.rings.generic": {
-        "ntests": 78
+        "ntests": 47
     },
     "sage.rings.homset": {
-        "ntests": 38
+        "ntests": 26
     },
     "sage.rings.ideal": {
-        "ntests": 333
+        "ntests": 292
     },
     "sage.rings.ideal_monoid": {
         "ntests": 16
     },
     "sage.rings.infinity": {
-        "ntests": 289
+        "ntests": 285
     },
     "sage.rings.integer": {
-        "ntests": 1130
+        "ntests": 993
     },
     "sage.rings.integer_ring": {
-        "ntests": 225
+        "ntests": 194
     },
     "sage.rings.invariants.invariant_theory": {
         "failed": true,
-        "ntests": 883
+        "ntests": 877
     },
     "sage.rings.invariants.reconstruction": {
-        "ntests": 59
+        "ntests": 58
     },
     "sage.rings.laurent_series_ring": {
-        "ntests": 168
+        "ntests": 138
     },
     "sage.rings.laurent_series_ring_element": {
-        "ntests": 394
+        "ntests": 324
     },
     "sage.rings.localization": {
         "failed": true,
-        "ntests": 165
+        "ntests": 88
     },
     "sage.rings.monomials": {
         "ntests": 3
     },
     "sage.rings.morphism": {
         "failed": true,
-        "ntests": 437
+        "ntests": 338
     },
     "sage.rings.multi_power_series_ring": {
-        "failed": true,
-        "ntests": 230
+        "ntests": 209
     },
     "sage.rings.multi_power_series_ring_element": {
         "failed": true,
-        "ntests": 425
+        "ntests": 413
     },
     "sage.rings.noncommutative_ideals": {
         "ntests": 23
     },
-    "sage.rings.number_field.class_group": {
-        "ntests": 238
-    },
-    "sage.rings.number_field.homset": {
-        "ntests": 129
-    },
-    "sage.rings.number_field.maps": {
-        "ntests": 196
-    },
-    "sage.rings.number_field.morphism": {
-        "ntests": 42
-    },
     "sage.rings.number_field.number_field_element_base": {
         "ntests": 2
-    },
-    "sage.rings.number_field.number_field_ideal_rel": {
-        "failed": true,
-        "ntests": 258
-    },
-    "sage.rings.number_field.number_field_rel": {
-        "ntests": 583
     },
     "sage.rings.number_field.order_ideal": {
         "failed": true,
         "ntests": 200
     },
-    "sage.rings.number_field.selmer_group": {
-        "ntests": 93
-    },
-    "sage.rings.number_field.small_primes_of_degree_one": {
-        "ntests": 41
-    },
-    "sage.rings.number_field.splitting_field": {
-        "ntests": 73
-    },
-    "sage.rings.number_field.totallyreal": {
-        "ntests": 17
-    },
-    "sage.rings.number_field.totallyreal_data": {
-        "ntests": 24
-    },
-    "sage.rings.number_field.totallyreal_phc": {
-        "ntests": 3
-    },
-    "sage.rings.number_field.unit_group": {
-        "failed": true,
-        "ntests": 175
-    },
-    "sage.rings.padics.CA_template.pxi": {
-        "ntests": 311
-    },
-    "sage.rings.padics.CR_template.pxi": {
-        "ntests": 431
-    },
-    "sage.rings.padics.FM_template.pxi": {
-        "ntests": 279
-    },
-    "sage.rings.padics.FP_template.pxi": {
-        "ntests": 342
-    },
-    "sage.rings.padics.eisenstein_extension_generic": {
-        "ntests": 41
-    },
-    "sage.rings.padics.factory": {
-        "ntests": 551
-    },
-    "sage.rings.padics.generic_nodes": {
-        "failed": true,
-        "ntests": 248
-    },
-    "sage.rings.padics.lattice_precision": {
-        "failed": true,
-        "ntests": 434
-    },
-    "sage.rings.padics.local_generic": {
-        "failed": true,
-        "ntests": 232
-    },
-    "sage.rings.padics.local_generic_element": {
-        "ntests": 220
-    },
     "sage.rings.padics.misc": {
-        "ntests": 26
-    },
-    "sage.rings.padics.morphism": {
-        "ntests": 66
-    },
-    "sage.rings.padics.padic_ZZ_pX_CA_element": {
-        "ntests": 464
-    },
-    "sage.rings.padics.padic_ZZ_pX_CR_element": {
-        "ntests": 649
-    },
-    "sage.rings.padics.padic_ZZ_pX_FM_element": {
-        "ntests": 362
-    },
-    "sage.rings.padics.padic_ZZ_pX_element": {
-        "ntests": 125
-    },
-    "sage.rings.padics.padic_base_generic": {
-        "ntests": 41
-    },
-    "sage.rings.padics.padic_base_leaves": {
-        "ntests": 181
-    },
-    "sage.rings.padics.padic_capped_absolute_element": {
-        "ntests": 61
-    },
-    "sage.rings.padics.padic_capped_relative_element": {
-        "ntests": 83
-    },
-    "sage.rings.padics.padic_ext_element": {
-        "ntests": 49
-    },
-    "sage.rings.padics.padic_extension_generic": {
-        "ntests": 208
-    },
-    "sage.rings.padics.padic_extension_leaves": {
-        "ntests": 68
-    },
-    "sage.rings.padics.padic_fixed_mod_element": {
-        "ntests": 66
-    },
-    "sage.rings.padics.padic_floating_point_element": {
-        "ntests": 62
-    },
-    "sage.rings.padics.padic_generic": {
-        "failed": true,
-        "ntests": 235
-    },
-    "sage.rings.padics.padic_generic_element": {
-        "failed": true,
-        "ntests": 795
-    },
-    "sage.rings.padics.padic_lattice_element": {
-        "ntests": 269
-    },
-    "sage.rings.padics.padic_printing": {
-        "ntests": 108
-    },
-    "sage.rings.padics.padic_relaxed_errors": {
-        "ntests": 5
-    },
-    "sage.rings.padics.padic_template_element.pxi": {
-        "ntests": 138
-    },
-    "sage.rings.padics.padic_valuation": {
-        "ntests": 123
+        "ntests": 21
     },
     "sage.rings.padics.pow_computer": {
         "ntests": 88
-    },
-    "sage.rings.padics.pow_computer_ext": {
-        "ntests": 281
-    },
-    "sage.rings.padics.pow_computer_flint": {
-        "ntests": 76
-    },
-    "sage.rings.padics.pow_computer_relative": {
-        "ntests": 97
-    },
-    "sage.rings.padics.qadic_flint_CA": {
-        "ntests": 19
-    },
-    "sage.rings.padics.qadic_flint_CR": {
-        "ntests": 23
-    },
-    "sage.rings.padics.qadic_flint_FM": {
-        "ntests": 17
-    },
-    "sage.rings.padics.qadic_flint_FP": {
-        "ntests": 22
-    },
-    "sage.rings.padics.relative_extension_leaves": {
-        "ntests": 87
-    },
-    "sage.rings.padics.relative_ramified_CA": {
-        "ntests": 9
-    },
-    "sage.rings.padics.relative_ramified_CR": {
-        "ntests": 9
-    },
-    "sage.rings.padics.relative_ramified_FM": {
-        "ntests": 9
-    },
-    "sage.rings.padics.relative_ramified_FP": {
-        "ntests": 9
-    },
-    "sage.rings.padics.relaxed_template.pxi": {
-        "ntests": 509
-    },
-    "sage.rings.padics.tests": {
-        "ntests": 8
-    },
-    "sage.rings.padics.tutorial": {
-        "ntests": 45
-    },
-    "sage.rings.padics.unramified_extension_generic": {
-        "ntests": 33
-    },
-    "sage.rings.pari_ring": {
-        "ntests": 46
     },
     "sage.rings.polynomial.commutative_polynomial": {
         "ntests": 7
     },
     "sage.rings.polynomial.complex_roots": {
+        "failed": true,
         "ntests": 42
     },
     "sage.rings.polynomial.cyclotomic": {
-        "ntests": 33
+        "ntests": 22
     },
     "sage.rings.polynomial.flatten": {
         "failed": true,
-        "ntests": 131
+        "ntests": 130
     },
     "sage.rings.polynomial.hilbert": {
         "ntests": 6
     },
     "sage.rings.polynomial.ideal": {
-        "ntests": 13
+        "ntests": 12
     },
     "sage.rings.polynomial.infinite_polynomial_element": {
         "failed": true,
         "ntests": 0
     },
     "sage.rings.polynomial.infinite_polynomial_ring": {
-        "ntests": 277
+        "ntests": 274
     },
     "sage.rings.polynomial.laurent_polynomial": {
         "failed": true,
-        "ntests": 447
+        "ntests": 423
     },
     "sage.rings.polynomial.laurent_polynomial_mpair": {
         "failed": true,
-        "ntests": 367
+        "ntests": 362
     },
     "sage.rings.polynomial.laurent_polynomial_ring": {
         "failed": true,
         "ntests": 155
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 114
+        "ntests": 112
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 509
+        "ntests": 469
     },
     "sage.rings.polynomial.multi_polynomial_element": {
-        "failed": true,
-        "ntests": 186
+        "ntests": 160
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 147
+        "ntests": 142
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "failed": true,
-        "ntests": 226
+        "ntests": 222
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 70
+        "ntests": 62
     },
     "sage.rings.polynomial.ore_function_element": {
-        "ntests": 232
+        "ntests": 39
     },
     "sage.rings.polynomial.ore_function_field": {
         "failed": true,
-        "ntests": 228
-    },
-    "sage.rings.polynomial.padics.polynomial_padic": {
-        "ntests": 64
-    },
-    "sage.rings.polynomial.padics.polynomial_padic_capped_relative_dense": {
-        "ntests": 143
-    },
-    "sage.rings.polynomial.padics.polynomial_padic_flat": {
-        "ntests": 3
+        "ntests": 52
     },
     "sage.rings.polynomial.polydict": {
-        "ntests": 387
+        "ntests": 386
     },
     "sage.rings.polynomial.polynomial_complex_arb": {
         "ntests": 137
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2309
+        "ntests": 1672
     },
     "sage.rings.polynomial.polynomial_element_generic": {
-        "ntests": 211
+        "ntests": 186
     },
     "sage.rings.polynomial.polynomial_integer_dense_flint": {
-        "ntests": 304
+        "failed": true,
+        "ntests": 288
     },
     "sage.rings.polynomial.polynomial_integer_dense_ntl": {
-        "ntests": 185
-    },
-    "sage.rings.polynomial.polynomial_modn_dense_ntl": {
-        "ntests": 368
-    },
-    "sage.rings.polynomial.polynomial_number_field": {
-        "ntests": 82
-    },
-    "sage.rings.polynomial.polynomial_quotient_ring": {
-        "failed": true,
-        "ntests": 333
-    },
-    "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "ntests": 117
+        "ntests": 169
     },
     "sage.rings.polynomial.polynomial_rational_flint": {
-        "failed": true,
-        "ntests": 386
+        "ntests": 356
     },
     "sage.rings.polynomial.polynomial_real_mpfr_dense": {
-        "ntests": 122
+        "ntests": 119
     },
     "sage.rings.polynomial.polynomial_ring": {
         "failed": true,
-        "ntests": 513
+        "ntests": 350
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
-        "ntests": 128
+        "ntests": 116
     },
     "sage.rings.polynomial.polynomial_ring_homomorphism": {
-        "ntests": 30
+        "ntests": 24
     },
     "sage.rings.polynomial.polynomial_singular_interface": {
-        "ntests": 31
+        "ntests": 19
     },
     "sage.rings.polynomial.polynomial_template.pxi": {
         "failed": true,
-        "ntests": 132
+        "ntests": 126
     },
     "sage.rings.polynomial.polynomial_zmod_flint": {
-        "ntests": 182
-    },
-    "sage.rings.polynomial.polynomial_zz_pex": {
-        "failed": true,
-        "ntests": 154
+        "ntests": 152
     },
     "sage.rings.polynomial.term_order": {
-        "ntests": 243
+        "ntests": 240
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 25
@@ -3296,49 +2790,46 @@
         "ntests": 41
     },
     "sage.rings.polynomial.toy_variety": {
-        "ntests": 43
+        "ntests": 22
     },
     "sage.rings.polynomial.weil.weil_polynomials": {
-        "ntests": 90
+        "ntests": 84
     },
     "sage.rings.power_series_mpoly": {
         "ntests": 4
     },
-    "sage.rings.power_series_pari": {
-        "ntests": 185
-    },
     "sage.rings.power_series_poly": {
-        "ntests": 267
+        "ntests": 257
     },
     "sage.rings.power_series_ring": {
-        "ntests": 239
+        "ntests": 231
     },
     "sage.rings.power_series_ring_element": {
-        "ntests": 471
+        "ntests": 447
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 61
     },
     "sage.rings.puiseux_series_ring_element": {
-        "ntests": 196
+        "ntests": 191
     },
     "sage.rings.quotient_ring": {
-        "ntests": 173
+        "ntests": 154
     },
     "sage.rings.quotient_ring_element": {
         "ntests": 25
     },
     "sage.rings.rational": {
-        "ntests": 524
+        "ntests": 508
     },
     "sage.rings.rational_field": {
-        "ntests": 184
+        "ntests": 164
     },
     "sage.rings.real_arb": {
         "ntests": 479
     },
     "sage.rings.real_double": {
-        "ntests": 285
+        "ntests": 282
     },
     "sage.rings.real_double_element_gsl": {
         "ntests": 133
@@ -3351,31 +2842,23 @@
         "ntests": 261
     },
     "sage.rings.real_mpfi": {
-        "ntests": 834
+        "ntests": 835
     },
     "sage.rings.real_mpfr": {
         "failed": true,
-        "ntests": 995
+        "ntests": 974
     },
     "sage.rings.ring": {
-        "failed": true,
-        "ntests": 169
+        "ntests": 128
     },
     "sage.rings.ring_extension": {
-        "ntests": 350
-    },
-    "sage.rings.ring_extension_conversion": {
-        "ntests": 75
+        "ntests": 97
     },
     "sage.rings.ring_extension_element": {
-        "failed": true,
-        "ntests": 242
-    },
-    "sage.rings.ring_extension_homset": {
-        "ntests": 9
+        "ntests": 38
     },
     "sage.rings.ring_extension_morphism": {
-        "ntests": 131
+        "ntests": 27
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
         "ntests": 12
@@ -3386,77 +2869,32 @@
     "sage.rings.sum_of_squares": {
         "ntests": 35
     },
-    "sage.rings.tate_algebra": {
-        "ntests": 267
-    },
-    "sage.rings.tate_algebra_element": {
-        "ntests": 672
-    },
-    "sage.rings.tate_algebra_ideal": {
-        "failed": true,
-        "ntests": 121
-    },
     "sage.rings.tests": {
-        "ntests": 38
-    },
-    "sage.rings.valuation.augmented_valuation": {
-        "ntests": 416
-    },
-    "sage.rings.valuation.developing_valuation": {
-        "ntests": 59
-    },
-    "sage.rings.valuation.gauss_valuation": {
-        "ntests": 138
-    },
-    "sage.rings.valuation.inductive_valuation": {
-        "ntests": 260
-    },
-    "sage.rings.valuation.limit_valuation": {
-        "ntests": 14
-    },
-    "sage.rings.valuation.scaled_valuation": {
-        "ntests": 40
-    },
-    "sage.rings.valuation.trivial_valuation": {
-        "ntests": 53
-    },
-    "sage.rings.valuation.valuation": {
-        "ntests": 168
-    },
-    "sage.rings.valuation.valuation_space": {
-        "ntests": 198
-    },
-    "sage.rings.valuation.value_group": {
-        "ntests": 100
+        "ntests": 26
     },
     "sage.schemes.affine.affine_homset": {
         "ntests": 42
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 276
+        "ntests": 258
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
-        "ntests": 62
+        "ntests": 60
     },
     "sage.schemes.affine.affine_rational_point": {
         "ntests": 24
     },
     "sage.schemes.affine.affine_space": {
-        "failed": true,
-        "ntests": 156
+        "ntests": 147
     },
     "sage.schemes.affine.affine_subscheme": {
         "ntests": 51
     },
-    "sage.schemes.elliptic_curves.descent_two_isogeny": {
-        "failed": true,
-        "ntests": 17
-    },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
-        "ntests": 276
+        "ntests": 273
     },
     "sage.schemes.generic.ambient_space": {
         "ntests": 59
@@ -3465,20 +2903,20 @@
         "ntests": 36
     },
     "sage.schemes.generic.homset": {
-        "ntests": 118
+        "ntests": 109
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 384
+        "ntests": 383
     },
     "sage.schemes.generic.point": {
         "ntests": 35
     },
     "sage.schemes.generic.scheme": {
-        "ntests": 164
+        "ntests": 156
     },
     "sage.schemes.generic.spec": {
-        "ntests": 31
+        "ntests": 29
     },
     "sage.schemes.product_projective.homset": {
         "ntests": 17
@@ -3493,33 +2931,33 @@
         "ntests": 24
     },
     "sage.schemes.product_projective.space": {
-        "ntests": 144
+        "ntests": 143
     },
     "sage.schemes.product_projective.subscheme": {
-        "ntests": 49
+        "ntests": 44
     },
     "sage.schemes.projective.proj_bdd_height": {
         "ntests": 21
     },
     "sage.schemes.projective.projective_homset": {
-        "ntests": 37
+        "ntests": 36
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 425
+        "ntests": 392
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
-        "ntests": 270
+        "ntests": 233
     },
     "sage.schemes.projective.projective_rational_point": {
-        "ntests": 29
+        "ntests": 27
     },
     "sage.schemes.projective.projective_space": {
-        "ntests": 340
+        "ntests": 333
     },
     "sage.schemes.projective.projective_subscheme": {
-        "ntests": 190
+        "ntests": 182
     },
     "sage.sets.cartesian_product": {
         "ntests": 54
@@ -3528,7 +2966,7 @@
         "ntests": 33
     },
     "sage.sets.disjoint_set": {
-        "ntests": 258
+        "ntests": 261
     },
     "sage.sets.disjoint_union_enumerated_sets": {
         "ntests": 50
@@ -3558,7 +2996,7 @@
         "ntests": 14
     },
     "sage.sets.primes": {
-        "ntests": 38
+        "ntests": 32
     },
     "sage.sets.pythonclass": {
         "ntests": 55
@@ -3570,7 +3008,7 @@
         "ntests": 332
     },
     "sage.sets.set": {
-        "ntests": 387
+        "ntests": 336
     },
     "sage.sets.set_from_iterator": {
         "ntests": 143
@@ -3587,7 +3025,7 @@
     },
     "sage.stats.distributions.discrete_gaussian_lattice": {
         "failed": true,
-        "ntests": 144
+        "ntests": 109
     },
     "sage.stats.distributions.discrete_gaussian_polynomial": {
         "ntests": 22
@@ -3611,11 +3049,10 @@
         "ntests": 295
     },
     "sage.structure.category_object": {
-        "failed": true,
-        "ntests": 148
+        "ntests": 146
     },
     "sage.structure.coerce": {
-        "ntests": 342
+        "ntests": 329
     },
     "sage.structure.coerce_actions": {
         "ntests": 122
@@ -3624,7 +3061,7 @@
         "ntests": 289
     },
     "sage.structure.coerce_maps": {
-        "ntests": 88
+        "ntests": 83
     },
     "sage.structure.debug_options": {
         "ntests": 5
@@ -3634,7 +3071,7 @@
     },
     "sage.structure.element": {
         "failed": true,
-        "ntests": 632
+        "ntests": 598
     },
     "sage.structure.element.pxd": {
         "ntests": 22
@@ -3643,16 +3080,16 @@
         "ntests": 156
     },
     "sage.structure.factorization": {
-        "ntests": 200
+        "ntests": 159
     },
     "sage.structure.factorization_integer": {
         "ntests": 6
     },
     "sage.structure.factory": {
-        "ntests": 107
+        "ntests": 96
     },
     "sage.structure.formal_sum": {
-        "ntests": 70
+        "ntests": 69
     },
     "sage.structure.global_options": {
         "ntests": 132
@@ -3679,20 +3116,20 @@
         "ntests": 11
     },
     "sage.structure.parent": {
-        "ntests": 291
+        "ntests": 278
     },
     "sage.structure.parent_gens": {
-        "ntests": 41
+        "ntests": 29
     },
     "sage.structure.parent_old": {
         "failed": true,
-        "ntests": 9
+        "ntests": 6
     },
     "sage.structure.proof.all": {
         "ntests": 31
     },
     "sage.structure.proof.proof": {
-        "ntests": 50
+        "ntests": 49
     },
     "sage.structure.richcmp": {
         "ntests": 56
@@ -3701,7 +3138,7 @@
         "ntests": 23
     },
     "sage.structure.sage_object": {
-        "ntests": 91
+        "ntests": 74
     },
     "sage.structure.sequence": {
         "ntests": 180
@@ -3719,7 +3156,7 @@
         "ntests": 6
     },
     "sage.structure.unique_representation": {
-        "ntests": 222
+        "ntests": 219
     },
     "sage.symbolic.assumptions": {
         "ntests": 257
@@ -3737,27 +3174,26 @@
         "ntests": 3
     },
     "sage.symbolic.constants": {
-        "ntests": 237
+        "ntests": 230
     },
     "sage.symbolic.constants_c_impl.pxi": {
         "ntests": 38
     },
     "sage.symbolic.expression": {
         "failed": true,
-        "ntests": 3037
+        "ntests": 3018
     },
     "sage.symbolic.expression_conversion_algebraic": {
-        "ntests": 50
+        "ntests": 30
     },
     "sage.symbolic.expression_conversion_sympy": {
         "ntests": 72
     },
     "sage.symbolic.expression_conversions": {
-        "failed": true,
-        "ntests": 431
+        "ntests": 400
     },
     "sage.symbolic.function": {
-        "ntests": 130
+        "ntests": 123
     },
     "sage.symbolic.function_factory": {
         "ntests": 96
@@ -3766,11 +3202,10 @@
         "ntests": 30
     },
     "sage.symbolic.integration.external": {
-        "failed": true,
-        "ntests": 46
+        "ntests": 14
     },
     "sage.symbolic.integration.integral": {
-        "ntests": 213
+        "ntests": 210
     },
     "sage.symbolic.maxima_wrapper": {
         "ntests": 33
@@ -3785,17 +3220,17 @@
         "ntests": 18
     },
     "sage.symbolic.pynac_impl.pxi": {
-        "ntests": 329
+        "ntests": 314
     },
     "sage.symbolic.random_tests": {
         "ntests": 47
     },
     "sage.symbolic.relation": {
-        "ntests": 377
+        "ntests": 367
     },
     "sage.symbolic.ring": {
         "failed": true,
-        "ntests": 263
+        "ntests": 250
     },
     "sage.symbolic.series_impl.pxi": {
         "ntests": 55
@@ -3835,7 +3270,7 @@
         "ntests": 170
     },
     "sage.tensor.modules.free_module_automorphism": {
-        "ntests": 266
+        "ntests": 254
     },
     "sage.tensor.modules.free_module_basis": {
         "ntests": 187
@@ -3850,8 +3285,7 @@
         "ntests": 112
     },
     "sage.tensor.modules.free_module_morphism": {
-        "failed": true,
-        "ntests": 326
+        "ntests": 320
     },
     "sage.tensor.modules.free_module_tensor": {
         "ntests": 638
@@ -3868,21 +3302,14 @@
     "sage.tensor.modules.tensor_free_submodule_basis": {
         "ntests": 31
     },
-    "sage.tests.book_stein_ent": {
-        "failed": true,
-        "ntests": 238
-    },
     "sage.tests.cmdline": {
-        "ntests": 106
+        "ntests": 101
     },
     "sage.tests.functools_partial_src": {
         "ntests": 3
     },
     "sage.tests.numpy": {
         "ntests": 6
-    },
-    "sage.tests.parigp": {
-        "ntests": 7
     },
     "sage.tests.startup": {
         "ntests": 6

--- a/pkgs/sagemath-symbolics/pyproject.toml.m4
+++ b/pkgs/sagemath-symbolics/pyproject.toml.m4
@@ -12,7 +12,6 @@ requires = [
     SPKG_INSTALL_REQUIRES_cython
     SPKG_INSTALL_REQUIRES_gmpy2
     SPKG_INSTALL_REQUIRES_numpy
-    SPKG_INSTALL_REQUIRES_sagemath_pari
     SPKG_INSTALL_REQUIRES_cysignals
 ]
 build-backend = "setuptools.build_meta"
@@ -22,7 +21,6 @@ name = "passagemath-symbolics"
 description = "passagemath: Symbolic calculus"
 dependencies = [
     SPKG_INSTALL_REQUIRES_gmpy2
-    SPKG_INSTALL_REQUIRES_sagemath_pari
     SPKG_INSTALL_REQUIRES_cysignals
     SPKG_INSTALL_REQUIRES_numpy
     SPKG_INSTALL_REQUIRES_sagemath_categories

--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -794,6 +794,7 @@ def nintegral(ex, x, a, b,
     Important note: using PARI/GP one can compute numerical integrals
     to high precision::
 
+        sage: # needs sage.libs.pari
         sage: gp.eval('intnum(x=17,42,exp(-x^2)*log(x))')
         '2.565728500561051474934096410 E-127'            # 32-bit
         '2.5657285005610514829176211363206621657 E-127'  # 64-bit

--- a/src/sage/functions/orthogonal_polys.py
+++ b/src/sage/functions/orthogonal_polys.py
@@ -2633,9 +2633,9 @@ class Func_gen_laguerre(OrthogonalFunction):
             sage: gen_laguerre(3, 1/2, sin(x))                                          # needs sage.symbolic
             -1/6*sin(x)^3 + 7/4*sin(x)^2 - 35/8*sin(x) + 35/16
             sage: R.<x> = PolynomialRing(QQ, 'x')
-            sage: gen_laguerre(4, -1/2, x)                                              # needs mpmath
+            sage: gen_laguerre(4, -1/2, x)                                              # needs mpmath sage.libs.pari
             1/24*x^4 - 7/12*x^3 + 35/16*x^2 - 35/16*x + 35/128
-            sage: gen_laguerre(4, -1/2, x + 1)                                          # needs mpmath
+            sage: gen_laguerre(4, -1/2, x + 1)                                          # needs mpmath sage.libs.pari
             1/24*(x + 1)^4 - 7/12*(x + 1)^3 + 35/16*(x + 1)^2 - 35/16*x - 245/128
             sage: gen_laguerre(10, 1, 1 + I)                                            # needs sage.symbolic
             25189/2100*I + 11792/2835

--- a/src/sage/interfaces/mathematica.py
+++ b/src/sage/interfaces/mathematica.py
@@ -187,7 +187,7 @@ We find the `x` such that `e^x - 3x = 0`.
 
 Note that this agrees with what the PARI interpreter gp produces::
 
-    sage: gp('solve(x=1,2,exp(x)-3*x)')
+    sage: gp('solve(x=1,2,exp(x)-3*x)')                                                 # needs sage.libs.pari
     1.512134551657842473896739678              # 32-bit
     1.5121345516578424738967396780720387046    # 64-bit
 

--- a/src/sage/interfaces/mathics.py
+++ b/src/sage/interfaces/mathics.py
@@ -196,7 +196,7 @@ We find the `x` such that `e^x - 3x = 0`.
 
 Note that this agrees with what the PARI interpreter gp produces::
 
-    sage: gp('solve(x=1,2,exp(x)-3*x)')
+    sage: gp('solve(x=1,2,exp(x)-3*x)')                                                 # needs sage.libs.pari
     1.512134551657842473896739678              # 32-bit
     1.5121345516578424738967396780720387046    # 64-bit
 

--- a/src/sage/interfaces/maxima.py
+++ b/src/sage/interfaces/maxima.py
@@ -251,7 +251,7 @@ We can also compute the echelon form in Sage::
     [  0   0   0   0]
     [  0   0   0   0]
     [  0   0   0   0]
-    sage: B.charpoly('x').factor()
+    sage: B.charpoly('x').factor()                                                      # needs sage.libs.pari
     (x - 4) * x^3
 
 Laplace Transforms

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -945,6 +945,7 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
 
         EXAMPLES::
 
+            sage: # needs sage.rings.number_field
             sage: u = maxima.unit_quadratic_integer(101); u
             a + 10
             sage: u.parent()
@@ -1489,6 +1490,7 @@ class MaximaAbstractElement(ExtraTabCompletion, InterfaceElement):
         Note that GP also does numerical integration, and can do so to very
         high precision very quickly::
 
+            sage: # needs sage.libs.pari
             sage: gp('intnum(x=0,1,exp(-sqrt(x)))')
             0.5284822353142307136179049194             # 32-bit
             0.52848223531423071361790491935415653022   # 64-bit

--- a/src/sage/interfaces/sympy_wrapper.py
+++ b/src/sage/interfaces/sympy_wrapper.py
@@ -133,7 +133,7 @@ class SageSet(Set):
             sage: sPrimes = Primes()._sympy_(); sPrimes
             SageSet(Set of all prime numbers: 2, 3, 5, 7, ...)
             sage: iter_sPrimes = iter(sPrimes)
-            sage: next(iter_sPrimes), next(iter_sPrimes), next(iter_sPrimes)
+            sage: next(iter_sPrimes), next(iter_sPrimes), next(iter_sPrimes)            # needs sage.libs.pari
             (2, 3, 5)
         """
         for element in self._sage_():

--- a/src/sage/libs/flint/nmod_poly_linkage.pxi
+++ b/src/sage/libs/flint/nmod_poly_linkage.pxi
@@ -274,7 +274,7 @@ cdef long celement_len(nmod_poly_t a, unsigned long n) except -2:
         1
         sage: (x).degree()
         1
-        sage: P(0).degree()
+        sage: Q(0).degree()
         -1
     """
     return <long>nmod_poly_length(a)

--- a/src/sage/manifolds/chart_func.py
+++ b/src/sage/manifolds/chart_func.py
@@ -2765,6 +2765,7 @@ class ChartFunctionRing(Parent, UniqueRepresentation):
             sage: FR.zero()
             0
 
+            sage: # needs sage.rings.padics
             sage: M = Manifold(2, 'M', structure='topological', field=Qp(5))
             sage: X.<x,y> = M.chart()
             sage: X.function_ring().zero()
@@ -2791,6 +2792,7 @@ class ChartFunctionRing(Parent, UniqueRepresentation):
             sage: FR.one()
             1
 
+            sage: # needs sage.rings.padics
             sage: M = Manifold(2, 'M', structure='topological', field=Qp(5))
             sage: X.<x,y> = M.chart()
             sage: X.function_ring().one()

--- a/src/sage/manifolds/differentiable/manifold.py
+++ b/src/sage/manifolds/differentiable/manifold.py
@@ -570,6 +570,7 @@ class DifferentiableManifold(TopologicalManifold):
 
     A differentiable manifold over `\QQ_5`, the field of 5-adic numbers::
 
+        sage: # needs sage.rings.padics
         sage: N = Manifold(2, 'N', field=Qp(5)); N
         2-dimensional differentiable manifold N over the 5-adic Field with
          capped relative precision 20

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -1384,7 +1384,7 @@ cdef class ComplexBall(RingElement):
             sage: NF.<a> = QuadraticField(-1, embedding=None)                           # needs sage.rings.number_field
             sage: CBF(a)                                                                # needs sage.rings.number_field
             1.000000000000000*I
-            sage: CBF.coerce(a)
+            sage: CBF.coerce(a)                                                         # needs sage.rings.number_field
             Traceback (most recent call last):
             ...
             TypeError: no canonical coercion ...

--- a/src/sage/rings/complex_mpfr.pyx
+++ b/src/sage/rings/complex_mpfr.pyx
@@ -57,7 +57,7 @@ cimport gmpy2
 gmpy2.import_gmpy2()
 
 try:
-    from sage.libs.pari.all import pari_gen
+    from sage.libs.pari.all import pari_gen, pari
 except ImportError:
     pari_gen = ()
 
@@ -1435,7 +1435,7 @@ cdef class ComplexNumber(sage.structure.element.FieldElement):
         """
         if self.is_real():
             return self.real().__pari__()
-        return sage.libs.pari.all.pari.complex(self.real() or 0, self.imag())
+        return pari.complex(self.real() or 0, self.imag())
 
     def __mpc__(self):
         """

--- a/src/sage/rings/padics/misc.py
+++ b/src/sage/rings/padics/misc.py
@@ -98,15 +98,15 @@ def gauss_sum(a, p, f, prec=20, factored=False, algorithm='pari', parent=None):
     Next, we verify that `g_5(a) g_5(-a) = 5 (-1)^a`::
 
         sage: from sage.rings.padics.misc import gauss_sum
-        sage: gauss_sum(2,5,1)^2 - 5                                                    # needs sage.libs.ntl
+        sage: gauss_sum(2,5,1)^2 - 5                                                    # needs sage.libs.ntl sage.rings.padics
         O(pi^84)
-        sage: gauss_sum(1,5,1)*gauss_sum(3,5,1) + 5                                     # needs sage.libs.ntl
+        sage: gauss_sum(1,5,1)*gauss_sum(3,5,1) + 5                                     # needs sage.libs.ntl sage.rings.padics
         O(pi^84)
 
     Finally, we compute a non-trivial value::
 
         sage: from sage.rings.padics.misc import gauss_sum
-        sage: gauss_sum(2,13,2)                                                         # needs sage.libs.ntl
+        sage: gauss_sum(2,13,2)                                                         # needs sage.libs.ntl sage.rings.padics
         6*pi^2 + 7*pi^14 + 11*pi^26 + 3*pi^62 + 6*pi^74 + 3*pi^86 + 5*pi^98 +
         pi^110 + 7*pi^134 + 9*pi^146 + 4*pi^158 + 6*pi^170 + 4*pi^194 +
         pi^206 + 6*pi^218 + 9*pi^230 + O(pi^242)

--- a/src/sage/rings/polynomial/polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_rational_flint.pyx
@@ -39,8 +39,6 @@ from sage.libs.flint.fmpq_poly_sage cimport *
 from sage.libs.gmp.mpz cimport *
 from sage.libs.gmp.mpq cimport *
 
-from cypari2.gen import Gen as pari_gen
-
 from sage.rings.complex_arb cimport ComplexBall
 from sage.rings.integer cimport Integer, smallInteger
 from sage.rings.integer_ring import ZZ
@@ -56,6 +54,12 @@ from sage.structure.element cimport Element
 from sage.structure.element import coerce_binop
 
 from sage.misc.cachefunc import cached_method
+
+try:
+    from cypari2.gen import Gen as pari_gen
+except ImportError:
+    pari_gen = ()
+
 
 cdef inline bint _do_sig(fmpq_poly_t op) noexcept:
     """

--- a/src/sage/rings/polynomial/polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_rational_flint.pyx
@@ -2272,6 +2272,7 @@ cdef class Polynomial_rational_flint(Polynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = QQ[]
             sage: (x^5 + 17*x^3 + x + 3).factor_mod(3)
             x * (x^2 + 1)^2
@@ -2282,7 +2283,7 @@ cdef class Polynomial_rational_flint(Polynomial):
         are supported (see :issue:`20631`)::
 
             sage: R.<zeta> = QQ[]
-            sage: (zeta^2 + zeta + 1).factor_mod(7)
+            sage: (zeta^2 + zeta + 1).factor_mod(7)                                     # needs sage.libs.pari
             (zeta + 3) * (zeta + 5)
         """
         from sage.rings.finite_rings.finite_field_constructor import FiniteField
@@ -2402,17 +2403,18 @@ cdef class Polynomial_rational_flint(Polynomial):
         EXAMPLES::
 
             sage: R.<x> = QQ[]
-            sage: R((x-1)*(x+1)).hensel_lift(7, 2)
+            sage: R((x-1)*(x+1)).hensel_lift(7, 2)                                      # needs sage.libs.pari
             [x + 1, x + 48]
 
         If the input polynomial `f` is not monic, we get a factorization of
         `f / lc(f)`::
 
-            sage: R(2*x^2 - 2).hensel_lift(7, 2)
+            sage: R(2*x^2 - 2).hensel_lift(7, 2)                                        # needs sage.libs.pari
             [x + 1, x + 48]
 
         TESTS::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = QQ[]
             sage: R(0).hensel_lift(7, 2)
             []
@@ -2424,6 +2426,7 @@ cdef class Polynomial_rational_flint(Polynomial):
         Variable names that are reserved in PARI, such as ``I``, are
         supported (see :issue:`20631`)::
 
+            sage: # needs sage.libs.pari
             sage: R.<I> = QQ[]
             sage: (I^2 + 1).hensel_lift(5, 3)
             [I + 57, I + 68]
@@ -2495,9 +2498,9 @@ cdef class Polynomial_rational_flint(Polynomial):
 
             sage: R.<t> = QQ[]
             sage: f = t^3 + t + 1
-            sage: d = f.discriminant(); d
+            sage: d = f.discriminant(); d                                               # needs sage.libs.pari
             -31
-            sage: d.parent() is QQ
+            sage: d.parent() is QQ                                                      # needs sage.libs.pari
             True
             sage: EllipticCurve([1, 1]).discriminant() / 16                             # needs sage.schemes
             -31
@@ -2506,18 +2509,19 @@ cdef class Polynomial_rational_flint(Polynomial):
 
             sage: R.<t> = QQ[]
             sage: f = 2*t^3 + t + 1
-            sage: d = f.discriminant(); d
+            sage: d = f.discriminant(); d                                               # needs sage.libs.pari
             -116
 
         ::
 
             sage: R.<t> = QQ[]
             sage: f = t^3 + 3*t - 17
-            sage: f.discriminant()
+            sage: f.discriminant()                                                      # needs sage.libs.pari
             -7911
 
         TESTS::
 
+            sage: # needs sage.libs.pari
             sage: R.<t> = QQ[]
             sage: R(0).discriminant()
             0
@@ -2530,7 +2534,7 @@ cdef class Polynomial_rational_flint(Polynomial):
         supported (see :issue:`20631`)::
 
             sage: R.<I> = QQ[]
-            sage: (I^2 + 1).discriminant()
+            sage: (I^2 + 1).discriminant()                                              # needs sage.libs.pari
             -4
         """
         return QQ(self._pari_with_name().poldisc())
@@ -2551,6 +2555,7 @@ cdef class Polynomial_rational_flint(Polynomial):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: P.<x> = QQ[]
             sage: u = x^7 + x + 1
             sage: u.galois_group_davenport_smith_test()

--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -769,6 +769,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         Test zero polynomial::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<x> = PolynomialRing(GF(65537), implementation="FLINT")
             sage: R.zero().squarefree_decomposition()
             Traceback (most recent call last):

--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -18,10 +18,10 @@ EXAMPLES::
     sage: R.<a> = PolynomialRing(Integers(100))
     sage: type(a)
     <class 'sage.rings.polynomial.polynomial_zmod_flint.Polynomial_zmod_flint'>
-    sage: R.<a> = PolynomialRing(Integers(5*2^64))
-    sage: type(a)
+    sage: R.<a> = PolynomialRing(Integers(5*2^64))                                      # needs sage.rings.finite_rings
+    sage: type(a)                                                                       # needs sage.rings.finite_rings
     <class 'sage.rings.polynomial.polynomial_modn_dense_ntl.Polynomial_dense_modn_ntl_ZZ'>
-    sage: R.<a> = PolynomialRing(Integers(5*2^64), implementation="FLINT")
+    sage: R.<a> = PolynomialRing(Integers(5*2^64), implementation="FLINT")              # needs sage.rings.finite_rings
     Traceback (most recent call last):
     ...
     ValueError: FLINT does not support modulus 92233720368547758080
@@ -624,6 +624,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         Check that :issue:`37169` is fixed - it does not throw an error::
 
+            sage: # needs sage.rings.finite_rings
             sage: R.<x> = Zmod(4)[]
             sage: _.<z> = R.quotient_ring(x^2 - 1)
             sage: c = 2 * z + 1
@@ -795,8 +796,8 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
 
         It also works for prime-power moduli::
 
-            sage: R.<x> = Zmod(23^5)[]
-            sage: (x^3 + 1).factor()
+            sage: R.<x> = Zmod(23^5)[]                                                  # needs sage.rings.finite_rings
+            sage: (x^3 + 1).factor()                                                    # needs sage.rings.finite_rings
             (x + 1) * (x^2 + 6436342*x + 1)
 
         TESTS::

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -518,6 +518,7 @@ class WeilPolynomials():
 
     Test that :issue:`29475` is resolved::
 
+        sage: # needs sage.libs.pari
         sage: P.<x> = QQ[]
         sage: u = x^6 + x^5 + 6*x^4 - 2*x^3 + 66*x^2 + 121*x + 1331
         sage: u.is_weil_polynomial()

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -5396,7 +5396,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
             sage: r = sqrt(2.0); r
             1.41421356237310
-            sage: r.algebraic_dependency(5)
+            sage: r.algebraic_dependency(5)                                             # needs fpylll
             x^2 - 2
         """
         return sage.arith.misc.algdep(self, n)

--- a/src/sage/symbolic/constants.py
+++ b/src/sage/symbolic/constants.py
@@ -883,7 +883,7 @@ class Log2(Constant):
         log(2)
         sage: maxima(log2).float()
         0.6931471805599453
-        sage: gp(log2)
+        sage: gp(log2)                                                                  # needs sage.libs.pari
         0.6931471805599453094172321215             # 32-bit
         0.69314718055994530941723212145817656807   # 64-bit
         sage: RealField(150)(2).log()

--- a/src/sage/symbolic/constants.py
+++ b/src/sage/symbolic/constants.py
@@ -38,10 +38,10 @@ type the following::
     pi
     sage: gap(pi)                                                                       # needs sage.libs.gap
     pi
-    sage: gp(pi)
+    sage: gp(pi)                                                                        # needs sage.libs.pari
     3.141592653589793238462643383     # 32-bit
     3.1415926535897932384626433832795028842   # 64-bit
-    sage: pari(pi)
+    sage: pari(pi)                                                                      # needs sage.libs.pari
     3.14159265358979
     sage: kash(pi)                    # optional - kash
     3.14159265358979323846264338328
@@ -63,7 +63,7 @@ can be coerced into other systems or evaluated.
     %pi+(4*%e)/5
     sage: RealField(15)(a)           # 15 *bits* of precision
     5.316
-    sage: gp(a)
+    sage: gp(a)                                                                         # needs sage.libs.pari
     5.316218116357029426750873360              # 32-bit
     5.3162181163570294267508733603616328824    # 64-bit
     sage: print(mathematica(a))                  # optional - mathematica
@@ -626,7 +626,7 @@ Note that conversions to real fields will give TypeErrors::
     Traceback (most recent call last):
     ...
     TypeError: unable to simplify to float approximation
-    sage: gp(SR.I())
+    sage: gp(SR.I())                                                                    # needs sage.libs.pari
     I
     sage: RR(SR.I())
     Traceback (most recent call last):
@@ -833,6 +833,7 @@ class GoldenRatio(Constant):
         """
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: golden_ratio._algebraic_(QQbar)
             1.618033988749895?
             sage: QQbar(golden_ratio)

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -1237,7 +1237,7 @@ cdef class Expression(Expression_abc):
             'Sin[(Pi)+(2)]'
 
             sage: f = pi + I*e
-            sage: f._pari_init_()
+            sage: f._pari_init_()                                                       # needs sage.libs.pari
             '(Pi)+((exp(1))*(I))'
 
         TESTS:
@@ -1870,7 +1870,7 @@ cdef class Expression(Expression_abc):
 
             sage: ComplexField(200)(SR(1/11))
             0.090909090909090909090909090909090909090909090909090909090909
-            sage: zeta(x).subs(x=I)._complex_mpfr_field_(ComplexField(70))
+            sage: zeta(x).subs(x=I)._complex_mpfr_field_(ComplexField(70))              # needs sage.libs.pari
             0.0033002236853241028742 - 0.41815544914132167669*I
             sage: gamma(x).subs(x=I)._complex_mpfr_field_(ComplexField(60))
             -0.1549498283018106... - 0.49801566811835604*I
@@ -1901,7 +1901,7 @@ cdef class Expression(Expression_abc):
 
             sage: CDF(SR(1/11))
             0.09090909090909091
-            sage: zeta(x).subs(x=I)._complex_double_(CDF)  # rel tol 1e-16
+            sage: zeta(x).subs(x=I)._complex_double_(CDF)  # rel tol 1e-16              # needs sage.libs.pari
             0.003300223685324103 - 0.4181554491413217*I
             sage: gamma(x).subs(x=I)._complex_double_(CDF)
             -0.15494982830181067 - 0.49801566811835607*I
@@ -2004,7 +2004,7 @@ cdef class Expression(Expression_abc):
             4.242640687119285?
             sage: AA(sqrt(2) ^ 4) == 4
             True
-            sage: AA(-golden_ratio)
+            sage: AA(-golden_ratio)                                                     # needs sage.libs.pari
             -1.618033988749895?
             sage: QQbar(SR(2*I)^(1/2))
             1 + 1*I
@@ -2519,7 +2519,7 @@ cdef class Expression(Expression_abc):
             True
             sage: (sqrt(2) + 2^(1/3) - 1).is_algebraic()
             True
-            sage: (I*golden_ratio + sqrt(2)).is_algebraic()
+            sage: (I*golden_ratio + sqrt(2)).is_algebraic()                             # needs sage.libs.pari
             True
             sage: (sqrt(2) + pi).is_algebraic()
             False
@@ -9799,7 +9799,7 @@ cdef class Expression(Expression_abc):
 
         ::
 
-            sage: gp('gamma(1+I)')
+            sage: gp('gamma(1+I)')                                                      # needs sage.libs.pari
             0.4980156681183560427136911175 - 0.1549498283018106851249551305*I # 32-bit
             0.49801566811835604271369111746219809195 - 0.15494982830181068512495513048388660520*I # 64-bit
 
@@ -12209,6 +12209,7 @@ cdef class Expression(Expression_abc):
 
         Now let us find some roots over different rings::
 
+            sage: # needs sage.libs.pari
             sage: f.roots(ring=CC)
             [(-0.0588115223184..., 1),
              (-1.331099917875... - 1.52241655183732*I, 1),

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -3587,7 +3587,7 @@ cdef class Expression(Expression_abc):
 
             sage: m = 540579833922455191419978421211010409605356811833049025*sqrt(1/2)
             sage: m1 = 382247666339265723780973363167714496025733124557617743
-            sage: (m == m1).test_relation(domain=QQbar)
+            sage: (m == m1).test_relation(domain=QQbar)                                 # needs sage.rings.number_field
             False
             sage: (m == m1).test_relation()
             False
@@ -4035,8 +4035,8 @@ cdef class Expression(Expression_abc):
             ...
             TypeError: unsupported operand parent(s) for *: 'Finite Field of size 5' and 'Symbolic Ring'
 
-            sage: b = polygen(FiniteField(9), 'b')
-            sage: SR('I') * b
+            sage: b = polygen(FiniteField(9), 'b')                                      # needs sage.rings.finite_rings
+            sage: SR('I') * b                                                           # needs sage.rings.finite_rings
             Traceback (most recent call last):
             ...
             TypeError: positive characteristic not allowed in symbolic computations

--- a/src/sage/symbolic/expression_conversion_algebraic.py
+++ b/src/sage/symbolic/expression_conversion_algebraic.py
@@ -161,6 +161,7 @@ class AlgebraicConverter(Converter):
 
         Test :issue:`22571`::
 
+            sage: # needs sage.libs.pari
             sage: a.composition(exp(0, hold=True), exp)
             1
             sage: a.composition(exp(1, hold=True), exp)
@@ -180,6 +181,7 @@ class AlgebraicConverter(Converter):
 
         Check that :issue:`24440` is fixed::
 
+            sage: # needs sage.libs.pari
             sage: QQbar(tanh(pi + 0.1))
             Traceback (most recent call last):
             ...

--- a/src/sage/symbolic/expression_conversion_algebraic.py
+++ b/src/sage/symbolic/expression_conversion_algebraic.py
@@ -135,13 +135,13 @@ class AlgebraicConverter(Converter):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: from sage.symbolic.expression_conversions import AlgebraicConverter
             sage: a = AlgebraicConverter(QQbar)
             sage: a.composition(exp(I*pi/3, hold=True), exp)
             0.500000000000000? + 0.866025403784439?*I
             sage: a.composition(sin(pi/7), sin)
             0.4338837391175581? + 0.?e-18*I
-
             sage: x = SR.var('x')
             sage: a.composition(complex_root_of(x^3 - x^2 - x - 1, 0), complex_root_of)
             1.839286755214161?
@@ -282,11 +282,11 @@ def algebraic(ex, field):
         <class 'sage.rings.qqbar.AlgebraicNumber'>
         sage: QQbar(i)
         I
-        sage: AA(golden_ratio)
+        sage: AA(golden_ratio)                                                          # needs sage.libs.pari
         1.618033988749895?
-        sage: QQbar(golden_ratio)
+        sage: QQbar(golden_ratio)                                                       # needs sage.libs.pari
         1.618033988749895?
-        sage: QQbar(sin(pi/3))
+        sage: QQbar(sin(pi/3))                                                          # needs sage.libs.pari
         0.866025403784439?
 
         sage: QQbar(sqrt(2) + sqrt(8))

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -417,8 +417,8 @@ class InterfaceInit(Converter):
             sage: f(x) = x
             sage: m.symbol(f)
             '_SAGE_VAR_x'
-            sage: ii = InterfaceInit(gp)
-            sage: ii.symbol(x)
+            sage: ii = InterfaceInit(gp)                                                # needs sage.libs.pari
+            sage: ii.symbol(x)                                                          # needs sage.libs.pari
             'x'
             sage: g = InterfaceInit(giac)
             sage: g.symbol(x)
@@ -434,6 +434,7 @@ class InterfaceInit(Converter):
         """
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: from sage.symbolic.expression_conversions import InterfaceInit
             sage: ii = InterfaceInit(gp)
             sage: f = 2+SR(I)
@@ -881,7 +882,7 @@ class PolynomialConverter(Converter):
         TESTS::
 
             sage: t, x, z = SR.var('t,x,z')
-            sage: QQ[i]['x,y,z,t'](4*I*t + 2*x -12*z + 2)
+            sage: QQ[i]['x,y,z,t'](4*I*t + 2*x -12*z + 2)                       # needs sage.rings.number_field
             2*x - 12*z + (4*I)*t + 2
         """
         if not (ring is None or base_ring is None):

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -420,8 +420,8 @@ class InterfaceInit(Converter):
             sage: ii = InterfaceInit(gp)                                                # needs sage.libs.pari
             sage: ii.symbol(x)                                                          # needs sage.libs.pari
             'x'
-            sage: g = InterfaceInit(giac)
-            sage: g.symbol(x)
+            sage: g = InterfaceInit(giac)                                               # needs sage.libs.giac
+            sage: g.symbol(x)                                                           # needs sage.libs.giac
             'sageVARx'
         """
         if self.interface.name() == 'maxima':
@@ -440,10 +440,8 @@ class InterfaceInit(Converter):
             sage: f = 2+SR(I)
             sage: ii.pyobject(f, f.pyobject())
             'I + 2'
-
             sage: ii.pyobject(SR(2), 2)
             '2'
-
             sage: ii.pyobject(pi, pi.pyobject())
             'Pi'
         """

--- a/src/sage/symbolic/pynac_impl.pxi
+++ b/src/sage/symbolic/pynac_impl.pxi
@@ -832,6 +832,7 @@ cdef int py_get_parent_char(o) except -1:
 
     :issue:`24072` fixes the workaround provided in :issue:`21187`::
 
+        sage: # needs sage.rings.finite_rings
         sage: p = next_prime(2^100)
         sage: R.<y> = FiniteField(p)[]
         sage: y = SR(y)
@@ -1136,7 +1137,7 @@ cdef bint py_is_integer(x) noexcept:
         True
         sage: py_is_integer(4/2)
         True
-        sage: py_is_integer(QQbar(sqrt(2))^2)
+        sage: py_is_integer(QQbar(sqrt(2))^2)                                           # needs sage.rings.number_field
         True
         sage: py_is_integer(3.0)
         False
@@ -1256,8 +1257,8 @@ cdef py_numer(n):
         3
         sage: py_numer(2/3)
         2
-        sage: C.<i> = NumberField(x^2+1)
-        sage: py_numer(2/3*i)
+        sage: C.<i> = NumberField(x^2 + 1)                                              # needs sage.rings.number_field
+        sage: py_numer(2/3*i)                                                           # needs sage.rings.number_field
         2*i
         sage: class no_numer:
         ....:   def denominator(self):
@@ -1303,8 +1304,8 @@ cdef py_denom(n):
         1
         sage: py_denom(2/3)
         3
-        sage: C.<i> = NumberField(x^2+1)
-        sage: py_denom(2/3*i)
+        sage: C.<i> = NumberField(x^2 + 1)                                              # needs sage.rings.number_field
+        sage: py_denom(2/3*i)                                                           # needs sage.rings.number_field
         3
     """
     if isinstance(n, (int, Integer)):
@@ -1657,6 +1658,7 @@ cdef py_zeta(x):
 
     TESTS::
 
+        sage: # needs sage.libs.pari
         sage: from sage.symbolic.expression import py_zeta_for_doctests as py_zeta
         sage: py_zeta(CC.0)
         0.00330022368532410 - 0.418155449141322*I
@@ -1677,6 +1679,7 @@ def py_zeta_for_doctests(x):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.pari
         sage: from sage.symbolic.expression import py_zeta_for_doctests
         sage: py_zeta_for_doctests(CC.0)
         0.00330022368532410 - 0.418155449141322*I
@@ -2396,7 +2399,7 @@ def init_pynac_I():
         Traceback (most recent call last):
         ...
         TypeError: unable to simplify to float approximation
-        sage: gp(symbolic_I)
+        sage: gp(symbolic_I)                                                            # needs sage.libs.pari
         I
         sage: RR(symbolic_I)
         Traceback (most recent call last):

--- a/src/sage/symbolic/relation.py
+++ b/src/sage/symbolic/relation.py
@@ -1511,7 +1511,8 @@ def solve_mod(eqns, modulus, solution_dict=False):
 
     We can solve with respect to a bigger modulus if it consists only of small prime factors::
 
-        sage: [d] = solve_mod([5*x + y == 3, 2*x - 3*y == 9], 3*5*7*11*19*23*29, solution_dict = True)
+        sage: # needs sage.libs.pari
+        sage: [d] = solve_mod([5*x + y == 3, 2*x - 3*y == 9], 3*5*7*11*19*23*29, solution_dict=True)
         sage: d[x]
         12915279
         sage: d[y]

--- a/src/sage/symbolic/relation.py
+++ b/src/sage/symbolic/relation.py
@@ -1522,7 +1522,7 @@ def solve_mod(eqns, modulus, solution_dict=False):
     factors are small, this can be efficient even if the modulus itself
     is large::
 
-        sage: sorted(solve_mod([x^2 == 41], 10^20))
+        sage: sorted(solve_mod([x^2 == 41], 10^20))                                     # needs sage.libs.pari
         [(4538602480526452429,), (11445932736758703821,), (38554067263241296179,),
         (45461397519473547571,), (54538602480526452429,), (61445932736758703821,),
         (88554067263241296179,), (95461397519473547571,)]
@@ -1530,7 +1530,7 @@ def solve_mod(eqns, modulus, solution_dict=False):
     We solve a simple equation modulo 2::
 
         sage: x,y = var('x,y')
-        sage: solve_mod([x == y], 2)
+        sage: solve_mod([x == y], 2)                                                    # needs sage.libs.pari
         [(0, 0), (1, 1)]
 
     .. warning::
@@ -1550,24 +1550,24 @@ def solve_mod(eqns, modulus, solution_dict=False):
 
     Make sure that we short-circuit in at least some cases::
 
-        sage: solve_mod([2*x==1], 2*next_prime(10^50))
+        sage: solve_mod([2*x==1], 2*next_prime(10^50))                                  # needs sage.libs.pari
         []
 
     Try multi-equation cases::
 
         sage: x, y, z = var("x y z")
-        sage: solve_mod([2*x^2 + x*y, -x*y+2*y^2+x-2*y, -2*x^2+2*x*y-y^2-x-y], 12)
+        sage: solve_mod([2*x^2 + x*y, -x*y+2*y^2+x-2*y, -2*x^2+2*x*y-y^2-x-y], 12)      # needs sage.libs.pari
         [(0, 0), (4, 4), (0, 3), (4, 7)]
         sage: eqs = [-y^2+z^2, -x^2+y^2-3*z^2-z-1, -y*z-z^2-x-y+2, -x^2-12*z^2-y+z]
-        sage: solve_mod(eqs, 11)
+        sage: solve_mod(eqs, 11)                                                        # needs sage.libs.pari
         [(8, 5, 6)]
 
     Confirm that modulus 1 now behaves as it should::
 
         sage: x, y = var("x y")
-        sage: solve_mod([x==1], 1)
+        sage: solve_mod([x==1], 1)                                                      # needs sage.libs.pari
         [(0,)]
-        sage: solve_mod([2*x^2+x*y, -x*y+2*y^2+x-2*y, -2*x^2+2*x*y-y^2-x-y], 1)
+        sage: solve_mod([2*x^2+x*y, -x*y+2*y^2+x-2*y, -2*x^2+2*x*y-y^2-x-y], 1)         # needs sage.libs.pari
         [(0, 0)]
     """
     from sage.rings.finite_rings.integer_mod_ring import Integers

--- a/src/sage/symbolic/ring.pyx
+++ b/src/sage/symbolic/ring.pyx
@@ -157,7 +157,7 @@ cdef class SymbolicRing(sage.rings.abc.SymbolicRing):
 
         TESTS::
 
-            sage: SR.has_coerce_map_from(pari)
+            sage: SR.has_coerce_map_from(pari)                                          # needs sage.libs.pari
             False
 
         Check if arithmetic with bools works (see :issue:`9560`)::
@@ -307,6 +307,7 @@ cdef class SymbolicRing(sage.rings.abc.SymbolicRing):
 
         Polynomial ring element factorizations::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = QQ[]
             sage: SR(factor(5*x^2 - 5))
             5*(x + 1)*(x - 1)

--- a/src/sage/symbolic/ring.pyx
+++ b/src/sage/symbolic/ring.pyx
@@ -146,7 +146,7 @@ cdef class SymbolicRing(sage.rings.abc.SymbolicRing):
             False
             sage: SR.has_coerce_map_from(Integers(8))
             True
-            sage: SR.has_coerce_map_from(GF(9, 'a'))
+            sage: SR.has_coerce_map_from(GF(9, 'a'))                                    # needs sage.rings.finite_rings
             True
             sage: SR.has_coerce_map_from(RealBallField())
             True
@@ -182,9 +182,9 @@ cdef class SymbolicRing(sage.rings.abc.SymbolicRing):
             sage: SR.has_coerce_map_from(SR.subring(no_variables=True))
             True
 
-            sage: SR.has_coerce_map_from(AA)
+            sage: SR.has_coerce_map_from(AA)                                            # needs sage.rings.number_field
             True
-            sage: SR.has_coerce_map_from(QQbar)
+            sage: SR.has_coerce_map_from(QQbar)                                         # needs sage.rings.number_field
             True
         """
         if isinstance(R, type):
@@ -246,8 +246,8 @@ cdef class SymbolicRing(sage.rings.abc.SymbolicRing):
             <class 'sage.symbolic.expression.Expression'>
             sage: a.parent()
             Symbolic Ring
-            sage: K.<a> = QuadraticField(-3)
-            sage: a + sin(x)
+            sage: K.<a> = QuadraticField(-3)                                            # needs sage.rings.number_field
+            sage: a + sin(x)                                                            # needs sage.rings.number_field
             I*sqrt(3) + sin(x)
             sage: x = var('x'); y0,y1 = PolynomialRing(ZZ,2,'y').gens()
             sage: x+y0/y1


### PR DESCRIPTION
- **pkgs/sagemath-symbolics/pyproject.toml.m4: Remove pari deps**
- **src/sage/calculus/calculus.py: Add # needs**
- **src/sage/functions/orthogonal_polys.py: Add # needs**
- **src/sage/interfaces: Add # needs**
- **src/sage/libs/flint/nmod_poly_linkage.pxi: Fix typo in doctest**
- **src/sage/manifolds: Add # needs**
- **src/sage/rings/complex_mpfr.pyx: Modularize pari import**
- **src/sage/rings/polynomial/polynomial_rational_flint.pyx: Modularize pari import**
- **src/sage/rings/padics/misc.py: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/symbolic: Add # needs**
- **src/sage/symbolic: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/symbolic/relation.py: Add # needs**
- **src/sage/interfaces/sympy_wrapper.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-symbolics' --update-known-test-failures**
