### PR TITLE
pkgs/sagemath-schemes: Add dependencies, fix doctests

### DIFF
--- a/pkgs/sagemath-schemes/MANIFEST.in
+++ b/pkgs/sagemath-schemes/MANIFEST.in
@@ -26,6 +26,8 @@ exclude sage/schemes/elliptic_curves/descent_two_isogeny.p*
 #exclude sage/modular/arithgroup/arithgroup_element.pyx          # via Matrix_integer_dense
 #exclude sage/modular/arithgroup/congroup.pyx                    # via Matrix_integer_dense
 
+include sage/rings/polynomial/binary_form_reduce.p*
+
 include sage/databases/cremona.p*
 include sage/databases/db_modular_polynomials.p*
 include sage/databases/stein_watkins.p*

--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -110,7 +110,10 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1123
+        "ntests": 1130
+    },
+    "sage.arith.multi_modular": {
+        "ntests": 134
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -1499,7 +1502,7 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 162
+        "ntests": 161
     },
     "sage.functions.gamma": {
         "failed": true,
@@ -1539,7 +1542,8 @@
         "ntests": 6
     },
     "sage.functions.prime_pi": {
-        "ntests": 4
+        "failed": true,
+        "ntests": 20
     },
     "sage.functions.special": {
         "failed": true,
@@ -1877,14 +1881,12 @@
         "ntests": 21
     },
     "sage.groups.matrix_gps.orthogonal": {
-        "failed": true,
         "ntests": 57
     },
     "sage.groups.matrix_gps.symplectic": {
         "ntests": 24
     },
     "sage.groups.matrix_gps.unitary": {
-        "failed": true,
         "ntests": 50
     },
     "sage.groups.old": {
@@ -2193,7 +2195,6 @@
         "ntests": 7
     },
     "sage.matrix.matrix_cyclo_linbox": {
-        "failed": true,
         "ntests": 30
     },
     "sage.matrix.matrix_dense": {
@@ -2215,8 +2216,7 @@
         "ntests": 390
     },
     "sage.matrix.matrix_integer_dense": {
-        "failed": true,
-        "ntests": 636
+        "ntests": 662
     },
     "sage.matrix.matrix_integer_dense_hnf": {
         "ntests": 125
@@ -2228,7 +2228,6 @@
         "ntests": 32
     },
     "sage.matrix.matrix_integer_linbox": {
-        "failed": true,
         "ntests": 31
     },
     "sage.matrix.matrix_integer_pari": {
@@ -2274,7 +2273,7 @@
         "ntests": 540
     },
     "sage.matrix.matrix_rational_dense": {
-        "ntests": 332
+        "ntests": 343
     },
     "sage.matrix.matrix_rational_pari": {
         "ntests": 17
@@ -2286,7 +2285,6 @@
         "ntests": 13
     },
     "sage.matrix.matrix_space": {
-        "failed": true,
         "ntests": 462
     },
     "sage.matrix.matrix_sparse": {
@@ -2705,7 +2703,6 @@
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gamma1": {
-        "failed": true,
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gammaH": {
@@ -2748,7 +2745,7 @@
         "ntests": 12
     },
     "sage.modular.etaproducts": {
-        "ntests": 87
+        "ntests": 102
     },
     "sage.modular.hecke.algebra": {
         "ntests": 91
@@ -2830,7 +2827,6 @@
         "ntests": 59
     },
     "sage.modular.modform.cuspidal_submodule": {
-        "failed": true,
         "ntests": 69
     },
     "sage.modular.modform.eis_series": {
@@ -2873,7 +2869,6 @@
         "ntests": 12
     },
     "sage.modular.modform.tests": {
-        "failed": true,
         "ntests": 4
     },
     "sage.modular.modform.theta": {
@@ -2916,7 +2911,6 @@
         "ntests": 6
     },
     "sage.modular.modsym.heilbronn": {
-        "failed": true,
         "ntests": 66
     },
     "sage.modular.modsym.manin_symbol": {
@@ -2927,7 +2921,6 @@
         "ntests": 188
     },
     "sage.modular.modsym.modsym": {
-        "failed": true,
         "ntests": 80
     },
     "sage.modular.modsym.modular_symbols": {
@@ -3029,7 +3022,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 12
+        "ntests": 119
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3038,7 +3031,8 @@
         "ntests": 306
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
-        "ntests": 135
+        "failed": true,
+        "ntests": 150
     },
     "sage.modules.matrix_morphism": {
         "ntests": 393
@@ -3453,7 +3447,7 @@
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
-        "ntests": 523
+        "ntests": 527
     },
     "sage.rings.continued_fraction": {
         "failed": true,
@@ -3724,7 +3718,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2285
+        "ntests": 2292
     },
     "sage.rings.number_field.number_field_base": {
         "ntests": 83
@@ -3938,6 +3932,9 @@
     "sage.rings.pari_ring": {
         "ntests": 46
     },
+    "sage.rings.polynomial.binary_form_reduce": {
+        "ntests": 42
+    },
     "sage.rings.polynomial.commutative_polynomial": {
         "ntests": 7
     },
@@ -3979,7 +3976,6 @@
         "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
-        "failed": true,
         "ntests": 585
     },
     "sage.rings.polynomial.multi_polynomial_element": {
@@ -4391,7 +4387,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 771
+        "ntests": 766
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4653,7 +4649,6 @@
         "ntests": 46
     },
     "sage.schemes.projective.projective_space": {
-        "failed": true,
         "ntests": 441
     },
     "sage.schemes.projective.projective_subscheme": {
@@ -4666,14 +4661,8 @@
     "sage.schemes.toric.chow_group": {
         "ntests": 1
     },
-    "sage.schemes.toric.divisor": {
-        "ntests": 2
-    },
-    "sage.schemes.toric.points": {
-        "ntests": 3
-    },
     "sage.schemes.toric.variety": {
-        "ntests": 9
+        "ntests": 3
     },
     "sage.sets.cartesian_product": {
         "ntests": 54

--- a/pkgs/sagemath-schemes/known-test-failures--ntl.json
+++ b/pkgs/sagemath-schemes/known-test-failures--ntl.json
@@ -110,7 +110,7 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1130
+        "ntests": 1123
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -403,7 +403,7 @@
         "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "ntests": 97
+        "ntests": 95
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -1001,7 +1001,7 @@
         "ntests": 284
     },
     "sage.combinat.root_system.root_lattice_realizations": {
-        "ntests": 483
+        "ntests": 484
     },
     "sage.combinat.root_system.root_space": {
         "ntests": 78
@@ -1390,7 +1390,6 @@
         "ntests": 23
     },
     "sage.features.kenzo": {
-        "failed": true,
         "ntests": 6
     },
     "sage.features.latex": {
@@ -1427,6 +1426,9 @@
         "ntests": 4
     },
     "sage.features.pandoc": {
+        "ntests": 4
+    },
+    "sage.features.pari": {
         "ntests": 4
     },
     "sage.features.pdf2svg": {
@@ -1621,6 +1623,7 @@
         "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
+        "failed": true,
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
@@ -2016,6 +2019,9 @@
     },
     "sage.libs.gsl.array": {
         "ntests": 22
+    },
+    "sage.libs.linkages.padics.unram_shared.pxi": {
+        "ntests": 74
     },
     "sage.libs.mpmath.utils": {
         "ntests": 57
@@ -2948,7 +2954,6 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3328,7 +3333,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 114
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3488,7 +3493,6 @@
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
-        "failed": true,
         "ntests": 283
     },
     "sage.rings.finite_rings.finite_field_base": {
@@ -3720,7 +3724,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2292
+        "ntests": 2285
     },
     "sage.rings.number_field.number_field_base": {
         "ntests": 83
@@ -3983,7 +3987,6 @@
         "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
-        "failed": true,
         "ntests": 895
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
@@ -4032,7 +4035,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2690
+        "ntests": 0
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -4479,7 +4482,7 @@
         "ntests": 51
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
-        "ntests": 1
+        "ntests": 7
     },
     "sage.schemes.elliptic_curves.padics": {
         "failed": true,
@@ -4487,7 +4490,7 @@
     },
     "sage.schemes.elliptic_curves.period_lattice": {
         "failed": true,
-        "ntests": 434
+        "ntests": 427
     },
     "sage.schemes.elliptic_curves.period_lattice_region": {
         "ntests": 12

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -110,7 +110,7 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1130
+        "ntests": 1123
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -403,7 +403,7 @@
         "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "ntests": 97
+        "ntests": 95
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -1001,7 +1001,7 @@
         "ntests": 284
     },
     "sage.combinat.root_system.root_lattice_realizations": {
-        "ntests": 483
+        "ntests": 484
     },
     "sage.combinat.root_system.root_space": {
         "ntests": 78
@@ -1390,7 +1390,6 @@
         "ntests": 23
     },
     "sage.features.kenzo": {
-        "failed": true,
         "ntests": 6
     },
     "sage.features.latex": {
@@ -1427,6 +1426,9 @@
         "ntests": 4
     },
     "sage.features.pandoc": {
+        "ntests": 4
+    },
+    "sage.features.pari": {
         "ntests": 4
     },
     "sage.features.pdf2svg": {
@@ -1621,6 +1623,7 @@
         "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
+        "failed": true,
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
@@ -2016,6 +2019,9 @@
     },
     "sage.libs.gsl.array": {
         "ntests": 22
+    },
+    "sage.libs.linkages.padics.unram_shared.pxi": {
+        "ntests": 74
     },
     "sage.libs.mpmath.utils": {
         "ntests": 57
@@ -2948,6 +2954,7 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
+        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3327,7 +3334,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 114
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3487,7 +3494,6 @@
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
-        "failed": true,
         "ntests": 283
     },
     "sage.rings.finite_rings.finite_field_base": {
@@ -3719,7 +3725,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2292
+        "ntests": 2285
     },
     "sage.rings.number_field.number_field_base": {
         "ntests": 83
@@ -3982,7 +3988,6 @@
         "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
-        "failed": true,
         "ntests": 895
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
@@ -4031,7 +4036,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2690
+        "ntests": 0
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -4478,7 +4483,7 @@
         "ntests": 51
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
-        "ntests": 1
+        "ntests": 7
     },
     "sage.schemes.elliptic_curves.padics": {
         "failed": true,
@@ -4486,7 +4491,7 @@
     },
     "sage.schemes.elliptic_curves.period_lattice": {
         "failed": true,
-        "ntests": 434
+        "ntests": 427
     },
     "sage.schemes.elliptic_curves.period_lattice_region": {
         "ntests": 12

--- a/pkgs/sagemath-schemes/known-test-failures--pari.json
+++ b/pkgs/sagemath-schemes/known-test-failures--pari.json
@@ -110,7 +110,10 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1123
+        "ntests": 1130
+    },
+    "sage.arith.multi_modular": {
+        "ntests": 134
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -1499,7 +1502,7 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 162
+        "ntests": 161
     },
     "sage.functions.gamma": {
         "failed": true,
@@ -1539,7 +1542,8 @@
         "ntests": 6
     },
     "sage.functions.prime_pi": {
-        "ntests": 4
+        "failed": true,
+        "ntests": 20
     },
     "sage.functions.special": {
         "failed": true,
@@ -1877,14 +1881,12 @@
         "ntests": 21
     },
     "sage.groups.matrix_gps.orthogonal": {
-        "failed": true,
         "ntests": 57
     },
     "sage.groups.matrix_gps.symplectic": {
         "ntests": 24
     },
     "sage.groups.matrix_gps.unitary": {
-        "failed": true,
         "ntests": 50
     },
     "sage.groups.old": {
@@ -2193,7 +2195,6 @@
         "ntests": 7
     },
     "sage.matrix.matrix_cyclo_linbox": {
-        "failed": true,
         "ntests": 30
     },
     "sage.matrix.matrix_dense": {
@@ -2215,8 +2216,7 @@
         "ntests": 390
     },
     "sage.matrix.matrix_integer_dense": {
-        "failed": true,
-        "ntests": 636
+        "ntests": 662
     },
     "sage.matrix.matrix_integer_dense_hnf": {
         "ntests": 125
@@ -2228,7 +2228,6 @@
         "ntests": 32
     },
     "sage.matrix.matrix_integer_linbox": {
-        "failed": true,
         "ntests": 31
     },
     "sage.matrix.matrix_integer_pari": {
@@ -2274,7 +2273,7 @@
         "ntests": 540
     },
     "sage.matrix.matrix_rational_dense": {
-        "ntests": 332
+        "ntests": 343
     },
     "sage.matrix.matrix_rational_pari": {
         "ntests": 17
@@ -2286,7 +2285,6 @@
         "ntests": 13
     },
     "sage.matrix.matrix_space": {
-        "failed": true,
         "ntests": 462
     },
     "sage.matrix.matrix_sparse": {
@@ -2705,7 +2703,6 @@
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gamma1": {
-        "failed": true,
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gammaH": {
@@ -2748,7 +2745,7 @@
         "ntests": 12
     },
     "sage.modular.etaproducts": {
-        "ntests": 87
+        "ntests": 102
     },
     "sage.modular.hecke.algebra": {
         "ntests": 91
@@ -2830,7 +2827,6 @@
         "ntests": 59
     },
     "sage.modular.modform.cuspidal_submodule": {
-        "failed": true,
         "ntests": 69
     },
     "sage.modular.modform.eis_series": {
@@ -2873,7 +2869,6 @@
         "ntests": 12
     },
     "sage.modular.modform.tests": {
-        "failed": true,
         "ntests": 4
     },
     "sage.modular.modform.theta": {
@@ -2916,7 +2911,6 @@
         "ntests": 6
     },
     "sage.modular.modsym.heilbronn": {
-        "failed": true,
         "ntests": 66
     },
     "sage.modular.modsym.manin_symbol": {
@@ -2927,7 +2921,6 @@
         "ntests": 188
     },
     "sage.modular.modsym.modsym": {
-        "failed": true,
         "ntests": 80
     },
     "sage.modular.modsym.modular_symbols": {
@@ -2954,7 +2947,6 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3030,7 +3022,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 12
+        "ntests": 119
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3039,7 +3031,8 @@
         "ntests": 306
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
-        "ntests": 135
+        "failed": true,
+        "ntests": 150
     },
     "sage.modules.matrix_morphism": {
         "ntests": 393
@@ -3454,7 +3447,7 @@
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
-        "ntests": 523
+        "ntests": 527
     },
     "sage.rings.continued_fraction": {
         "failed": true,
@@ -3725,7 +3718,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2285
+        "ntests": 2292
     },
     "sage.rings.number_field.number_field_base": {
         "ntests": 83
@@ -3939,6 +3932,9 @@
     "sage.rings.pari_ring": {
         "ntests": 46
     },
+    "sage.rings.polynomial.binary_form_reduce": {
+        "ntests": 42
+    },
     "sage.rings.polynomial.commutative_polynomial": {
         "ntests": 7
     },
@@ -3980,7 +3976,6 @@
         "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
-        "failed": true,
         "ntests": 585
     },
     "sage.rings.polynomial.multi_polynomial_element": {
@@ -4392,7 +4387,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 771
+        "ntests": 766
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4654,7 +4649,6 @@
         "ntests": 46
     },
     "sage.schemes.projective.projective_space": {
-        "failed": true,
         "ntests": 441
     },
     "sage.schemes.projective.projective_subscheme": {
@@ -4667,14 +4661,8 @@
     "sage.schemes.toric.chow_group": {
         "ntests": 1
     },
-    "sage.schemes.toric.divisor": {
-        "ntests": 2
-    },
-    "sage.schemes.toric.points": {
-        "ntests": 3
-    },
     "sage.schemes.toric.variety": {
-        "ntests": 9
+        "ntests": 3
     },
     "sage.sets.cartesian_product": {
         "ntests": 54

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -110,7 +110,7 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1130
+        "ntests": 1123
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -403,7 +403,7 @@
         "ntests": 10
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "ntests": 97
+        "ntests": 95
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -1001,7 +1001,7 @@
         "ntests": 284
     },
     "sage.combinat.root_system.root_lattice_realizations": {
-        "ntests": 483
+        "ntests": 484
     },
     "sage.combinat.root_system.root_space": {
         "ntests": 78
@@ -1390,7 +1390,6 @@
         "ntests": 23
     },
     "sage.features.kenzo": {
-        "failed": true,
         "ntests": 6
     },
     "sage.features.latex": {
@@ -1427,6 +1426,9 @@
         "ntests": 4
     },
     "sage.features.pandoc": {
+        "ntests": 4
+    },
+    "sage.features.pari": {
         "ntests": 4
     },
     "sage.features.pdf2svg": {
@@ -1621,6 +1623,7 @@
         "ntests": 7
     },
     "sage.geometry.integral_points.pxi": {
+        "failed": true,
         "ntests": 171
     },
     "sage.geometry.lattice_polytope": {
@@ -2016,6 +2019,9 @@
     },
     "sage.libs.gsl.array": {
         "ntests": 22
+    },
+    "sage.libs.linkages.padics.unram_shared.pxi": {
+        "ntests": 74
     },
     "sage.libs.mpmath.utils": {
         "ntests": 57
@@ -3328,7 +3334,7 @@
     },
     "sage.repl.interpreter": {
         "failed": true,
-        "ntests": 113
+        "ntests": 114
     },
     "sage.repl.ipython_extension": {
         "failed": true,
@@ -3488,7 +3494,6 @@
         "ntests": 178
     },
     "sage.rings.finite_rings.element_pari_ffelt": {
-        "failed": true,
         "ntests": 283
     },
     "sage.rings.finite_rings.finite_field_base": {
@@ -3720,7 +3725,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2292
+        "ntests": 2285
     },
     "sage.rings.number_field.number_field_base": {
         "ntests": 83
@@ -3983,7 +3988,6 @@
         "ntests": 534
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
-        "failed": true,
         "ntests": 895
     },
     "sage.rings.polynomial.multi_polynomial_ideal_libsingular": {
@@ -4032,7 +4036,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 2690
+        "ntests": 0
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "failed": true,
@@ -4479,7 +4483,7 @@
         "ntests": 51
     },
     "sage.schemes.elliptic_curves.padic_lseries": {
-        "ntests": 1
+        "ntests": 7
     },
     "sage.schemes.elliptic_curves.padics": {
         "failed": true,
@@ -4487,7 +4491,7 @@
     },
     "sage.schemes.elliptic_curves.period_lattice": {
         "failed": true,
-        "ntests": 434
+        "ntests": 427
     },
     "sage.schemes.elliptic_curves.period_lattice_region": {
         "ntests": 12

--- a/pkgs/sagemath-schemes/known-test-failures.json
+++ b/pkgs/sagemath-schemes/known-test-failures.json
@@ -110,7 +110,10 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 1123
+        "ntests": 1130
+    },
+    "sage.arith.multi_modular": {
+        "ntests": 134
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -1499,7 +1502,7 @@
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 162
+        "ntests": 161
     },
     "sage.functions.gamma": {
         "failed": true,
@@ -1539,7 +1542,8 @@
         "ntests": 6
     },
     "sage.functions.prime_pi": {
-        "ntests": 4
+        "failed": true,
+        "ntests": 20
     },
     "sage.functions.special": {
         "failed": true,
@@ -1877,14 +1881,12 @@
         "ntests": 21
     },
     "sage.groups.matrix_gps.orthogonal": {
-        "failed": true,
         "ntests": 57
     },
     "sage.groups.matrix_gps.symplectic": {
         "ntests": 24
     },
     "sage.groups.matrix_gps.unitary": {
-        "failed": true,
         "ntests": 50
     },
     "sage.groups.old": {
@@ -2193,7 +2195,6 @@
         "ntests": 7
     },
     "sage.matrix.matrix_cyclo_linbox": {
-        "failed": true,
         "ntests": 30
     },
     "sage.matrix.matrix_dense": {
@@ -2215,8 +2216,7 @@
         "ntests": 390
     },
     "sage.matrix.matrix_integer_dense": {
-        "failed": true,
-        "ntests": 636
+        "ntests": 662
     },
     "sage.matrix.matrix_integer_dense_hnf": {
         "ntests": 125
@@ -2228,7 +2228,6 @@
         "ntests": 32
     },
     "sage.matrix.matrix_integer_linbox": {
-        "failed": true,
         "ntests": 31
     },
     "sage.matrix.matrix_integer_pari": {
@@ -2274,7 +2273,7 @@
         "ntests": 540
     },
     "sage.matrix.matrix_rational_dense": {
-        "ntests": 332
+        "ntests": 343
     },
     "sage.matrix.matrix_rational_pari": {
         "ntests": 17
@@ -2286,7 +2285,6 @@
         "ntests": 13
     },
     "sage.matrix.matrix_space": {
-        "failed": true,
         "ntests": 462
     },
     "sage.matrix.matrix_sparse": {
@@ -2705,7 +2703,6 @@
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gamma1": {
-        "failed": true,
         "ntests": 95
     },
     "sage.modular.arithgroup.congroup_gammaH": {
@@ -2748,7 +2745,7 @@
         "ntests": 12
     },
     "sage.modular.etaproducts": {
-        "ntests": 87
+        "ntests": 102
     },
     "sage.modular.hecke.algebra": {
         "ntests": 91
@@ -2830,7 +2827,6 @@
         "ntests": 59
     },
     "sage.modular.modform.cuspidal_submodule": {
-        "failed": true,
         "ntests": 69
     },
     "sage.modular.modform.eis_series": {
@@ -2873,7 +2869,6 @@
         "ntests": 12
     },
     "sage.modular.modform.tests": {
-        "failed": true,
         "ntests": 4
     },
     "sage.modular.modform.theta": {
@@ -2916,7 +2911,6 @@
         "ntests": 6
     },
     "sage.modular.modsym.heilbronn": {
-        "failed": true,
         "ntests": 66
     },
     "sage.modular.modsym.manin_symbol": {
@@ -2927,7 +2921,6 @@
         "ntests": 188
     },
     "sage.modular.modsym.modsym": {
-        "failed": true,
         "ntests": 80
     },
     "sage.modular.modsym.modular_symbols": {
@@ -2954,7 +2947,6 @@
         "ntests": 57
     },
     "sage.modular.modsym.tests": {
-        "failed": true,
         "ntests": 39
     },
     "sage.modular.overconvergent.genus0": {
@@ -3030,7 +3022,7 @@
         "ntests": 60
     },
     "sage.modules.free_module_integer": {
-        "ntests": 12
+        "ntests": 119
     },
     "sage.modules.free_module_morphism": {
         "ntests": 171
@@ -3039,7 +3031,8 @@
         "ntests": 306
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
-        "ntests": 135
+        "failed": true,
+        "ntests": 150
     },
     "sage.modules.matrix_morphism": {
         "ntests": 393
@@ -3454,7 +3447,7 @@
     },
     "sage.rings.complex_mpfr": {
         "failed": true,
-        "ntests": 523
+        "ntests": 527
     },
     "sage.rings.continued_fraction": {
         "failed": true,
@@ -3725,7 +3718,7 @@
     },
     "sage.rings.number_field.number_field": {
         "failed": true,
-        "ntests": 2285
+        "ntests": 2292
     },
     "sage.rings.number_field.number_field_base": {
         "ntests": 83
@@ -3939,6 +3932,9 @@
     "sage.rings.pari_ring": {
         "ntests": 46
     },
+    "sage.rings.polynomial.binary_form_reduce": {
+        "ntests": 42
+    },
     "sage.rings.polynomial.commutative_polynomial": {
         "ntests": 7
     },
@@ -3980,7 +3976,6 @@
         "ntests": 129
     },
     "sage.rings.polynomial.multi_polynomial": {
-        "failed": true,
         "ntests": 585
     },
     "sage.rings.polynomial.multi_polynomial_element": {
@@ -4392,7 +4387,7 @@
     },
     "sage.schemes.elliptic_curves.ell_rational_field": {
         "failed": true,
-        "ntests": 771
+        "ntests": 766
     },
     "sage.schemes.elliptic_curves.ell_tate_curve": {
         "ntests": 64
@@ -4654,7 +4649,6 @@
         "ntests": 46
     },
     "sage.schemes.projective.projective_space": {
-        "failed": true,
         "ntests": 441
     },
     "sage.schemes.projective.projective_subscheme": {
@@ -4667,14 +4661,8 @@
     "sage.schemes.toric.chow_group": {
         "ntests": 1
     },
-    "sage.schemes.toric.divisor": {
-        "ntests": 2
-    },
-    "sage.schemes.toric.points": {
-        "ntests": 3
-    },
     "sage.schemes.toric.variety": {
-        "ntests": 9
+        "ntests": 3
     },
     "sage.sets.cartesian_product": {
         "ntests": 54

--- a/pkgs/sagemath-schemes/pyproject.toml.m4
+++ b/pkgs/sagemath-schemes/pyproject.toml.m4
@@ -23,7 +23,9 @@ description = "passagemath: Schemes, varieties, elliptic curves, algebraic Riema
 dependencies = [
     SPKG_INSTALL_REQUIRES_gmpy2
     SPKG_INSTALL_REQUIRES_cysignals
+    SPKG_INSTALL_REQUIRES_fpylll
     SPKG_INSTALL_REQUIRES_memory_allocator
+    SPKG_INSTALL_REQUIRES_primecountpy
     SPKG_INSTALL_REQUIRES_scipy
     SPKG_INSTALL_REQUIRES_sagemath_modules
     SPKG_INSTALL_REQUIRES_sagemath_flint
@@ -41,8 +43,8 @@ content-type = "text/x-rst"
 test    = ["passagemath-repl"]
 
 # extras by packages (same as sagemath-modules)
-flint   = ["passagemath-flint"]
-fpylll  = [SPKG_INSTALL_REQUIRES_fpylll]
+flint   = []  # No extra needed
+fpylll  = []  # No extra needed
 gsl     = []  # No extra needed
 linbox  = ["passagemath-linbox"]
 m4ri    = ["passagemath-modules[linbox]"]

--- a/src/sage/rings/all__sagemath_schemes.py
+++ b/src/sage/rings/all__sagemath_schemes.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-schemes

--- a/src/sage/rings/polynomial/all__sagemath_schemes.py
+++ b/src/sage/rings/polynomial/all__sagemath_schemes.py
@@ -1,0 +1,1 @@
+# sage_setup: distribution = sagemath-schemes

--- a/src/sage/rings/polynomial/binary_form_reduce.py
+++ b/src/sage/rings/polynomial/binary_form_reduce.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-schemes
 r"""
 Helper functions for reduction of binary forms.
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -971,7 +971,7 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
                 gens_map = dict(zip(Q.variable_names(),self.gens()[:Q.ngens()]))
                 return eval(str(element),gens_map)
 
-        if isinstance(element, (sage.interfaces.abc.SingularElement, cypari2.gen.Gen)):
+        if isinstance(element, (sage.interfaces.abc.SingularElement, Gen)):
             element = str(element)
         elif isinstance(element, sage.interfaces.abc.Macaulay2Element):
             element = element.external_string()

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -255,8 +255,14 @@ from sage.misc.sage_eval import sage_eval
 
 import sage.rings.polynomial.polynomial_singular_interface
 
-cimport cypari2.gen
 from sage.rings.polynomial import polynomial_element
+
+
+try:
+    from cypari2.gen import Gen
+except ImportError:
+    Gen = ()
+
 
 permstore=[]
 cdef class MPolynomialRing_libsingular(MPolynomialRing_base):

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2681,7 +2681,7 @@ def special_supersingular_curve(F, q=None, *, endomorphism=False):
         sage: pi = E.frobenius_isogeny()
         sage: pi.codomain() is pi.domain() is E
         True
-        sage: pi * endo == -endo * pi
+        sage: pi * endo == -endo * pi                                                   # needs sage.symbolic
         True
 
     Also try it for larger-degree fields::

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1530,7 +1530,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         When the input is horrendous, some of the algorithms just bomb
         out with a :exc:`RuntimeError`::
 
-            sage: EllipticCurve([1234567,89101112]).analytic_rank(algorithm='rubinstein')
+            sage: EllipticCurve([1234567,89101112]).analytic_rank(algorithm='rubinstein')   # needs lcalc
             Traceback (most recent call last):
             ...
             RuntimeError: unable to compute analytic rank using rubinstein algorithm (unable to convert ' 6.19283... and is too large' to an integer)

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1273,6 +1273,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         Since :issue:`10256`, the interface for negative modular symbols in eclib is available::
 
+            sage: # needs eclib
             sage: E = EllipticCurve('11a1')
             sage: Mplus = E.modular_symbol(+1); Mplus
             Modular symbol with sign 1 over Rational Field attached to
@@ -1695,14 +1696,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([-39,123])
             sage: E.rank()                                                              # needs eclib
             1
-            sage: E.analytic_rank_upper_bound(max_Delta=1, adaptive=True)
+            sage: E.analytic_rank_upper_bound(max_Delta=1, adaptive=True)               # needs sage.symbolic
             1
 
         This is especially true for elliptic curves with large rank.
 
         ::
 
-            sage: for r in range(9):
+            sage: for r in range(9):                                                    # needs sage.symbolic
             ....:     E = elliptic_curves.rank(r)[0]
             ....:     print((r, E.analytic_rank_upper_bound(max_Delta=1,
             ....:                                           adaptive=False,
@@ -2113,7 +2114,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([0,0, 1, -7, 6])
             sage: E.gens(use_database=False, algorithm='pari')  # random    # needs eclib
             [(2 : 0 : 1), (-1 : 3 : 1), (11 : 35 : 1)]
-            sage: E.saturation(_)[1]
+            sage: E.saturation(_)[1]                                        # needs eclib
             1
 
         Since :issue:`23962`, the default is to use the Cremona
@@ -6557,25 +6558,25 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         An example with negative discriminant::
 
-            sage: EllipticCurve('900d1').S_integral_points([17], both_signs=True)
+            sage: EllipticCurve('900d1').S_integral_points([17], both_signs=True)           # needs eclib
             [(-11 : -27 : 1), (-11 : 27 : 1), (-4 : -34 : 1), (-4 : 34 : 1), (4 : -18 : 1),
              (4 : 18 : 1), (2636/289 : -98786/4913 : 1), (2636/289 : 98786/4913 : 1),
              (16 : -54 : 1), (16 : 54 : 1)]
 
         Output checked with Magma (corrected in 3 cases)::
 
-            sage: [len(e.S_integral_points([2], both_signs=False)) for e in cremona_curves([11..100])] # long time (17s on sage.math, 2011)
+            sage: [len(e.S_integral_points([2], both_signs=False)) for e in cremona_curves([11..100])] # long time (17s on sage.math, 2011)     # needs eclib
             [2, 0, 2, 3, 3, 1, 3, 1, 3, 5, 3, 5, 4, 1, 1, 2, 2, 2, 3, 1, 2, 1, 0, 1, 3, 3, 1, 1, 5, 3, 4, 2, 1, 1, 5, 3, 2, 2, 1, 1, 1, 0, 1, 3, 0, 1, 0, 1, 1, 3, 7, 1, 3, 3, 3, 1, 1, 2, 3, 1, 2, 3, 1, 2, 1, 3, 3, 1, 1, 1, 0, 1, 3, 3, 1, 1, 7, 1, 0, 1, 1, 0, 1, 2, 0, 3, 1, 2, 1, 3, 1, 2, 2, 4, 5, 3, 2, 1, 1, 6, 1, 0, 1, 3, 1, 3, 3, 1, 1, 1, 1, 1, 3, 1, 5, 1, 2, 4, 1, 1, 1, 1, 1, 0, 1, 0, 2, 2, 0, 0, 1, 0, 1, 1, 6, 1, 0, 1, 1, 0, 4, 3, 1, 2, 1, 2, 3, 1, 1, 1, 1, 8, 3, 1, 2, 1, 2, 0, 8, 2, 0, 6, 2, 3, 1, 1, 1, 3, 1, 3, 2, 1, 3, 1, 2, 1, 6, 9, 3, 3, 1, 1, 2, 3, 1, 1, 5, 5, 1, 1, 0, 1, 1, 2, 3, 1, 1, 2, 3, 1, 3, 1, 1, 1, 1, 0, 0, 1, 3, 3, 1, 3, 1, 1, 2, 2, 0, 0, 6, 1, 0, 1, 1, 1, 1, 3, 1, 2, 6, 3, 1, 2, 2, 1, 1, 1, 1, 7, 5, 4, 3, 3, 1, 1, 1, 1, 1, 1, 8, 5, 1, 1, 3, 3, 1, 1, 3, 3, 1, 1, 2, 3, 6, 1, 1, 7, 3, 3, 4, 5, 9, 6, 1, 0, 7, 1, 1, 3, 1, 1, 2, 3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 7, 8, 2, 3, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1]
 
         An example from [PZGH1999]_::
 
             sage: E = EllipticCurve([0,0,0,-172,505])
-            sage: E.rank(), len(E.S_integral_points([3,5,7]))  # long time (5s on sage.math, 2011)
+            sage: E.rank(), len(E.S_integral_points([3,5,7]))  # long time (5s on sage.math, 2011)      # needs eclib
             (4, 72)
 
         This is curve "7690e1" which failed until :issue:`4805` was fixed::
 
-            sage: EllipticCurve([1,1,1,-301,-1821]).S_integral_points([13,2])
+            sage: EllipticCurve([1,1,1,-301,-1821]).S_integral_points([13,2])                           # needs eclib
             [(-13 : -4 : 1), (-9 : -12 : 1), (-7 : 2 : 1), (21 : -52 : 1),
              (23 : -76 : 1), (63 : -516 : 1), (71 : -620 : 1), (87 : -844 : 1),
              (2711 : -142540 : 1), (7323 : -630376 : 1), (17687 : -2361164 : 1)]

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -70,7 +70,7 @@ Here we find that the Heegner point generates a subgroup of index 3::
     sage: P = E.heegner_point(-7)
     sage: z = P.point_exact(); z == E(0, 1, 1)  or -z == E(0, 1, 1)
     True
-    sage: E.regulator()
+    sage: E.regulator()                                                                 # needs eclib
     0.0498083972980648
     sage: z.height()
     0.448275575682583

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -3237,7 +3237,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             [-1.2...e-16, -1.00000000000000, 1.00000000000000]
             sage: -2*E.gens()[0]                                                        # needs eclib
             (0 : -1 : 1)
-            sage: P._trace_index()
+            sage: P._trace_index()                                                      # needs eclib
             2
 
             sage: P = E.heegner_point(-68); P
@@ -3245,7 +3245,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             sage: N(P)
             (0.219223593595584 - 1.87443160153148*I
              : -1.34232921921325 - 1.52356748877889*I : 1.00000000000000)
-            sage: P._trace_index()
+            sage: P._trace_index()                                                      # needs eclib
             0
         """
         if self.conductor() != 1:
@@ -3356,9 +3356,9 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         the discriminant below is strong confirmation -- but not proof
         -- that this polynomial is correct::
 
-            sage: f = P.numerical_approx(70)[0].algdep(6); f
+            sage: f = P.numerical_approx(70)[0].algdep(6); f                            # needs fpylll
             1225*x^6 + 1750*x^5 - 21675*x^4 - 380*x^3 + 110180*x^2 - 129720*x + 48771
-            sage: f.discriminant().factor()
+            sage: f.discriminant().factor()                                             # needs fpylll
             2^6 * 3^2 * 5^11 * 7^4 * 13^2 * 19^6 * 199^2 * 719^2 * 26161^2
         """
         tau = ComplexField(prec)(self.tau())

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -21,9 +21,9 @@ EXAMPLES::
       From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
       To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
       Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101)
-    sage: phi + phi == phi * E.scalar_multiplication(2)
+    sage: phi + phi == phi * E.scalar_multiplication(2)                                 # needs sage.symbolic
     True
-    sage: phi + phi + phi == phi * E.scalar_multiplication(3)
+    sage: phi + phi + phi == phi * E.scalar_multiplication(3)                           # needs sage.symbolic
     True
 
 An example of computing with a supersingular endomorphism ring::
@@ -452,7 +452,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF(419^2), [1,0])
             sage: i = E.automorphisms()[-1]
             sage: j = E.frobenius_isogeny()
-            sage: i + j == j + i
+            sage: i + j == j + i                                                        # needs sage.symbolic
             True
         """
         from sage.structure.richcmp import op_EQ
@@ -590,7 +590,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
               From: Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
               To:   Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
               Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101)
-            sage: (phi + phi).dual() == phi.dual() + phi.dual()
+            sage: (phi + phi).dual() == phi.dual() + phi.dual()                         # needs sage.symbolic
             True
 
         ::
@@ -605,7 +605,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 431^2
               Via:  (Scalar-multiplication endomorphism [2] of Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 431^2, Elliptic-curve endomorphism of Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 431^2
               Via:  (u,r,s,t) = (8*z2 + 427, 0, 0, 0))
-            sage: endo.dual() == (m2 - iota)
+            sage: endo.dual() == (m2 - iota)                                            # needs sage.symbolic
             True
 
         ALGORITHM: Taking the dual distributes over addition.

--- a/src/sage/schemes/elliptic_curves/padic_lseries.py
+++ b/src/sage/schemes/elliptic_curves/padic_lseries.py
@@ -112,7 +112,7 @@ class pAdicLseries(SageObject):
         O(5^4) + O(5)*T + (4 + O(5))*T^2 + (2 + O(5))*T^3 + (3 + O(5))*T^4 + O(T^5)
         sage: L.series(3, prec=10)
         O(5^5) + O(5^2)*T + (4 + 4*5 + O(5^2))*T^2 + (2 + 4*5 + O(5^2))*T^3 + (3 + O(5^2))*T^4 + (1 + O(5))*T^5 + O(5)*T^6 + (4 + O(5))*T^7 + (2 + O(5))*T^8 + O(5)*T^9 + O(T^10)
-        sage: L.series(2,quadratic_twist=-3)
+        sage: L.series(2, quadratic_twist=-3)                                           # needs sage.graphs
         2 + 4*5 + 4*5^2 + O(5^4) + O(5)*T + (1 + O(5))*T^2 + (4 + O(5))*T^3 + O(5)*T^4 + O(T^5)
 
     A prime p such that E[p] is reducible::
@@ -204,7 +204,7 @@ class pAdicLseries(SageObject):
 
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(5)
-            sage: lp.modular_symbol(1/7,sign=-1)  #indirect doctest
+            sage: lp.modular_symbol(1/7, sign=-1)  # indirect doctest                   # needs sage.graphs
             -1/2
         """
         self._negative_modular_symbol = self._E.modular_symbol(sign=-1, implementation='sage', normalize=self._normalize)
@@ -302,9 +302,9 @@ class pAdicLseries(SageObject):
             sage: lp = E.padic_lseries(5)
             sage: [lp.modular_symbol(r) for r in [0,1/5,oo,1/11]]
             [1/5, 6/5, 0, 0]
-            sage: [lp.modular_symbol(r,sign=-1) for r in [0,1/3,oo,1/7]]
+            sage: [lp.modular_symbol(r, sign=-1) for r in [0,1/3,oo,1/7]]               # needs sage.graphs
             [0, 1/2, 0, -1/2]
-            sage: [lp.modular_symbol(r,quadratic_twist=-20) for r in [0,1/5,oo,1/11]]
+            sage: [lp.modular_symbol(r, quadratic_twist=-20) for r in [0,1/5,oo,1/11]]  # needs sage.graphs
             [1, 1, 0, 1/2]
 
             sage: E = EllipticCurve('20a1')
@@ -392,9 +392,9 @@ class pAdicLseries(SageObject):
             sage: L = E.padic_lseries(5)
             sage: L.measure(1,2, prec=9)
             2 + 3*5 + 4*5^3 + 2*5^4 + 3*5^5 + 3*5^6 + 4*5^7 + 4*5^8 + O(5^9)
-            sage: L.measure(1,2, quadratic_twist=8,prec=15)
+            sage: L.measure(1,2, quadratic_twist=8, prec=15)
             O(5^15)
-            sage: L.measure(1,2, quadratic_twist=-4,prec=15)
+            sage: L.measure(1,2, quadratic_twist=-4, prec=15)                           # needs sage.graphs
             4 + 4*5 + 4*5^2 + 3*5^3 + 2*5^4 + 5^5 + 3*5^6 + 5^8 + 2*5^9 + 3*5^12 + 2*5^13 + 4*5^14 + O(5^15)
 
             sage: E = EllipticCurve('11a1')
@@ -817,7 +817,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
             sage: E = EllipticCurve('43a1')
             sage: lp = E.padic_lseries(3)
-            sage: lp.series(2,quadratic_twist=-19)
+            sage: lp.series(2, quadratic_twist=-19)                                     # needs sage.graphs
             2 + 2*3 + 2*3^2 + O(3^4) + (1 + O(3))*T + (1 + O(3))*T^2 + O(T^3)
             sage: E.quadratic_twist(-19).label()    # optional -- database_cremona_ellcurve
             '15523a1'

--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -158,9 +158,9 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
         sage: f = x^2 - e.ap(3)*x + 3
         sage: f(alpha)
         O(3^9)
-        sage: r = e.lseries().L_ratio(); r
+        sage: r = e.lseries().L_ratio(); r                                              # needs sage.graphs
         1/5
-        sage: (1 - alpha^(-1))^2 * r
+        sage: (1 - alpha^(-1))^2 * r                                                    # needs sage.graphs
         2 + 3 + 3^2 + 2*3^3 + 2*3^5 + 3^6 + 3^7 + O(3^9)
         sage: P(0)
         2 + 3 + 3^2 + 2*3^3 + 2*3^5 + 3^6 + O(3^7)

--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -132,6 +132,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     EXAMPLES::
 
+        sage: # needs eclib
         sage: E = EllipticCurve('37a')
         sage: L = E.padic_lseries(5); L
         5-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field


### PR DESCRIPTION
- **src/sage/rings/polynomial/multi_polynomial_libsingular.pyx: Modularize import from cypari2**
- **src/sage/schemes/elliptic_curves: Add # needs**
- **src/sage/rings/polynomial/multi_polynomial_libsingular.pyx: Modularize import from cypari2 (fixup)**
- **src/sage/schemes/elliptic_curves: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-schemes*' --update-known-test-failures**
- **pkgs/sagemath-schemes: Add sage.rings.polynomial.binary_form_reduce**
- **pkgs/sagemath-schemes: Add fpylll, primecountpy as dependencies**
- **./sage --fixdoctests --distribution 'sagemath-schemes*' --update-known-test-failures**
- **src/sage/schemes/elliptic_curves/heegner.py: Add # needs**
