### PR TITLE
pkgs/sagemath-symbolics: Make sure maxima is found, fix doctests

### DIFF
--- a/pkgs/sagemath-maxima/pyproject.toml.m4
+++ b/pkgs/sagemath-maxima/pyproject.toml.m4
@@ -17,7 +17,9 @@ build-backend = "setuptools.build_meta"
 name = "passagemath-maxima"
 description = "passagemath: Symbolic calculus"
 dependencies = [
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sagemath_ecl
+    SPKG_INSTALL_REQUIRES_sagemath_environment
 ]
 dynamic = ["version"]
 include(`pyproject_toml_metadata.m4')dnl'

--- a/pkgs/sagemath-symbolics/known-test-failures.json
+++ b/pkgs/sagemath-symbolics/known-test-failures.json
@@ -1,7 +1,6 @@
 {
     "sage.algebras.clifford_algebra": {
-        "failed": true,
-        "ntests": 618
+        "ntests": 616
     },
     "sage.algebras.clifford_algebra_element": {
         "ntests": 148
@@ -60,8 +59,7 @@
         "ntests": 77
     },
     "sage.calculus.calculus": {
-        "failed": true,
-        "ntests": 434
+        "ntests": 404
     },
     "sage.calculus.desolvers": {
         "ntests": 220
@@ -152,8 +150,7 @@
         "ntests": 328
     },
     "sage.categories.chain_complexes": {
-        "failed": true,
-        "ntests": 18
+        "ntests": 12
     },
     "sage.categories.coalgebras_with_basis": {
         "ntests": 5
@@ -1247,8 +1244,7 @@
         "ntests": 15
     },
     "sage.geometry.toric_lattice": {
-        "failed": true,
-        "ntests": 295
+        "ntests": 254
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 79
@@ -1265,14 +1261,6 @@
     },
     "sage.groups.abelian_gps.values": {
         "ntests": 59
-    },
-    "sage.groups.additive_abelian.additive_abelian_group": {
-        "failed": true,
-        "ntests": 77
-    },
-    "sage.groups.additive_abelian.additive_abelian_wrapper": {
-        "failed": true,
-        "ntests": 69
     },
     "sage.groups.additive_abelian.qmodnz": {
         "ntests": 37
@@ -1342,7 +1330,7 @@
     },
     "sage.homology.chain_complex": {
         "failed": true,
-        "ntests": 241
+        "ntests": 216
     },
     "sage.homology.chain_complex_morphism": {
         "ntests": 37
@@ -1357,15 +1345,13 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
-        "failed": true,
-        "ntests": 5
+        "ntests": 3
     },
     "sage.interfaces.abc": {
         "ntests": 8
     },
     "sage.interfaces.magma": {
-        "failed": true,
-        "ntests": 83
+        "ntests": 75
     },
     "sage.interfaces.maple": {
         "ntests": 19
@@ -1377,12 +1363,10 @@
         "ntests": 29
     },
     "sage.interfaces.maxima": {
-        "failed": true,
-        "ntests": 191
+        "ntests": 190
     },
     "sage.interfaces.maxima_abstract": {
-        "failed": true,
-        "ntests": 231
+        "ntests": 223
     },
     "sage.interfaces.maxima_lib": {
         "ntests": 225
@@ -1571,8 +1555,7 @@
         "ntests": 115
     },
     "sage.manifolds.differentiable.manifold": {
-        "failed": true,
-        "ntests": 563
+        "ntests": 562
     },
     "sage.manifolds.differentiable.manifold_homset": {
         "ntests": 283
@@ -1727,7 +1710,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 1688
+        "ntests": 1654
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 3
@@ -1755,11 +1738,7 @@
     },
     "sage.matrix.matrix_integer_dense": {
         "failed": true,
-        "ntests": 577
-    },
-    "sage.matrix.matrix_integer_dense_hnf": {
-        "failed": true,
-        "ntests": 125
+        "ntests": 507
     },
     "sage.matrix.matrix_integer_dense_saturation": {
         "ntests": 44
@@ -1790,7 +1769,7 @@
     },
     "sage.matrix.matrix_rational_dense": {
         "failed": true,
-        "ntests": 312
+        "ntests": 297
     },
     "sage.matrix.matrix_rational_sparse": {
         "failed": true,
@@ -1827,8 +1806,7 @@
         "ntests": 69
     },
     "sage.matrix.symplectic_basis": {
-        "failed": true,
-        "ntests": 46
+        "ntests": 44
     },
     "sage.matrix.tests": {
         "ntests": 13
@@ -1852,8 +1830,7 @@
         "ntests": 99
     },
     "sage.matroids.database_matroids": {
-        "failed": true,
-        "ntests": 349
+        "ntests": 347
     },
     "sage.matroids.dual_matroid": {
         "ntests": 77
@@ -1862,12 +1839,10 @@
         "ntests": 48
     },
     "sage.matroids.linear_matroid": {
-        "failed": true,
-        "ntests": 542
+        "ntests": 538
     },
     "sage.matroids.matroid": {
-        "failed": true,
-        "ntests": 828
+        "ntests": 827
     },
     "sage.matroids.minor_matroid": {
         "ntests": 73
@@ -1967,7 +1942,7 @@
         "ntests": 32
     },
     "sage.misc.functional": {
-        "ntests": 179
+        "ntests": 181
     },
     "sage.misc.html": {
         "ntests": 64
@@ -2339,12 +2314,7 @@
         "ntests": 17
     },
     "sage.quadratic_forms.quadratic_form__split_local_covering": {
-        "failed": true,
-        "ntests": 13
-    },
-    "sage.quadratic_forms.quadratic_form__ternary_Tornaria": {
-        "failed": true,
-        "ntests": 58
+        "ntests": 10
     },
     "sage.quadratic_forms.quadratic_form__theta": {
         "ntests": 13
@@ -2359,8 +2329,7 @@
         "ntests": 97
     },
     "sage.quadratic_forms.ternary_qf": {
-        "failed": true,
-        "ntests": 286
+        "ntests": 285
     },
     "sage.repl.attach": {
         "ntests": 135
@@ -2655,10 +2624,6 @@
     "sage.rings.number_field.number_field_element_base": {
         "ntests": 2
     },
-    "sage.rings.number_field.order_ideal": {
-        "failed": true,
-        "ntests": 200
-    },
     "sage.rings.padics.misc": {
         "ntests": 21
     },
@@ -2667,10 +2632,6 @@
     },
     "sage.rings.polynomial.commutative_polynomial": {
         "ntests": 7
-    },
-    "sage.rings.polynomial.complex_roots": {
-        "failed": true,
-        "ntests": 42
     },
     "sage.rings.polynomial.cyclotomic": {
         "ntests": 22
@@ -2741,14 +2702,13 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1672
+        "ntests": 1666
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 186
     },
     "sage.rings.polynomial.polynomial_integer_dense_flint": {
-        "failed": true,
-        "ntests": 288
+        "ntests": 286
     },
     "sage.rings.polynomial.polynomial_integer_dense_ntl": {
         "ntests": 169
@@ -3024,8 +2984,7 @@
         "ntests": 1
     },
     "sage.stats.distributions.discrete_gaussian_lattice": {
-        "failed": true,
-        "ntests": 109
+        "ntests": 107
     },
     "sage.stats.distributions.discrete_gaussian_polynomial": {
         "ntests": 22
@@ -3181,7 +3140,7 @@
     },
     "sage.symbolic.expression": {
         "failed": true,
-        "ntests": 3018
+        "ntests": 3016
     },
     "sage.symbolic.expression_conversion_algebraic": {
         "ntests": 30

--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -2286,7 +2286,7 @@ class ExteriorAlgebraBoundary(ExteriorAlgebraDifferential):
                                   [ 0  0  2]       [0]
                     [0 0 0]       [ 1  0  0]       [0]
          0 <-- C_0 <-------- C_1 <----------- C_2 <---- C_3 <-- 0
-        sage: C.homology()
+        sage: C.homology()                                                              # needs sage.libs.pari
         {0: Z, 1: C2 x C2, 2: 0, 3: Z}
 
     REFERENCES:
@@ -2529,7 +2529,7 @@ class ExteriorAlgebraCoboundary(ExteriorAlgebraDifferential):
                                   [-2  0  0]       [0]
                     [0 0 0]       [ 0  2  0]       [0]
          0 <-- C_3 <-------- C_2 <----------- C_1 <---- C_0 <-- 0
-        sage: C.homology()
+        sage: C.homology()                                                              # needs sage.libs.pari
         {0: Z, 1: 0, 2: C2 x C2, 3: Z}
 
     REFERENCES:

--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -997,6 +997,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     EXAMPLES: First some simple examples::
 
+        sage: # needs fpylll
         sage: sqrt(2).minpoly()
         x^2 - 2
         sage: minpoly(2^(1/3))
@@ -1011,6 +1012,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
+        sage: # needs fpylll
         sage: sin(pi/3).minpoly()
         x^2 - 3/4
         sage: sin(pi/7).minpoly()
@@ -1024,6 +1026,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
+        sage: # needs fpylll
         sage: (sqrt(2) + sqrt(3) + sqrt(6)).minpoly()
         x^4 - 22*x^2 - 48*x - 23
         sage: K.<a,b> = NumberField([x^2-2, x^2-3])
@@ -1033,6 +1036,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
     The :func:`minpoly` function is used implicitly when creating
     number fields::
 
+        sage: # needs fpylll
         sage: x = var('x')
         sage: eqn =  x^3 + sqrt(2)*x + 5 == 0
         sage: a = solve(eqn, x)[0].rhs()
@@ -1045,6 +1049,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
+        sage: # needs fpylll
         sage: f = x^3 - x + 1
         sage: a = f.solve(x)[0].rhs(); a
         -1/2*(1/18*sqrt(23)*sqrt(3) - 1/2)^(1/3)*(I*sqrt(3) + 1)
@@ -1057,7 +1062,8 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
-        sage: a = sqrt(2)+sqrt(3)+sqrt(5)
+        sage: # needs fpylll
+        sage: a = sqrt(2) + sqrt(3) + sqrt(5)
         sage: f = a.minpoly(); f
         x^8 - 40*x^6 + 352*x^4 - 960*x^2 + 576
         sage: f(a)
@@ -1069,6 +1075,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
+        sage: # needs fpylll
         sage: a = sin(pi/7)
         sage: f = a.minpoly(algorithm='numerical'); f
         x^6 - 7/4*x^4 + 7/8*x^2 - 7/64
@@ -1079,6 +1086,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
+        sage: # needs fpylll
         sage: a = sqrt(3) + sqrt(2)
         sage: a.minpoly(algorithm='numerical', bits=100, degree=3)
         Traceback (most recent call last):
@@ -1089,6 +1097,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     ::
 
+        sage: # needs fpylll
         sage: cos(pi/33).minpoly(algorithm='algebraic')
         x^10 + 1/2*x^9 - 5/2*x^8 - 5/4*x^7 + 17/8*x^6 + 17/16*x^5
          - 43/64*x^4 - 43/128*x^3 + 3/64*x^2 + 3/128*x + 1/1024
@@ -1098,7 +1107,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
     Sometimes it fails, as it must given that some numbers aren't algebraic::
 
-        sage: sin(1).minpoly(algorithm='numerical')
+        sage: sin(1).minpoly(algorithm='numerical')                                     # needs fpylll
         Traceback (most recent call last):
         ...
         ValueError: Could not find minimal polynomial (1000 bits, degree 24).

--- a/src/sage/categories/chain_complexes.py
+++ b/src/sage/categories/chain_complexes.py
@@ -67,7 +67,7 @@ class ChainComplexes(Category_module):
 
             EXAMPLES::
 
-                sage: # needs sage.modules
+                sage: # needs sage.libs.pari sage.modules
                 sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})
                 sage: C.homology(0)
                 Z x Z
@@ -173,7 +173,7 @@ class HomologyFunctor(Functor):
 
         sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})               # needs sage.modules
         sage: H = HomologyFunctor(ChainComplexes(ZZ), 1)
-        sage: H(C)                                                                      # needs sage.modules
+        sage: H(C)                                                                      # needs sage.libs.pari sage.modules
         Z x C3
 
     ::
@@ -231,7 +231,7 @@ class HomologyFunctor(Functor):
 
             sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})           # needs sage.modules
             sage: H = HomologyFunctor(ChainComplexes(ZZ), 1)
-            sage: H._apply_functor(C)                                                   # needs sage.modules
+            sage: H._apply_functor(C)                                                   # needs sage.libs.pari sage.modules
             Z x C3
         """
         return x.homology(self._n)

--- a/src/sage/geometry/toric_lattice.py
+++ b/src/sage/geometry/toric_lattice.py
@@ -223,7 +223,7 @@ def is_ToricLatticeQuotient(x):
         sage: is_ToricLatticeQuotient(N)
         False
         sage: Q = N / N.submodule([(1,2,3), (3,2,1)])
-        sage: Q
+        sage: Q                                                                         # needs sage.libs.pari
         Quotient with torsion of 3-d lattice N
         by Sublattice <N(1, 2, 3), N(0, 4, 8)>
         sage: is_ToricLatticeQuotient(Q)
@@ -434,10 +434,10 @@ class ToricLattice_generic(FreeModule_generic_pid):
 
             sage: N3 = ToricLattice(3, 'N3')
             sage: Q = N3 / N3.span([ N3(1,2,3) ])
-            sage: Q.an_element()
+            sage: Q.an_element()                                                        # needs sage.libs.pari
             N3[1, 0, 0]
             sage: N2 = ToricLattice(2, 'N2')
-            sage: N2( Q.an_element() )
+            sage: N2( Q.an_element() )                                                  # needs sage.libs.pari
             N2(1, 0)
         """
         supercall = super().__call__
@@ -678,7 +678,7 @@ class ToricLattice_generic(FreeModule_generic_pid):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: Q
+            sage: Q                                                                     # needs sage.libs.pari
             Quotient with torsion of 3-d lattice N
             by Sublattice <N(1, 8, 0), N(0, 12, 0)>
 
@@ -701,10 +701,10 @@ class ToricLattice_generic(FreeModule_generic_pid):
             sage: N = ToricLattice(3)
             sage: M = ToricLattice(3, name='M')
             sage: Ms = M.submodule([M(2,4,0), M(9,12,0)])
-            sage: N.quotient(Ms.vector_space())
+            sage: N.quotient(Ms.vector_space())                                         # needs sage.libs.pari
             Quotient with torsion of 3-d lattice N by Sublattice
             <N(1, 8, 0), N(0, 12, 0)>
-            sage: N.quotient(Ms.sparse_module())
+            sage: N.quotient(Ms.sparse_module())                                        # needs sage.libs.pari
             Quotient with torsion of 3-d lattice N by Sublattice
             <N(1, 8, 0), N(0, 12, 0)>
 
@@ -729,13 +729,13 @@ class ToricLattice_generic(FreeModule_generic_pid):
         We can quotient by the trivial sublattice::
 
             sage: N = ToricLattice(3)
-            sage: N.quotient(N.zero_submodule())
+            sage: N.quotient(N.zero_submodule())                                        # needs sage.libs.pari
             3-d lattice, quotient of 3-d lattice N by Sublattice <>
 
         We can quotient a lattice by itself::
 
             sage: N = ToricLattice(3)
-            sage: N.quotient(N)
+            sage: N.quotient(N)                                                         # needs sage.libs.pari
             0-d lattice, quotient of 3-d lattice N by Sublattice
             <N(1, 0, 0), N(0, 1, 0), N(0, 0, 1)>
         """
@@ -1167,7 +1167,7 @@ class ToricLattice_sublattice_with_basis(ToricLattice_generic,
 
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([(1,1,0), (3,2,1)])
-            sage: Ns.dual()
+            sage: Ns.dual()                                                             # needs sage.libs.pari
             2-d lattice, quotient of 3-d lattice M by Sublattice <M(1, -1, -1)>
         """
         if "_dual" not in self.__dict__:
@@ -1289,11 +1289,11 @@ class ToricLattice_quotient_element(FGP_Element):
         sage: e2 = Q(N(2,3,3))
         sage: e2
         N[2, 3, 3]
-        sage: e == e2
+        sage: e == e2                                                                   # needs sage.libs.pari
         True
-        sage: e.vector()
+        sage: e.vector()                                                                # needs sage.libs.pari
         (-4)
-        sage: e2.vector()
+        sage: e2.vector()                                                               # needs sage.libs.pari
         (-4)
     """
 
@@ -1308,7 +1308,7 @@ class ToricLattice_quotient_element(FGP_Element):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: print(Q.gen(0)._latex_())
+            sage: print(Q.gen(0)._latex_())                                             # needs sage.libs.pari
             \left[0,\,1,\,0\right]_{N}
         """
         return latex(self.lift()).replace("(", "[", 1).replace(")", "]", 1)
@@ -1324,7 +1324,7 @@ class ToricLattice_quotient_element(FGP_Element):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: print(Q.gen(0)._repr_())
+            sage: print(Q.gen(0)._repr_())                                              # needs sage.libs.pari
             N[0, 1, 0]
         """
         return str(self.lift()).replace("(", "[", 1).replace(")", "]", 1)
@@ -1344,7 +1344,7 @@ class ToricLattice_quotient_element(FGP_Element):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: Q.0.set_immutable()
+            sage: Q.0.set_immutable()                                                   # needs sage.libs.pari
         """
         pass
 
@@ -1391,33 +1391,33 @@ class ToricLattice_quotient(FGP_Module_class):
         sage: N = ToricLattice(3)
         sage: sublattice = N.submodule([(1,1,0), (3,2,1)])
         sage: Q = N/sublattice
-        sage: Q
+        sage: Q                                                                         # needs sage.libs.pari
         1-d lattice, quotient of 3-d lattice N by Sublattice <N(1, 0, 1), N(0, 1, -1)>
-        sage: Q.gens()
+        sage: Q.gens()                                                                  # needs sage.libs.pari
         (N[1, 0, 0],)
 
     Here, ``sublattice`` happens to be of codimension one in ``N``. If
     you want to prescribe the sign of the quotient generator, you can
     do either::
 
-        sage: Q = N.quotient(sublattice, positive_point=N(0,0,-1)); Q
+        sage: Q = N.quotient(sublattice, positive_point=N(0,0,-1)); Q                   # needs sage.libs.pari
         1-d lattice, quotient of 3-d lattice N by Sublattice <N(1, 0, 1), N(0, 1, -1)>
-        sage: Q.gens()
+        sage: Q.gens()                                                                  # needs sage.libs.pari
         (N[1, 0, 0],)
 
     or::
 
         sage: M = N.dual()
-        sage: Q = N.quotient(sublattice, positive_dual_point=M(1,0,0)); Q
+        sage: Q = N.quotient(sublattice, positive_dual_point=M(1,0,0)); Q               # needs sage.libs.pari
         1-d lattice, quotient of 3-d lattice N by Sublattice <N(1, 0, 1), N(0, 1, -1)>
-        sage: Q.gens()
+        sage: Q.gens()                                                                  # needs sage.libs.pari
         (N[1, 0, 0],)
 
     TESTS::
 
         sage: loads(dumps(Q)) == Q
         True
-        sage: loads(dumps(Q)).gens() == Q.gens()
+        sage: loads(dumps(Q)).gens() == Q.gens()                                        # needs sage.libs.pari
         True
     """
 
@@ -1431,7 +1431,7 @@ class ToricLattice_quotient(FGP_Module_class):
 
             sage: N = ToricLattice(3)
             sage: from sage.geometry.toric_lattice import ToricLattice_quotient
-            sage: ToricLattice_quotient(N, N.span([N(1,2,3)]))
+            sage: ToricLattice_quotient(N, N.span([N(1,2,3)]))                          # needs sage.libs.pari
             2-d lattice, quotient of 3-d lattice N by Sublattice <N(1, 2, 3)>
 
         An :exc:`ArithmeticError` will be raised if ``W`` is not a
@@ -1443,7 +1443,7 @@ class ToricLattice_quotient(FGP_Module_class):
             Sublattice <N(1, 0, 0)>
             sage: Ns.span([N.gen(1)])
             Sublattice <N(0, 1, 0)>
-            sage: Ns.quotient(Ns.span([N.gen(1)]))
+            sage: Ns.quotient(Ns.span([N.gen(1)]))                                      # needs sage.libs.pari
             Traceback (most recent call last):
             ...
             ArithmeticError: W must be a sublattice of V
@@ -1490,8 +1490,8 @@ class ToricLattice_quotient(FGP_Module_class):
         EXAMPLES::
 
             sage: N = ToricLattice(3)
-            sage: Q = N.quotient(N.span([N(1,2,3), N(0,2,1)]), positive_point=N(0,-1,0))
-            sage: Q.gens()
+            sage: Q = N.quotient(N.span([N(1,2,3), N(0,2,1)]), positive_point=N(0,-1,0))    # needs sage.libs.pari
+            sage: Q.gens()                                                                  # needs sage.libs.pari
             (N[0, -1, 0],)
         """
         gens = self.smith_form_gens()
@@ -1533,12 +1533,12 @@ class ToricLattice_quotient(FGP_Module_class):
             True
             sage: x.parent() is Q
             True
-            sage: x == Q(N(1,2,3))
+            sage: x == Q(N(1,2,3))                                                          # needs sage.libs.pari
             True
             sage: y = Q(3,6,3)
             sage: y
             N[3, 6, 3]
-            sage: x == y
+            sage: x == y                                                                    # needs sage.libs.pari
             True
         """
         if len(x) == 1 and (x[0] not in ZZ or x[0] == 0):
@@ -1585,12 +1585,12 @@ class ToricLattice_quotient(FGP_Module_class):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: print(Q._repr_())
+            sage: print(Q._repr_())                                                         # needs sage.libs.pari
             Quotient with torsion of 3-d lattice N
             by Sublattice <N(1, 8, 0), N(0, 12, 0)>
             sage: Ns = N.submodule([N(1,4,0)])
             sage: Q = N/Ns
-            sage: print(Q._repr_())
+            sage: print(Q._repr_())                                                         # needs sage.libs.pari
             2-d lattice, quotient of 3-d lattice N
             by Sublattice <N(1, 4, 0)>
         """
@@ -1617,9 +1617,9 @@ class ToricLattice_quotient(FGP_Module_class):
 
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
-            sage: Q = N/Ns; Q
+            sage: Q = N/Ns; Q                                                               # needs sage.libs.pari
             Quotient with torsion of 3-d lattice N by Sublattice <N(1, 8, 0), N(0, 12, 0)>
-            sage: Q._module_constructor(N,Ns)
+            sage: Q._module_constructor(N,Ns)                                               # needs sage.libs.pari
             Quotient with torsion of 3-d lattice N by Sublattice <N(1, 8, 0), N(0, 12, 0)>
         """
         return ToricLattice_quotient(V,W,check)
@@ -1668,11 +1668,11 @@ class ToricLattice_quotient(FGP_Module_class):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: Q.is_torsion_free()
+            sage: Q.is_torsion_free()                                                       # needs sage.libs.pari
             False
             sage: Ns = N.submodule([N(1,4,0)])
             sage: Q = N/Ns
-            sage: Q.is_torsion_free()
+            sage: Q.is_torsion_free()                                                       # needs sage.libs.pari
             True
         """
         return sum(self.invariants()) == 0
@@ -1708,13 +1708,13 @@ class ToricLattice_quotient(FGP_Module_class):
             sage: N = ToricLattice(3)
             sage: Ns = N.submodule([N(2,4,0), N(9,12,0)])
             sage: Q = N/Ns
-            sage: Q.ngens()
+            sage: Q.ngens()                                                                 # needs sage.libs.pari
             2
             sage: Q.rank()
             1
             sage: Ns = N.submodule([N(1,4,0)])
             sage: Q = N/Ns
-            sage: Q.ngens()
+            sage: Q.ngens()                                                                 # needs sage.libs.pari
             2
             sage: Q.rank()
             2
@@ -1739,6 +1739,7 @@ class ToricLattice_quotient(FGP_Module_class):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: N = ToricLattice(3)
             sage: Q = N.quotient(N.span([N(1,2,3), N(0,2,1)]), positive_point=N(0,-1,0))
             sage: q = Q.gen(0); q

--- a/src/sage/groups/additive_abelian/additive_abelian_group.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_group.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-modules
+# sage.doctest: needs sage.libs.pari
 r"""
 Additive Abelian Groups
 

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-modules
+# sage.doctest: needs sage.libs.pari
 r"""
 Wrapper class for abelian groups
 

--- a/src/sage/homology/chain_complex.py
+++ b/src/sage/homology/chain_complex.py
@@ -812,7 +812,7 @@ class ChainComplex_class(Parent):
 
             sage: G = AdditiveAbelianGroup([0, 3])
             sage: C = ChainComplex(grading_group=G, degree=G(vector([1,2])))
-            sage: C.grading_group()
+            sage: C.grading_group()                                                     # needs sage.libs.pari
             Additive abelian group isomorphic to Z + Z/3
             sage: C.degree_of_differential()
             (1, 2)
@@ -1202,12 +1202,12 @@ class ChainComplex_class(Parent):
         EXAMPLES::
 
             sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})
-            sage: C.homology()
+            sage: C.homology()                                                          # needs sage.libs.pari
             {0: Z x Z, 1: Z x C3}
-            sage: C.homology(deg=1, base_ring=GF(3))
+            sage: C.homology(deg=1, base_ring=GF(3))                                    # needs sage.libs.pari
             Vector space of dimension 2 over Finite Field of size 3
             sage: D = ChainComplex({0: identity_matrix(ZZ, 4), 4: identity_matrix(ZZ, 30)})
-            sage: D.homology()
+            sage: D.homology()                                                          # needs sage.libs.pari
             {0: 0, 1: 0, 4: 0, 5: 0}
 
         Generators: generators are given as a list of cycles, each of
@@ -1224,7 +1224,7 @@ class ChainComplex_class(Parent):
             sage: d1 = matrix(ZZ, 1,3, [[0,0,0]])
             sage: d2 = matrix(ZZ, 3,2, [[1,1], [1,-1], [-1,1]])
             sage: C_k = ChainComplex({0:d0, 1:d1, 2:d2}, degree=-1)
-            sage: C_k.homology(generators=true)
+            sage: C_k.homology(generators=true)                                         # needs sage.libs.pari
             {0: [(Z, Chain(0:(1)))],
              1: [(C2, Chain(1:(0, 1, -1))), (Z, Chain(1:(0, 1, 0)))],
              2: []}
@@ -1233,7 +1233,7 @@ class ChainComplex_class(Parent):
 
             sage: T = simplicial_complexes.Torus()                                      # needs sage.graphs
             sage: C_t = T.chain_complex()                                               # needs sage.graphs
-            sage: C_t.homology(base_ring=QQ, generators=True)                           # needs sage.graphs
+            sage: C_t.homology(base_ring=QQ, generators=True)                           # needs sage.graphs sage.libs.pari
             {0: [(Vector space of dimension 1 over Rational Field,
                Chain(0:(0, 0, 0, 0, 0, 0, 1)))],
              1: [(Vector space of dimension 1 over Rational Field,
@@ -1271,7 +1271,7 @@ class ChainComplex_class(Parent):
         EXAMPLES::
 
             sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})
-            sage: C.homology(1) == C._homology_in_degree(1, ZZ, False, False, 'auto')
+            sage: C.homology(1) == C._homology_in_degree(1, ZZ, False, False, 'auto')   # needs sage.libs.pari
             True
         """
         if deg not in self.nonzero_degrees():
@@ -1347,9 +1347,9 @@ class ChainComplex_class(Parent):
         EXAMPLES::
 
             sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})
-            sage: C.homology(1)
+            sage: C.homology(1)                                                         # needs sage.libs.pari
             Z x C3
-            sage: C._homology_generators_snf(C.differential(0), C.differential(1), 0)
+            sage: C._homology_generators_snf(C.differential(0), C.differential(1), 0)   # needs sage.libs.pari
             ([3, 0], [(1, 0), (0, 1)])
         """
         # Find the kernel of the out-going differential.
@@ -1460,14 +1460,14 @@ class ChainComplex_class(Parent):
         EXAMPLES::
 
             sage: C = ChainComplex({0: matrix(ZZ, 2, 3, [3, 0, 0, 0, 0, 0])})
-            sage: C.homology()
+            sage: C.homology()                                                          # needs sage.libs.pari
             {0: Z x Z, 1: Z x C3}
             sage: C.torsion_list(11)                                                    # needs sage.rings.finite_rings
             [(3, [1])]
             sage: C = ChainComplex([matrix(ZZ, 1, 1, [2]), matrix(ZZ, 1, 1), matrix(1, 1, [3])])
-            sage: C.homology(1)
+            sage: C.homology(1)                                                         # needs sage.libs.pari
             C2
-            sage: C.homology(3)
+            sage: C.homology(3)                                                         # needs sage.libs.pari
             C3
             sage: C.torsion_list(5)                                                     # needs sage.rings.finite_rings
             [(2, [1]), (3, [3])]
@@ -1766,8 +1766,8 @@ class ChainComplex_class(Parent):
 
             sage: G = AdditiveAbelianGroup([0, 0])
             sage: m = matrix([0])
-            sage: C = ChainComplex(grading_group=G, degree=G(vector([1,2])), data={G.zero(): m})
-            sage: C._latex_()
+            sage: C = ChainComplex(grading_group=G, degree=G(vector([1,2])), data={G.zero(): m})    # needs sage.libs.pari
+            sage: C._latex_()                                                                       # needs sage.libs.pari
             '\\Bold{Z}^{1} \\xrightarrow{d_{\\text{\\texttt{(0,{ }0)}}}} \\Bold{Z}^{1}'
         """
 #         Warning: this is likely to screw up if, for example, the
@@ -1885,6 +1885,7 @@ class ChainComplex_class(Parent):
 
         ::
 
+            sage: # needs sage.libs.pari
             sage: R.<x> = ZZ[]
             sage: G = AdditiveAbelianGroup([0,7])
             sage: d = {G(vector([1,1])):matrix([[x]])}
@@ -2019,6 +2020,7 @@ class ChainComplex_class(Parent):
 
         ::
 
+            sage: # needs sage.libs.pari
             sage: R.<x,y> = ZZ[]
             sage: G = AdditiveAbelianGroup([0,7])
             sage: d1 = {G(vector([1,1])):matrix([[x]])}

--- a/src/sage/homology/matrix_utils.py
+++ b/src/sage/homology/matrix_utils.py
@@ -64,10 +64,10 @@ def dhsw_snf(mat, verbose=False):
 
         sage: from sage.homology.matrix_utils import dhsw_snf
         sage: mat = matrix(ZZ, 3, 4, range(12))
-        sage: dhsw_snf(mat)
+        sage: dhsw_snf(mat)                                                             # needs sage.libs.pari
         [1, 4, 0]
         sage: mat = random_matrix(ZZ, 20, 20, x=-1, y=2)
-        sage: mat.elementary_divisors() == dhsw_snf(mat)
+        sage: mat.elementary_divisors() == dhsw_snf(mat)                                # needs sage.libs.pari
         True
     """
     ring = mat.base_ring()

--- a/src/sage/interfaces/magma.py
+++ b/src/sage/interfaces/magma.py
@@ -1995,6 +1995,7 @@ class MagmaElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.MagmaE
         Relative number field elements can be converted from Magma
         to Sage, but the other direction has not yet been implemented.::
 
+            sage: # needs sage.libs.pari
             sage: P.<y> = L[]
             sage: N.<b> = NumberField(y^2-alpha)
             sage: M = magma(N)                   # optional - magma
@@ -2084,6 +2085,7 @@ class MagmaElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.MagmaE
 
         EXAMPLES::
 
+            sage: # needs sage.rings.finite_rings
             sage: k.<a> = GF(9)
             sage: magma(k).gen(1)         # optional -- magma
             a
@@ -2822,6 +2824,7 @@ class MagmaGBLogPrettyPrinter:
             ...
             Total Faugere F4 time: 0.000, real time: 0.000
 
+            sage: # needs sage.libs.pari
             sage: set_random_seed(1)
             sage: sr = mq.SR(1,1,2,4)
             sage: F,s = sr.polynomial_system()

--- a/src/sage/manifolds/differentiable/manifold.py
+++ b/src/sage/manifolds/differentiable/manifold.py
@@ -597,7 +597,7 @@ class DifferentiableManifold(TopologicalManifold):
         True
         sage: M in Manifolds(RR).Smooth()
         True
-        sage: N in Manifolds(Qp(5)).Smooth()
+        sage: N in Manifolds(Qp(5)).Smooth()                                            # needs sage.rings.padics
         True
 
     The corresponding Sage *elements* are points::

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -1080,13 +1080,13 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: A = matrix(ZZ, 5, 7, [(1 + x^4) % 55 for x in range(5*7)]); A
             [ 1  2 17 27 37 21 32]
             [37 27 17 46 12  2 17]
             [27 26 32 32 37 27  6]
             [ 2 12  2 17 16 37 32]
             [32 37 16 17  2 12  2]
-
             sage: y = vector(ZZ, [1, 2, 3, 4, 5])
             sage: x, = A._solve_right_smith_form(y.column()).columns()
             sage: x.parent()
@@ -1095,7 +1095,6 @@ cdef class Matrix(Matrix1):
             True
             sage: x
             (10, 1530831087980480, -2969971929450215, -178745029498097, 2320752168397186, -806846536262381, -520939892126393)
-
             sage: z = vector(ZZ, [-4, -1, 1, 5, 14, 31, 4])
             sage: x, = A.transpose()._solve_right_smith_form(z.column()).columns()
             sage: x.parent()
@@ -1104,7 +1103,6 @@ cdef class Matrix(Matrix1):
             True
             sage: x
             (-1, 0, 1, 1, -1)
-
             sage: X = A._solve_right_smith_form(identity_matrix(ZZ,5))
             sage: X.parent()
             Full MatrixSpace of 7 by 5 dense matrices over Integer Ring
@@ -5005,7 +5003,7 @@ cdef class Matrix(Matrix1):
             ...
             ValueError: pivot basis only available over a field, not over Integer Ring
             sage: D = copy(A)
-            sage: D.right_kernel(algorithm='pari')
+            sage: D.right_kernel(algorithm='pari')                                      # needs sage.libs.pari
             Free module of degree 7 and rank 2 over Integer Ring
             Echelon basis matrix:
             [  1   5  -8   3  -1  -1  -1]
@@ -8516,6 +8514,7 @@ cdef class Matrix(Matrix1):
         ``include_zero_rows`` is a bit silly, since the
         extended echelon form will never have any zero rows. ::
 
+            sage: # needs sage.libs.pari
             sage: A = matrix(ZZ, [[1,2], [5,0], [5,9]])
             sage: E = A.extended_echelon_form(algorithm='padic', include_zero_rows=False)
             sage: E
@@ -10332,6 +10331,7 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: M = Matrix(ZZ,2,2,[5,2,3,4]); M
             [5 2]
             [3 4]
@@ -10347,10 +10347,10 @@ cdef class Matrix(Matrix1):
             sage: M = Matrix(QQ, 2, 2, [5/3,2/56, 33/13,41/10]); M
             [  5/3  1/28]
             [33/13 41/10]
-            sage: N = M.adjugate(); N                                                   # needs sage.libs.pari
+            sage: N = M.adjugate(); N
             [ 41/10  -1/28]
             [-33/13    5/3]
-            sage: M * N                                                                 # needs sage.libs.pari
+            sage: M * N
             [7363/1092         0]
             [        0 7363/1092]
 
@@ -10403,7 +10403,7 @@ cdef class Matrix(Matrix1):
             sage: A
             [ 1 24]
             [ 3  5]
-            sage: A._adjugate()
+            sage: A._adjugate()                                                         # needs sage.libs.pari
             [  5 -24]
             [ -3   1]
 
@@ -10420,7 +10420,7 @@ cdef class Matrix(Matrix1):
             [       -2*t^2 + t + 3/2       7*t^2 + 1/2*t - 1       -6*t^2 + t - 2/11]
             [-7/3*t^2 - 1/2*t - 1/15         -2*t^2 + 19/8*t     -10*t^2 + 2*t + 1/2]
             [            6*t^2 - 1/2        -1/7*t^2 + 9/4*t       -t^2 - 4*t - 1/10]
-            sage: A._adjugate()
+            sage: A._adjugate()                                                         # needs sage.libs.pari
             [          4/7*t^4 + 1591/56*t^3 - 961/70*t^2 - 109/80*t 55/7*t^4 + 104/7*t^3 + 6123/1540*t^2 - 959/220*t - 1/10       -82*t^4 + 101/4*t^3 + 1035/88*t^2 - 29/22*t - 1/2]
             [   -187/3*t^4 + 13/6*t^3 + 57/10*t^2 - 79/60*t - 77/300            38*t^4 + t^3 - 793/110*t^2 - 28/5*t - 53/220 -6*t^4 + 44/3*t^3 + 4727/330*t^2 - 1147/330*t - 487/660]
             [          37/3*t^4 - 136/7*t^3 - 1777/840*t^2 + 83/80*t      292/7*t^4 + 107/14*t^3 - 323/28*t^2 - 29/8*t + 1/2   61/3*t^4 - 25/12*t^3 - 269/120*t^2 + 743/240*t - 1/15]
@@ -16093,7 +16093,7 @@ cdef class Matrix(Matrix1):
             [1 0]  [6/17    0]  [     1 -47/17]
             [0 1], [  75  -51], [     0      1]
             )
-            sage: m.smith_form(integral=True)
+            sage: m.smith_form(integral=True)                                           # needs sage.libs.pari
             (
             [1/6   0]  [  3  -2]  [ 1  3]
             [  0 1/3], [-25  17], [ 0 -1]
@@ -16267,6 +16267,7 @@ cdef class Matrix(Matrix1):
         In the case of principal ideal domains, it is given by the elementary
         divisors::
 
+            sage: # needs sage.libs.pari
             sage: M = matrix([[2,1,3,5],[4,2,6,6],[0,3,2,0]])
             sage: M
             [2 1 3 5]

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -39,7 +39,7 @@ EXAMPLES::
 TESTS::
 
     sage: a = matrix(ZZ,2,range(4), sparse=False)
-    sage: TestSuite(a).run()
+    sage: TestSuite(a).run()                                                            # needs sage.libs.pari
     sage: Matrix(ZZ,0,0).inverse()
     []
 """
@@ -1228,7 +1228,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: n=20; A = Mat(ZZ,n)(range(n^2))
             sage: A.charpoly()
             x^20 - 3990*x^19 - 266000*x^18
-            sage: A.minpoly()
+            sage: A.minpoly()                                                           # needs sage.libs.pari
             x^3 - 3990*x^2 - 266000*x
 
         On non square matrices, this method raises an ArithmeticError::
@@ -1337,7 +1337,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         EXAMPLES::
 
             sage: A = matrix(ZZ, 6, range(36))
-            sage: A.minpoly()
+            sage: A.minpoly()                                                           # needs sage.libs.pari
             x^3 - 105*x^2 - 630*x
 
             sage: A = Mat(ZZ, 6)([k^2 for k in range(36)])
@@ -1616,7 +1616,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             [ 0  0  0  0  0]
             sage: F == C * E * C.transpose()
             True
-            sage: E.smith_form()[0]
+            sage: E.smith_form()[0]                                                     # needs sage.libs.pari
             [1 0 0 0 0]
             [0 1 0 0 0]
             [0 0 2 0 0]
@@ -2213,13 +2213,14 @@ cdef class Matrix_integer_dense(Matrix_dense):
                sage: M
                [3 0 1]
                [0 1 0]
-               sage: M.elementary_divisors()
+               sage: M.elementary_divisors()                                                # needs sage.libs.pari
                [1, 1]
-               sage: M.transpose().elementary_divisors()
+               sage: M.transpose().elementary_divisors()                                    # needs sage.libs.pari
                [1, 1, 0]
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: matrix(3, range(9)).elementary_divisors()
             [1, 3, 0]
             sage: matrix(3, range(9)).elementary_divisors(algorithm='pari')
@@ -2231,15 +2232,15 @@ cdef class Matrix_integer_dense(Matrix_dense):
         ::
 
             sage: M = matrix(ZZ, 3, [1,5,7, 3,6,9, 0,1,2])
-            sage: M.elementary_divisors()
+            sage: M.elementary_divisors()                                               # needs sage.libs.pari
             [1, 1, 6]
 
         This returns a copy, which is safe to change::
 
-            sage: edivs = M.elementary_divisors()
-            sage: edivs.pop()
+            sage: edivs = M.elementary_divisors()                                       # needs sage.libs.pari
+            sage: edivs.pop()                                                           # needs sage.libs.pari
             6
-            sage: M.elementary_divisors()
+            sage: M.elementary_divisors()                                               # needs sage.libs.pari
             [1, 1, 6]
 
         .. SEEALSO::
@@ -2291,6 +2292,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: A = MatrixSpace(IntegerRing(), 3)(range(9))
             sage: D, U, V = A.smith_form()
             sage: D
@@ -2312,6 +2314,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         It also makes sense for nonsquare matrices::
 
+            sage: # needs sage.libs.pari
             sage: A = Matrix(ZZ,3,2,range(6))
             sage: D, U, V = A.smith_form()
             sage: D
@@ -2332,6 +2335,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Empty matrices are handled sensibly (see :issue:`3068`)::
 
+            sage: # needs sage.libs.pari
             sage: m = MatrixSpace(ZZ, 2,0)(0); d,u,v = m.smith_form(); u*m*v == d
             True
             sage: m = MatrixSpace(ZZ, 0,2)(0); d,u,v = m.smith_form(); u*m*v == d
@@ -2395,6 +2399,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: A = MatrixSpace(ZZ, 3)(range(9))
             sage: A.frobenius_form(0)
             [ 0  0  0]
@@ -2492,7 +2497,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: A*X.transpose() == zero_matrix(ZZ, 4, 2)
             True
 
-            sage: result = A._right_kernel_matrix(algorithm='padic')                        # needs sage.libs.linbox
+            sage: # needs sage.libs.linbox
+            sage: result = A._right_kernel_matrix(algorithm='padic')
             sage: result[0]
             'computed-iml-int'
             sage: X = result[1]; X
@@ -2623,7 +2629,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         EXAMPLES::
 
             sage: m = matrix(ZZ,3,[1..9])
-            sage: m.adjugate()  # indirect doctest
+            sage: m.adjugate()  # indirect doctest                                      # needs sage.libs.pari
             [ -3   6  -3]
             [  6 -12   6]
             [ -3   6  -3]
@@ -3000,8 +3006,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: U * A == R
             True
 
-            sage: R, U = A.LLL(algorithm='pari', transformation=True)
-            sage: U * A == R
+            sage: R, U = A.LLL(algorithm='pari', transformation=True)                   # needs sage.libs.pari
+            sage: U * A == R                                                            # needs sage.libs.pari
             True
 
         Example with a nonzero kernel::
@@ -3015,7 +3021,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             [0 0 0]
             [0 0 0]
 
-            sage: M.LLL(algorithm='pari')[0:2]
+            sage: M.LLL(algorithm='pari')[0:2]                                         # needs sage.libs.pari
             [0 0 0]
             [0 0 0]
 
@@ -3056,8 +3062,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sage: M._cache
             {'rank': 2}
             sage: M._clear_cache()
-            sage: R = M.LLL(algorithm='pari')
-            sage: M._cache
+            sage: R = M.LLL(algorithm='pari')                                           # needs sage.libs.pari
+            sage: M._cache                                                              # needs sage.libs.pari
             {'rank': 2}
 
         Check that :issue:`37236` is fixed::
@@ -5555,6 +5561,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: a = matrix(ZZ,2,2,[1,2,3,4])
             sage: a.__pari__()
             [1, 2; 3, 4]
@@ -5575,7 +5582,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
-            sage: matrix(ZZ,3,[1..9])._rank_pari()
+            sage: matrix(ZZ,3,[1..9])._rank_pari()                                      # needs sage.libs.pari
             2
         """
         from .matrix_integer_pari import _rank_pari
@@ -5600,6 +5607,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: matrix(ZZ,3,[1..9])._hnf_pari()
             [1 2 3]
             [0 3 6]
@@ -5619,6 +5627,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Check that ``include_zero_rows=False`` works correctly::
 
+            sage: # needs sage.libs.pari
             sage: matrix(ZZ,3,[1..9])._hnf_pari(0, include_zero_rows=False)
             [1 2 3]
             [0 3 6]
@@ -5634,7 +5643,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         Check that :issue:`12346` is fixed::
 
-            sage: pari('mathnf(Mat([0,1]), 4)')
+            sage: pari('mathnf(Mat([0,1]), 4)')                                         # needs sage.libs.pari
             [Mat(1), [1, 0; 0, 1]]
         """
         from .matrix_integer_pari import _hnf_pari
@@ -5682,7 +5691,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         EXAMPLES::
 
             sage: B = matrix(ZZ, [[1, 0, 1], [1, -2, -1], [10, 0, 0]])
-            sage: B.p_minimal_polynomials(2)
+            sage: B.p_minimal_polynomials(2)                                            # needs sage.libs.pari
             {2: x^2 + 3*x + 2}
 
         .. SEEALSO::
@@ -5712,6 +5721,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.pari
             sage: B = matrix(ZZ, [[1, 0, 1], [1, -2, -1], [10, 0, 0]])
             sage: B.null_ideal()
             Principal ideal (x^3 + x^2 - 12*x - 20) of
@@ -5751,7 +5761,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         EXAMPLES::
 
             sage: B = matrix(ZZ, [[1, 0, 1], [1, -2, -1], [10, 0, 0]])
-            sage: B.integer_valued_polynomials_generators()
+            sage: B.integer_valued_polynomials_generators()                             # needs sage.libs.pari
             (x^3 + x^2 - 12*x - 20, [1, 1/4*x^2 + 3/4*x + 1/2])
 
         .. SEEALSO::

--- a/src/sage/matrix/matrix_integer_dense_hnf.py
+++ b/src/sage/matrix/matrix_integer_dense_hnf.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 """
 Modular algorithm to compute Hermite normal forms of integer matrices
 

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -777,7 +777,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
             -1/288
 
             sage: m = matrix(QQ, 4, [(-1)**n/n for n in range(1,17)])
-            sage: m.determinant(algorithm='pari')
+            sage: m.determinant(algorithm='pari')                                       # needs sage.libs.pari
             2/70945875
 
             sage: m = matrix(QQ, 5, [1/(i+j+1) for i in range(5) for j in range(5)])
@@ -790,7 +790,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
             Traceback (most recent call last):
             ...
             ValueError: non square matrix
-            sage: matrix(QQ, 2, 3).determinant(algorithm='pari')
+            sage: matrix(QQ, 2, 3).determinant(algorithm='pari')                        # needs sage.libs.pari
             Traceback (most recent call last):
             ...
             ValueError: non square matrix
@@ -1061,9 +1061,9 @@ cdef class Matrix_rational_dense(Matrix_dense):
             sage: f = a.minpoly(); f
             x^3 - 7/12*x^2 - 149/40*x + 97/30
             sage: a = Mat(ZZ,4)(range(16))
-            sage: f = a.minpoly(); f.factor()
+            sage: f = a.minpoly(); f.factor()                                           # needs sage.libs.pari
             x * (x^2 - 30*x - 80)
-            sage: f(a) == 0
+            sage: f(a) == 0                                                             # needs sage.libs.pari
             True
 
         ::
@@ -1286,7 +1286,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
             [1/9 2/9 1/3]
             [4/9 5/9 2/3]
             [7/9 8/9   1]
-            sage: m.adjugate()
+            sage: m.adjugate()                                                          # needs sage.libs.pari
             [-1/27  2/27 -1/27]
             [ 2/27 -4/27  2/27]
             [-1/27  2/27 -1/27]
@@ -1639,7 +1639,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         Check consistency::
 
-            sage: for _ in range(100):
+            sage: for _ in range(100):                                                  # needs sage.libs.linbox
             ....:     nrows = randint(0, 30)
             ....:     ncols = randint(0, 30)
             ....:     m = random_matrix(QQ, nrows, ncols, num_bound=10, den_bound=10)
@@ -2714,7 +2714,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
-            sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9]).__pari__()
+            sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9]).__pari__()                            # needs sage.libs.pari
             [1/5, -2/3; 3/4, 4/9]
         """
         from .matrix_rational_pari import _pari
@@ -2726,11 +2726,11 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
-            sage: matrix(QQ,3,[1..9])._det_pari()
+            sage: matrix(QQ,3,[1..9])._det_pari()                                       # needs sage.libs.pari
             0
-            sage: matrix(QQ,3,[1..9])._det_pari(1)
+            sage: matrix(QQ,3,[1..9])._det_pari(1)                                      # needs sage.libs.pari
             0
-            sage: matrix(QQ,3,[0]+[2..9])._det_pari()
+            sage: matrix(QQ,3,[0]+[2..9])._det_pari()                                   # needs sage.libs.pari
             3
         """
         from .matrix_rational_pari import _det_pari
@@ -2742,9 +2742,9 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
-            sage: matrix(QQ,3,[1..9])._rank_pari()
+            sage: matrix(QQ,3,[1..9])._rank_pari()                                      # needs sage.libs.pari
             2
-            sage: matrix(QQ, 0, 0)._rank_pari()
+            sage: matrix(QQ, 0, 0)._rank_pari()                                         # needs sage.libs.pari
             0
         """
         from .matrix_rational_pari import _rank_pari
@@ -2756,7 +2756,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
-            sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9])._multiply_pari(matrix(QQ,2,[1,2,3,4]))
+            sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9])._multiply_pari(matrix(QQ,2,[1,2,3,4]))    # needs sage.libs.pari
             [  -9/5 -34/15]
             [ 25/12  59/18]
 
@@ -2777,10 +2777,10 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
         EXAMPLES::
 
-            sage: matrix(QQ,2,[1,2,3,4])._invert_pari()
+            sage: matrix(QQ,2,[1,2,3,4])._invert_pari()                                 # needs sage.libs.pari
             [  -2    1]
             [ 3/2 -1/2]
-            sage: matrix(QQ,2,[1,2,2,4])._invert_pari()
+            sage: matrix(QQ,2,[1,2,2,4])._invert_pari()                                 # needs sage.libs.pari
             Traceback (most recent call last):
             ...
             PariError: impossible inverse in ginv: [1, 2; 2, 4]

--- a/src/sage/matrix/symplectic_basis.py
+++ b/src/sage/matrix/symplectic_basis.py
@@ -471,7 +471,7 @@ def symplectic_basis_over_ZZ(M):
         [ 0  0  0  0  0]
         sage: F == C * E * C.transpose()
         True
-        sage: E.smith_form()[0]
+        sage: E.smith_form()[0]                                                         # needs sage.libs.pari
         [1 0 0 0 0]
         [0 1 0 0 0]
         [0 0 2 0 0]

--- a/src/sage/matrix/symplectic_basis.py
+++ b/src/sage/matrix/symplectic_basis.py
@@ -444,7 +444,7 @@ def symplectic_basis_over_ZZ(M):
         [     0      0      0 -20191      0      0      0      0]
         sage: F == C * E * C.transpose()
         True
-        sage: E.smith_form()[0]
+        sage: E.smith_form()[0]                                                         # needs sage.libs.pari
         [    1     0     0     0     0     0     0     0]
         [    0     1     0     0     0     0     0     0]
         [    0     0     1     0     0     0     0     0]

--- a/src/sage/matroids/database_matroids.py
+++ b/src/sage/matroids/database_matroids.py
@@ -1190,7 +1190,7 @@ def Wheel4(groundset='abcdefgh'):
         Wheel(4): Regular matroid of rank 4 on 8 elements with 45 bases
         sage: M.is_valid() and M.is_graphic() and M.dual().is_graphic()
         True
-        sage: M.is_isomorphic(M.dual()) and not M.equals(M.dual())
+        sage: M.is_isomorphic(M.dual()) and not M.equals(M.dual())                      # needs sage.libs.pari
         True
         sage: M.automorphism_group().is_transitive()                                    # needs sage.graphs
         False
@@ -1217,7 +1217,7 @@ def Whirl4(groundset='abcdefgh'):
         Whirl(4): Ternary matroid of rank 4 on 8 elements, type 0+
         sage: M.is_valid()
         True
-        sage: M.is_isomorphic(M.dual()) and not M.equals(M.dual())
+        sage: M.is_isomorphic(M.dual()) and not M.equals(M.dual())                      # needs sage.libs.pari
         True
         sage: M.automorphism_group().is_transitive()                                    # needs sage.graphs
         False

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -5888,7 +5888,7 @@ cdef class RegularMatroid(LinearMatroid):
             sage: from sage.matroids.advanced import *
             sage: M = RegularMatroid(reduced_matrix=Matrix([[-1, 0, 1],
             ....:                                    [-1, 1, 0], [0, 1, -1]]))
-            sage: M._projection()
+            sage: M._projection()                                                       # needs sage.libs.pari
             [ 8 -4  4 -4  0  4]
             [-4  8 -4 -4  4  0]
             [ 4 -4  8  0  4 -4]
@@ -5918,9 +5918,9 @@ cdef class RegularMatroid(LinearMatroid):
             sage: M = matroids.catalog.R10()
             sage: N = matroids.catalog.R10().dual()
             sage: O = matroids.catalog.R12()
-            sage: M._invariant() == N._invariant()
+            sage: M._invariant() == N._invariant()                                      # needs sage.libs.pari
             True
-            sage: M._invariant() == O._invariant()
+            sage: M._invariant() == O._invariant()                                      # needs sage.libs.pari
             False
         """
         from sage.matroids.utilities import cmp_elements_key
@@ -6090,7 +6090,7 @@ cdef class RegularMatroid(LinearMatroid):
             ....:  [0,0,0,1,0,0,1,1,0,0,0,1],
             ....:  [0,0,0,0,1,0,1,0,1,0,0,1],
             ....:  [0,0,0,0,0,1,1,0,0,1,0,1]]))
-            sage: Mnew.is_isomorphic(Nnew)
+            sage: Mnew.is_isomorphic(Nnew)                                              # needs sage.libs.pari
             False
             sage: len(Mnew.circuits()) == len(Nnew.circuits())
             False

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -4067,7 +4067,7 @@ cdef class Matroid(SageObject):
 
             sage: M = matroids.Wheel(4)
             sage: N = M.minor(contractions=[7], deletions=[0])
-            sage: N.is_isomorphic(matroids.Wheel(3))
+            sage: N.is_isomorphic(matroids.Wheel(3))                                    # needs sage.libs.pari
             True
 
         The sets of contractions and deletions need not be independent,

--- a/src/sage/quadratic_forms/binary_qf.py
+++ b/src/sage/quadratic_forms/binary_qf.py
@@ -945,7 +945,14 @@ class BinaryQF(SageObject):
             return self
 
         if algorithm == "default":
-            algorithm = 'sage' if self.is_reducible() else 'pari'
+            algorithm = 'sage'
+            if not self.is_reducible():
+                try:
+                    import sage.libs.pari
+                except ImportError:
+                    pass
+                else:
+                    algorithm = 'pari'
 
         if algorithm == 'sage':
             if self.discriminant() <= 0:

--- a/src/sage/quadratic_forms/quadratic_form__split_local_covering.py
+++ b/src/sage/quadratic_forms/quadratic_form__split_local_covering.py
@@ -285,7 +285,7 @@ def complementary_subform_to_vector(self, v):
     EXAMPLES::
 
         sage: Q1 = DiagonalQuadraticForm(ZZ, [1,3,5,7])
-        sage: Q1.complementary_subform_to_vector([1,0,0,0])
+        sage: Q1.complementary_subform_to_vector([1,0,0,0])                             # needs sage.libs.pari
         Quadratic form in 3 variables over Integer Ring with coefficients:
         [ 7 0 0 ]
         [ * 5 0 ]
@@ -293,7 +293,7 @@ def complementary_subform_to_vector(self, v):
 
     ::
 
-        sage: Q1.complementary_subform_to_vector([1,1,0,0])
+        sage: Q1.complementary_subform_to_vector([1,1,0,0])                             # needs sage.libs.pari
         Quadratic form in 3 variables over Integer Ring with coefficients:
         [ 7 0 0 ]
         [ * 5 0 ]
@@ -301,7 +301,7 @@ def complementary_subform_to_vector(self, v):
 
     ::
 
-        sage: Q1.complementary_subform_to_vector([1,1,1,1])
+        sage: Q1.complementary_subform_to_vector([1,1,1,1])                             # needs sage.libs.pari
         Quadratic form in 3 variables over Integer Ring with coefficients:
         [ 880 -480 -160 ]
         [ * 624 -96 ]

--- a/src/sage/quadratic_forms/quadratic_form__ternary_Tornaria.py
+++ b/src/sage/quadratic_forms/quadratic_form__ternary_Tornaria.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-modules
+# sage.doctest: needs sage.libs.pari
 """
 Tornaria methods for computing with quadratic forms
 """

--- a/src/sage/quadratic_forms/ternary_qf.py
+++ b/src/sage/quadratic_forms/ternary_qf.py
@@ -624,7 +624,7 @@ class TernaryQF(SageObject):
             Ternary quadratic form with integer coefficients:
             [68 68 3]
             [0 0 -68]
-            sage: Q.adjoint().matrix() == 2*Q.matrix().adjoint_classical()
+            sage: Q.adjoint().matrix() == 2*Q.matrix().adjoint_classical()              # needs sage.libs.pari
             True
         """
         A11 = 4*self._b*self._c - self._r**2

--- a/src/sage/rings/number_field/order_ideal.py
+++ b/src/sage/rings/number_field/order_ideal.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 r"""
 Ideals of (Not Necessarily Maximal) Orders in Number Fields
 

--- a/src/sage/rings/polynomial/complex_roots.py
+++ b/src/sage/rings/polynomial/complex_roots.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-flint
+# sage.doctest: needs sage.libs.pari
 """
 Isolate Complex Roots of Polynomials
 

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -4666,7 +4666,7 @@ cdef class Polynomial(CommutativePolynomial):
 
             sage: R.<x> = PolynomialRing(Integers(35))
             sage: f = (x^2 + 2*x + 2) * (x^2 + 3*x + 9)
-            sage: f.factor()
+            sage: f.factor()                                                            # needs sage.libs.pari
             Traceback (most recent call last):
             ...
             NotImplementedError: factorization of polynomials over
@@ -8194,7 +8194,7 @@ cdef class Polynomial(CommutativePolynomial):
 
         An example involving large numbers::
 
-            sage: # needs numpy sage.rings.real_mpfr
+            sage: # needs numpy sage.libs.pari sage.rings.real_mpfr
             sage: x = RR['x'].0
             sage: f = x^2 - 1e100
             sage: f.roots()

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -1712,14 +1712,14 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
 
             sage: R.<x> = PolynomialRing(ZZ)
             sage: f = x^2 + 1
-            sage: f.factor_padic(5, 4)
+            sage: f.factor_padic(5, 4)                                                  # needs sage.rings.padics
             ((1 + O(5^4))*x + 2 + 5 + 2*5^2 + 5^3 + O(5^4))
             * ((1 + O(5^4))*x + 3 + 3*5 + 2*5^2 + 3*5^3 + O(5^4))
 
         A more difficult example::
 
             sage: f = 100 * (5*x + 1)^2 * (x + 5)^2
-            sage: f.factor_padic(5, 10)
+            sage: f.factor_padic(5, 10)                                                 # needs sage.rings.padics
             (4 + O(5^10)) * (5 + O(5^11))^2 * ((1 + O(5^10))*x + 5 + O(5^10))^2
             * ((5 + O(5^10))*x + 1 + O(5^10))^2
         """

--- a/src/sage/stats/distributions/discrete_gaussian_lattice.py
+++ b/src/sage/stats/distributions/discrete_gaussian_lattice.py
@@ -482,14 +482,14 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: c = vector(ZZ, [7, 2, 5])
             sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(ZZ^n, Sigma, c)
             sage: f = D.f
-            sage: nf = D._normalisation_factor_zz(); nf # This has not been properly implemented
+            sage: nf = D._normalisation_factor_zz(); nf # This has not been properly implemented    # needs fpylll
             78.6804...
 
         We can compute the expected number of samples before sampling a vector::
 
             sage: v = vector(ZZ, n, (11, 4, 8))
             sage: v.set_immutable()
-            sage: 1 / (f(v) / nf)
+            sage: 1 / (f(v) / nf)                                                                   # needs fpylll
             2553.9461...
 
             sage: counter = defaultdict(Integer); m = 0
@@ -497,7 +497,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             ....:     add_samples(1000)
             sage: sum(counter.values())  # random
             3000
-            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:                     # needs sage.symbolic
+            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:                     # needs fpylll sage.symbolic
             ....:     add_samples(1000)
 
         If the covariance provided is not positive definite, an error is thrown::

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -3367,7 +3367,7 @@ cdef class Expression(Expression_abc):
 
         Comparisons of infinities::
 
-            sage: assert( (1+I)*oo == (2+2*I)*oo )
+            sage: assert( (1+I)*oo == (2+2*I)*oo )                                      # needs sage.libs.pari
             sage: assert( SR(unsigned_infinity) == SR(unsigned_infinity) )
             sage: assert( SR(I*oo) == I*oo )
             sage: assert( SR(-oo) <= SR(oo) )
@@ -3589,7 +3589,7 @@ cdef class Expression(Expression_abc):
             sage: m1 = 382247666339265723780973363167714496025733124557617743
             sage: (m == m1).test_relation(domain=QQbar)                                 # needs sage.rings.number_field
             False
-            sage: (m == m1).test_relation()
+            sage: (m == m1).test_relation()                                             # needs sage.libs.pari
             False
 
         Try the examples from :issue:`31424` and :issue:`31665`::


### PR DESCRIPTION
- **pkgs/sagemath-maxima: Add sage-conf, sagemath-environment dependencies**
- **src/sage/quadratic_forms/binary_qf.py: Fall back to 'sage' when pari is not available**
- **src/sage/interfaces/magma.py: Add # needs**
- **src/sage/homology/matrix_utils.py: Add # needs**
- **src/sage/manifolds/differentiable/manifold.py: Add # needs**
- **src/sage/matrix: Add # needs**
- **src/sage/matroids: Add # needs**
- **src/sage/rings: Add # needs**
- **src/sage/symbolic/expression.pyx: Add # needs**
- **src/sage/stats/distributions/discrete_gaussian_lattice.py: Add # needs**
- **src/sage/quadratic_forms: Add # needs**
- **src/sage/algebras/clifford_algebra.py: Add # needs**
- **src/sage/calculus/calculus.py: Add # needs**
- **src/sage/categories/chain_complexes.py: Add # needs**
- **src/sage/matrix: Add # needs**
- **src/sage/homology/chain_complex.py: Add # needs**
- **src/sage/groups/additive_abelian: Add # needs**
- **src/sage/geometry/toric_lattice.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-symbolics' --update-known-test-failures**
