### PR TITLE
pkgs/sagemath-gap: Remove pari deps, set up testing, add some modules

### DIFF
--- a/pkgs/sagemath-gap/MANIFEST.in
+++ b/pkgs/sagemath-gap/MANIFEST.in
@@ -26,6 +26,7 @@ recursive-include sage/groups/semimonomial_transformations *.pxd        # FIXME
 include           sage/interfaces/gap*.p*
 graft             sage/libs/gap
 include           sage/matrix/matrix_gap.p*
+include           sage/rings/species.p*
 include           sage/rings/universal_cyclotomic_field.p*
 
 include           sage/geometry/ribbon_graph.p*

--- a/pkgs/sagemath-gap/MANIFEST.in
+++ b/pkgs/sagemath-gap/MANIFEST.in
@@ -14,6 +14,8 @@ include           sage/groups/*gap*.p*
 include           sage/groups/abelian_gps/abelian_group_gap.p*
 include           sage/groups/abelian_gps/abelian_aut.p*
 include           sage/groups/abelian_gps/abelian_group_morphism.p*
+include           sage/groups/class_function.p*
+include           sage/groups/conjugacy_classes.p*
 include           sage/groups/galois_group_perm.p*
 include           sage/groups/matrix_gps/*_gap.*
 include           sage/groups/matrix_gps/heisenberg.p*

--- a/pkgs/sagemath-gap/known-test-failures.json
+++ b/pkgs/sagemath-gap/known-test-failures.json
@@ -1,0 +1,2298 @@
+{
+    "sage.all__sagemath_gap": {
+        "failed": true,
+        "ntests": 2
+    },
+    "sage.arith.functions": {
+        "failed": true,
+        "ntests": 42
+    },
+    "sage.arith.misc": {
+        "failed": true,
+        "ntests": 920
+    },
+    "sage.arith.numerical_approx": {
+        "ntests": 1
+    },
+    "sage.arith.power": {
+        "ntests": 16
+    },
+    "sage.arith.rational_reconstruction": {
+        "ntests": 1
+    },
+    "sage.arith.srange": {
+        "ntests": 72
+    },
+    "sage.calculus.functional": {
+        "ntests": 3
+    },
+    "sage.categories.action": {
+        "ntests": 78
+    },
+    "sage.categories.additive_groups": {
+        "ntests": 9
+    },
+    "sage.categories.additive_magmas": {
+        "failed": true,
+        "ntests": 137
+    },
+    "sage.categories.additive_monoids": {
+        "ntests": 16
+    },
+    "sage.categories.additive_semigroups": {
+        "ntests": 28
+    },
+    "sage.categories.affine_weyl_groups": {
+        "ntests": 15
+    },
+    "sage.categories.algebra_functor": {
+        "ntests": 7
+    },
+    "sage.categories.algebra_ideals": {
+        "ntests": 8
+    },
+    "sage.categories.algebra_modules": {
+        "ntests": 9
+    },
+    "sage.categories.algebras": {
+        "ntests": 25
+    },
+    "sage.categories.algebras_with_basis": {
+        "ntests": 16
+    },
+    "sage.categories.aperiodic_semigroups": {
+        "ntests": 1
+    },
+    "sage.categories.associative_algebras": {
+        "ntests": 5
+    },
+    "sage.categories.bialgebras": {
+        "ntests": 4
+    },
+    "sage.categories.bialgebras_with_basis": {
+        "ntests": 24
+    },
+    "sage.categories.bimodules": {
+        "ntests": 15
+    },
+    "sage.categories.cartesian_product": {
+        "ntests": 42
+    },
+    "sage.categories.category": {
+        "failed": true,
+        "ntests": 433
+    },
+    "sage.categories.category_cy_helper": {
+        "ntests": 27
+    },
+    "sage.categories.category_singleton": {
+        "ntests": 59
+    },
+    "sage.categories.category_types": {
+        "ntests": 83
+    },
+    "sage.categories.category_with_axiom": {
+        "ntests": 328
+    },
+    "sage.categories.chain_complexes": {
+        "ntests": 22
+    },
+    "sage.categories.classical_crystals": {
+        "ntests": 4
+    },
+    "sage.categories.coalgebras": {
+        "ntests": 1
+    },
+    "sage.categories.coalgebras_with_basis": {
+        "ntests": 20
+    },
+    "sage.categories.coercion_methods": {
+        "ntests": 6
+    },
+    "sage.categories.commutative_additive_groups": {
+        "ntests": 17
+    },
+    "sage.categories.commutative_additive_monoids": {
+        "ntests": 5
+    },
+    "sage.categories.commutative_additive_semigroups": {
+        "ntests": 6
+    },
+    "sage.categories.commutative_algebra_ideals": {
+        "ntests": 9
+    },
+    "sage.categories.commutative_algebras": {
+        "ntests": 11
+    },
+    "sage.categories.commutative_ring_ideals": {
+        "ntests": 7
+    },
+    "sage.categories.commutative_rings": {
+        "ntests": 80
+    },
+    "sage.categories.complete_discrete_valuation": {
+        "ntests": 30
+    },
+    "sage.categories.complex_reflection_groups": {
+        "ntests": 16
+    },
+    "sage.categories.complex_reflection_or_generalized_coxeter_groups": {
+        "failed": true,
+        "ntests": 119
+    },
+    "sage.categories.covariant_functorial_construction": {
+        "failed": true,
+        "ntests": 65
+    },
+    "sage.categories.coxeter_group_algebras": {
+        "ntests": 2
+    },
+    "sage.categories.coxeter_groups": {
+        "failed": true,
+        "ntests": 368
+    },
+    "sage.categories.crystals": {
+        "ntests": 3
+    },
+    "sage.categories.cw_complexes": {
+        "ntests": 36
+    },
+    "sage.categories.dedekind_domains": {
+        "ntests": 30
+    },
+    "sage.categories.discrete_valuation": {
+        "ntests": 28
+    },
+    "sage.categories.distributive_magmas_and_additive_magmas": {
+        "ntests": 13
+    },
+    "sage.categories.division_rings": {
+        "ntests": 11
+    },
+    "sage.categories.domains": {
+        "ntests": 7
+    },
+    "sage.categories.dual": {
+        "ntests": 1
+    },
+    "sage.categories.enumerated_sets": {
+        "ntests": 132
+    },
+    "sage.categories.euclidean_domains": {
+        "ntests": 22
+    },
+    "sage.categories.examples.algebras_with_basis": {
+        "ntests": 8
+    },
+    "sage.categories.examples.commutative_additive_monoids": {
+        "ntests": 14
+    },
+    "sage.categories.examples.commutative_additive_semigroups": {
+        "ntests": 28
+    },
+    "sage.categories.examples.cw_complexes": {
+        "ntests": 33
+    },
+    "sage.categories.examples.facade_sets": {
+        "ntests": 21
+    },
+    "sage.categories.examples.filtered_algebras_with_basis": {
+        "failed": true,
+        "ntests": 25
+    },
+    "sage.categories.examples.filtered_modules_with_basis": {
+        "ntests": 12
+    },
+    "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
+        "ntests": 1
+    },
+    "sage.categories.examples.finite_enumerated_sets": {
+        "ntests": 29
+    },
+    "sage.categories.examples.finite_monoids": {
+        "ntests": 15
+    },
+    "sage.categories.examples.finite_semigroups": {
+        "ntests": 27
+    },
+    "sage.categories.examples.finite_weyl_groups": {
+        "ntests": 25
+    },
+    "sage.categories.examples.graded_modules_with_basis": {
+        "ntests": 14
+    },
+    "sage.categories.examples.graphs": {
+        "ntests": 24
+    },
+    "sage.categories.examples.infinite_enumerated_sets": {
+        "ntests": 35
+    },
+    "sage.categories.examples.lie_algebras": {
+        "ntests": 25
+    },
+    "sage.categories.examples.magmas": {
+        "ntests": 20
+    },
+    "sage.categories.examples.manifolds": {
+        "ntests": 15
+    },
+    "sage.categories.examples.monoids": {
+        "ntests": 16
+    },
+    "sage.categories.examples.posets": {
+        "ntests": 29
+    },
+    "sage.categories.examples.semigroups": {
+        "ntests": 83
+    },
+    "sage.categories.examples.semigroups_cython": {
+        "ntests": 47
+    },
+    "sage.categories.examples.sets_with_grading": {
+        "ntests": 14
+    },
+    "sage.categories.facade_sets": {
+        "ntests": 27
+    },
+    "sage.categories.fields": {
+        "ntests": 105
+    },
+    "sage.categories.filtered_algebras": {
+        "ntests": 5
+    },
+    "sage.categories.filtered_algebras_with_basis": {
+        "failed": true,
+        "ntests": 29
+    },
+    "sage.categories.filtered_hopf_algebras_with_basis": {
+        "ntests": 12
+    },
+    "sage.categories.filtered_modules": {
+        "ntests": 18
+    },
+    "sage.categories.filtered_modules_with_basis": {
+        "failed": true,
+        "ntests": 68
+    },
+    "sage.categories.finite_complex_reflection_groups": {
+        "ntests": 172
+    },
+    "sage.categories.finite_coxeter_groups": {
+        "ntests": 10
+    },
+    "sage.categories.finite_dimensional_algebras_with_basis": {
+        "ntests": 69
+    },
+    "sage.categories.finite_dimensional_bialgebras_with_basis": {
+        "ntests": 4
+    },
+    "sage.categories.finite_dimensional_coalgebras_with_basis": {
+        "ntests": 4
+    },
+    "sage.categories.finite_dimensional_graded_lie_algebras_with_basis": {
+        "ntests": 22
+    },
+    "sage.categories.finite_dimensional_hopf_algebras_with_basis": {
+        "ntests": 3
+    },
+    "sage.categories.finite_dimensional_lie_algebras_with_basis": {
+        "ntests": 34
+    },
+    "sage.categories.finite_dimensional_modules_with_basis": {
+        "ntests": 60
+    },
+    "sage.categories.finite_dimensional_nilpotent_lie_algebras_with_basis": {
+        "ntests": 19
+    },
+    "sage.categories.finite_dimensional_semisimple_algebras_with_basis": {
+        "ntests": 11
+    },
+    "sage.categories.finite_enumerated_sets": {
+        "ntests": 123
+    },
+    "sage.categories.finite_fields": {
+        "ntests": 14
+    },
+    "sage.categories.finite_groups": {
+        "failed": true,
+        "ntests": 39
+    },
+    "sage.categories.finite_lattice_posets": {
+        "ntests": 31
+    },
+    "sage.categories.finite_monoids": {
+        "ntests": 28
+    },
+    "sage.categories.finite_permutation_groups": {
+        "ntests": 32
+    },
+    "sage.categories.finite_posets": {
+        "ntests": 19
+    },
+    "sage.categories.finite_semigroups": {
+        "ntests": 14
+    },
+    "sage.categories.finite_sets": {
+        "ntests": 14
+    },
+    "sage.categories.finite_weyl_groups": {
+        "ntests": 6
+    },
+    "sage.categories.finitely_generated_lambda_bracket_algebras": {
+        "ntests": 11
+    },
+    "sage.categories.finitely_generated_lie_conformal_algebras": {
+        "ntests": 10
+    },
+    "sage.categories.finitely_generated_magmas": {
+        "ntests": 6
+    },
+    "sage.categories.finitely_generated_semigroups": {
+        "ntests": 27
+    },
+    "sage.categories.function_fields": {
+        "ntests": 11
+    },
+    "sage.categories.functor": {
+        "ntests": 128
+    },
+    "sage.categories.g_sets": {
+        "ntests": 7
+    },
+    "sage.categories.gcd_domains": {
+        "ntests": 5
+    },
+    "sage.categories.generalized_coxeter_groups": {
+        "ntests": 12
+    },
+    "sage.categories.graded_algebras": {
+        "ntests": 8
+    },
+    "sage.categories.graded_algebras_with_basis": {
+        "ntests": 8
+    },
+    "sage.categories.graded_bialgebras": {
+        "ntests": 3
+    },
+    "sage.categories.graded_bialgebras_with_basis": {
+        "ntests": 3
+    },
+    "sage.categories.graded_coalgebras": {
+        "ntests": 6
+    },
+    "sage.categories.graded_coalgebras_with_basis": {
+        "ntests": 6
+    },
+    "sage.categories.graded_hopf_algebras": {
+        "ntests": 3
+    },
+    "sage.categories.graded_hopf_algebras_with_basis": {
+        "ntests": 12
+    },
+    "sage.categories.graded_lie_algebras": {
+        "ntests": 12
+    },
+    "sage.categories.graded_lie_algebras_with_basis": {
+        "ntests": 5
+    },
+    "sage.categories.graded_lie_conformal_algebras": {
+        "ntests": 5
+    },
+    "sage.categories.graded_modules": {
+        "ntests": 16
+    },
+    "sage.categories.graded_modules_with_basis": {
+        "ntests": 25
+    },
+    "sage.categories.graphs": {
+        "ntests": 25
+    },
+    "sage.categories.group_algebras": {
+        "ntests": 30
+    },
+    "sage.categories.groupoid": {
+        "ntests": 9
+    },
+    "sage.categories.groups": {
+        "failed": true,
+        "ntests": 56
+    },
+    "sage.categories.h_trivial_semigroups": {
+        "ntests": 4
+    },
+    "sage.categories.hecke_modules": {
+        "ntests": 16
+    },
+    "sage.categories.homset": {
+        "ntests": 217
+    },
+    "sage.categories.homsets": {
+        "ntests": 56
+    },
+    "sage.categories.hopf_algebras": {
+        "failed": true,
+        "ntests": 19
+    },
+    "sage.categories.hopf_algebras_with_basis": {
+        "failed": true,
+        "ntests": 43
+    },
+    "sage.categories.infinite_enumerated_sets": {
+        "ntests": 13
+    },
+    "sage.categories.integral_domains": {
+        "ntests": 34
+    },
+    "sage.categories.isomorphic_objects": {
+        "ntests": 2
+    },
+    "sage.categories.j_trivial_semigroups": {
+        "ntests": 1
+    },
+    "sage.categories.kac_moody_algebras": {
+        "ntests": 9
+    },
+    "sage.categories.l_trivial_semigroups": {
+        "ntests": 5
+    },
+    "sage.categories.lambda_bracket_algebras": {
+        "ntests": 16
+    },
+    "sage.categories.lambda_bracket_algebras_with_basis": {
+        "ntests": 5
+    },
+    "sage.categories.lattice_posets": {
+        "ntests": 10
+    },
+    "sage.categories.left_modules": {
+        "ntests": 4
+    },
+    "sage.categories.lie_algebras": {
+        "ntests": 110
+    },
+    "sage.categories.lie_algebras_with_basis": {
+        "ntests": 19
+    },
+    "sage.categories.lie_conformal_algebras": {
+        "ntests": 25
+    },
+    "sage.categories.lie_conformal_algebras_with_basis": {
+        "ntests": 17
+    },
+    "sage.categories.lie_groups": {
+        "ntests": 9
+    },
+    "sage.categories.loop_crystals": {
+        "ntests": 1
+    },
+    "sage.categories.magmas": {
+        "failed": true,
+        "ntests": 147
+    },
+    "sage.categories.magmas_and_additive_magmas": {
+        "ntests": 21
+    },
+    "sage.categories.magmatic_algebras": {
+        "ntests": 27
+    },
+    "sage.categories.manifolds": {
+        "ntests": 52
+    },
+    "sage.categories.map": {
+        "ntests": 353
+    },
+    "sage.categories.matrix_algebras": {
+        "ntests": 3
+    },
+    "sage.categories.metric_spaces": {
+        "ntests": 46
+    },
+    "sage.categories.modular_abelian_varieties": {
+        "ntests": 8
+    },
+    "sage.categories.modules": {
+        "ntests": 120
+    },
+    "sage.categories.modules_with_basis": {
+        "ntests": 271
+    },
+    "sage.categories.monoid_algebras": {
+        "ntests": 4
+    },
+    "sage.categories.monoids": {
+        "failed": true,
+        "ntests": 86
+    },
+    "sage.categories.morphism": {
+        "ntests": 132
+    },
+    "sage.categories.noetherian_rings": {
+        "ntests": 19
+    },
+    "sage.categories.number_fields": {
+        "ntests": 41
+    },
+    "sage.categories.objects": {
+        "ntests": 12
+    },
+    "sage.categories.partially_ordered_monoids": {
+        "ntests": 4
+    },
+    "sage.categories.permutation_groups": {
+        "ntests": 6
+    },
+    "sage.categories.pointed_sets": {
+        "ntests": 3
+    },
+    "sage.categories.polyhedra": {
+        "ntests": 4
+    },
+    "sage.categories.poor_man_map": {
+        "ntests": 59
+    },
+    "sage.categories.posets": {
+        "ntests": 2
+    },
+    "sage.categories.primer": {
+        "ntests": 165
+    },
+    "sage.categories.principal_ideal_domains": {
+        "failed": true,
+        "ntests": 29
+    },
+    "sage.categories.pushout": {
+        "ntests": 624
+    },
+    "sage.categories.quantum_group_representations": {
+        "ntests": 13
+    },
+    "sage.categories.quotient_fields": {
+        "ntests": 77
+    },
+    "sage.categories.quotients": {
+        "ntests": 2
+    },
+    "sage.categories.r_trivial_semigroups": {
+        "ntests": 3
+    },
+    "sage.categories.realizations": {
+        "ntests": 21
+    },
+    "sage.categories.regular_crystals": {
+        "ntests": 3
+    },
+    "sage.categories.right_modules": {
+        "ntests": 4
+    },
+    "sage.categories.ring_ideals": {
+        "ntests": 9
+    },
+    "sage.categories.rings": {
+        "ntests": 211
+    },
+    "sage.categories.rngs": {
+        "ntests": 6
+    },
+    "sage.categories.schemes": {
+        "ntests": 39
+    },
+    "sage.categories.semigroups": {
+        "failed": true,
+        "ntests": 125
+    },
+    "sage.categories.semirings": {
+        "ntests": 6
+    },
+    "sage.categories.semisimple_algebras": {
+        "failed": true,
+        "ntests": 15
+    },
+    "sage.categories.sets_cat": {
+        "ntests": 412
+    },
+    "sage.categories.sets_with_grading": {
+        "ntests": 23
+    },
+    "sage.categories.sets_with_partial_maps": {
+        "ntests": 4
+    },
+    "sage.categories.shephard_groups": {
+        "ntests": 5
+    },
+    "sage.categories.signed_tensor": {
+        "ntests": 10
+    },
+    "sage.categories.simplicial_complexes": {
+        "ntests": 17
+    },
+    "sage.categories.simplicial_sets": {
+        "ntests": 51
+    },
+    "sage.categories.subobjects": {
+        "ntests": 2
+    },
+    "sage.categories.super_algebras": {
+        "ntests": 8
+    },
+    "sage.categories.super_algebras_with_basis": {
+        "failed": true,
+        "ntests": 10
+    },
+    "sage.categories.super_hopf_algebras_with_basis": {
+        "ntests": 10
+    },
+    "sage.categories.super_lie_conformal_algebras": {
+        "ntests": 20
+    },
+    "sage.categories.super_modules": {
+        "ntests": 18
+    },
+    "sage.categories.super_modules_with_basis": {
+        "ntests": 10
+    },
+    "sage.categories.supercommutative_algebras": {
+        "ntests": 8
+    },
+    "sage.categories.tensor": {
+        "ntests": 9
+    },
+    "sage.categories.topological_spaces": {
+        "ntests": 27
+    },
+    "sage.categories.triangular_kac_moody_algebras": {
+        "ntests": 12
+    },
+    "sage.categories.tutorial": {
+        "ntests": 4
+    },
+    "sage.categories.unique_factorization_domains": {
+        "ntests": 39
+    },
+    "sage.categories.unital_algebras": {
+        "ntests": 30
+    },
+    "sage.categories.vector_spaces": {
+        "ntests": 44
+    },
+    "sage.categories.with_realizations": {
+        "ntests": 24
+    },
+    "sage.combinat.backtrack": {
+        "ntests": 28
+    },
+    "sage.combinat.combinat": {
+        "ntests": 236
+    },
+    "sage.combinat.combinat_cython": {
+        "ntests": 22
+    },
+    "sage.combinat.combination": {
+        "ntests": 97
+    },
+    "sage.combinat.combinatorial_map": {
+        "ntests": 75
+    },
+    "sage.combinat.composition": {
+        "ntests": 287
+    },
+    "sage.combinat.dlx": {
+        "ntests": 61
+    },
+    "sage.combinat.integer_lists.base": {
+        "ntests": 116
+    },
+    "sage.combinat.integer_lists.invlex": {
+        "ntests": 304
+    },
+    "sage.combinat.integer_lists.lists": {
+        "ntests": 56
+    },
+    "sage.combinat.integer_lists.nn": {
+        "ntests": 5
+    },
+    "sage.combinat.integer_vector": {
+        "ntests": 254
+    },
+    "sage.combinat.integer_vector_weighted": {
+        "ntests": 45
+    },
+    "sage.combinat.matrices.dancing_links": {
+        "ntests": 250
+    },
+    "sage.combinat.matrices.dlxcpp": {
+        "ntests": 9
+    },
+    "sage.combinat.partition": {
+        "ntests": 1200
+    },
+    "sage.combinat.partitions": {
+        "ntests": 69
+    },
+    "sage.combinat.permutation": {
+        "ntests": 1197
+    },
+    "sage.combinat.permutation_cython": {
+        "ntests": 39
+    },
+    "sage.combinat.q_analogues": {
+        "failed": true,
+        "ntests": 113
+    },
+    "sage.combinat.ranker": {
+        "ntests": 48
+    },
+    "sage.combinat.root_system.reflection_group_c": {
+        "ntests": 10
+    },
+    "sage.combinat.root_system.reflection_group_element": {
+        "ntests": 84
+    },
+    "sage.combinat.root_system.weyl_group": {
+        "ntests": 1
+    },
+    "sage.combinat.subset": {
+        "ntests": 281
+    },
+    "sage.combinat.subsets_hereditary": {
+        "ntests": 7
+    },
+    "sage.combinat.subsets_pairwise": {
+        "ntests": 32
+    },
+    "sage.combinat.tools": {
+        "ntests": 2
+    },
+    "sage.combinat.tuple": {
+        "ntests": 33
+    },
+    "sage.cpython.atexit": {
+        "ntests": 19
+    },
+    "sage.cpython.cython_metaclass": {
+        "ntests": 4
+    },
+    "sage.cpython.debug": {
+        "ntests": 13
+    },
+    "sage.cpython.dict_del_by_value": {
+        "ntests": 21
+    },
+    "sage.cpython.getattr": {
+        "ntests": 65
+    },
+    "sage.cpython.string": {
+        "ntests": 1
+    },
+    "sage.cpython.string.pxd": {
+        "ntests": 8
+    },
+    "sage.cpython.type": {
+        "ntests": 7
+    },
+    "sage.cpython.wrapperdescr": {
+        "ntests": 13
+    },
+    "sage.data_structures.bitset": {
+        "ntests": 425
+    },
+    "sage.data_structures.blas_dict": {
+        "ntests": 61
+    },
+    "sage.data_structures.list_of_pairs": {
+        "ntests": 14
+    },
+    "sage.data_structures.mutable_poset": {
+        "ntests": 441
+    },
+    "sage.data_structures.pairing_heap": {
+        "ntests": 284
+    },
+    "sage.databases.sql_db": {
+        "ntests": 230
+    },
+    "sage.doctest.check_tolerance": {
+        "ntests": 9
+    },
+    "sage.doctest.control": {
+        "ntests": 3
+    },
+    "sage.doctest.external": {
+        "ntests": 42
+    },
+    "sage.doctest.fixtures": {
+        "ntests": 59
+    },
+    "sage.doctest.forker": {
+        "ntests": 254
+    },
+    "sage.doctest.marked_output": {
+        "failed": true,
+        "ntests": 21
+    },
+    "sage.doctest.parsing": {
+        "ntests": 233
+    },
+    "sage.doctest.reporting": {
+        "ntests": 126
+    },
+    "sage.doctest.rif_tol": {
+        "ntests": 3
+    },
+    "sage.doctest.sources": {
+        "ntests": 343
+    },
+    "sage.doctest.test": {
+        "ntests": 23
+    },
+    "sage.doctest.util": {
+        "ntests": 166
+    },
+    "sage.env": {
+        "ntests": 40
+    },
+    "sage.ext.fast_callable": {
+        "failed": true,
+        "ntests": 317
+    },
+    "sage.ext.fast_eval": {
+        "ntests": 4
+    },
+    "sage.features": {
+        "ntests": 146
+    },
+    "sage.features.all": {
+        "ntests": 14
+    },
+    "sage.features.bliss": {
+        "ntests": 8
+    },
+    "sage.features.cddlib": {
+        "ntests": 4
+    },
+    "sage.features.coxeter3": {
+        "ntests": 4
+    },
+    "sage.features.csdp": {
+        "ntests": 6
+    },
+    "sage.features.cython": {
+        "ntests": 3
+    },
+    "sage.features.databases": {
+        "ntests": 38
+    },
+    "sage.features.dot2tex": {
+        "ntests": 4
+    },
+    "sage.features.dvipng": {
+        "ntests": 4
+    },
+    "sage.features.eclib": {
+        "ntests": 4
+    },
+    "sage.features.ecm": {
+        "ntests": 4
+    },
+    "sage.features.ffmpeg": {
+        "ntests": 4
+    },
+    "sage.features.four_ti_2": {
+        "ntests": 6
+    },
+    "sage.features.fricas": {
+        "ntests": 6
+    },
+    "sage.features.frobby": {
+        "ntests": 4
+    },
+    "sage.features.gap": {
+        "ntests": 6
+    },
+    "sage.features.gfan": {
+        "ntests": 2
+    },
+    "sage.features.giac": {
+        "ntests": 4
+    },
+    "sage.features.graph_generators": {
+        "ntests": 18
+    },
+    "sage.features.graphviz": {
+        "ntests": 16
+    },
+    "sage.features.igraph": {
+        "ntests": 4
+    },
+    "sage.features.imagemagick": {
+        "ntests": 10
+    },
+    "sage.features.info": {
+        "ntests": 4
+    },
+    "sage.features.interfaces": {
+        "ntests": 34
+    },
+    "sage.features.internet": {
+        "ntests": 5
+    },
+    "sage.features.jmol": {
+        "ntests": 4
+    },
+    "sage.features.join_feature": {
+        "ntests": 23
+    },
+    "sage.features.kenzo": {
+        "ntests": 6
+    },
+    "sage.features.latex": {
+        "ntests": 30
+    },
+    "sage.features.latte": {
+        "ntests": 8
+    },
+    "sage.features.lrs": {
+        "ntests": 16
+    },
+    "sage.features.macaulay2": {
+        "ntests": 3
+    },
+    "sage.features.mcqd": {
+        "ntests": 4
+    },
+    "sage.features.meataxe": {
+        "ntests": 4
+    },
+    "sage.features.mip_backends": {
+        "ntests": 9
+    },
+    "sage.features.msolve": {
+        "ntests": 6
+    },
+    "sage.features.nauty": {
+        "ntests": 8
+    },
+    "sage.features.normaliz": {
+        "ntests": 4
+    },
+    "sage.features.palp": {
+        "ntests": 4
+    },
+    "sage.features.pandoc": {
+        "ntests": 4
+    },
+    "sage.features.pari": {
+        "ntests": 4
+    },
+    "sage.features.pdf2svg": {
+        "ntests": 4
+    },
+    "sage.features.phitigra": {
+        "ntests": 4
+    },
+    "sage.features.pkg_systems": {
+        "ntests": 25
+    },
+    "sage.features.polymake": {
+        "ntests": 4
+    },
+    "sage.features.poppler": {
+        "ntests": 4
+    },
+    "sage.features.qepcad": {
+        "ntests": 4
+    },
+    "sage.features.rubiks": {
+        "ntests": 28
+    },
+    "sage.features.sagemath": {
+        "ntests": 177
+    },
+    "sage.features.sat": {
+        "ntests": 16
+    },
+    "sage.features.singular": {
+        "ntests": 4
+    },
+    "sage.features.sirocco": {
+        "ntests": 4
+    },
+    "sage.features.sloane_database": {
+        "ntests": 6
+    },
+    "sage.features.sphinx": {
+        "ntests": 8
+    },
+    "sage.features.symengine_py": {
+        "ntests": 4
+    },
+    "sage.features.sympow": {
+        "ntests": 4
+    },
+    "sage.features.tdlib": {
+        "ntests": 2
+    },
+    "sage.features.threejs": {
+        "ntests": 7
+    },
+    "sage.features.topcom": {
+        "ntests": 8
+    },
+    "sage.functions.airy": {
+        "ntests": 101
+    },
+    "sage.functions.bessel": {
+        "ntests": 160
+    },
+    "sage.functions.error": {
+        "ntests": 94
+    },
+    "sage.functions.exp_integral": {
+        "ntests": 156
+    },
+    "sage.functions.gamma": {
+        "ntests": 140
+    },
+    "sage.functions.generalized": {
+        "ntests": 70
+    },
+    "sage.functions.hyperbolic": {
+        "ntests": 81
+    },
+    "sage.functions.hypergeometric": {
+        "ntests": 79
+    },
+    "sage.functions.jacobi": {
+        "ntests": 38
+    },
+    "sage.functions.log": {
+        "ntests": 153
+    },
+    "sage.functions.min_max": {
+        "ntests": 21
+    },
+    "sage.functions.orthogonal_polys": {
+        "ntests": 230
+    },
+    "sage.functions.other": {
+        "failed": true,
+        "ntests": 239
+    },
+    "sage.functions.piecewise": {
+        "ntests": 6
+    },
+    "sage.functions.prime_pi": {
+        "ntests": 4
+    },
+    "sage.functions.special": {
+        "ntests": 121
+    },
+    "sage.functions.spike_function": {
+        "ntests": 32
+    },
+    "sage.functions.transcendental": {
+        "ntests": 55
+    },
+    "sage.functions.trig": {
+        "ntests": 126
+    },
+    "sage.functions.wigner": {
+        "ntests": 24
+    },
+    "sage.geometry.abc": {
+        "ntests": 15
+    },
+    "sage.geometry.ribbon_graph": {
+        "ntests": 224
+    },
+    "sage.groups.conjugacy_classes": {
+        "ntests": 2
+    },
+    "sage.groups.galois_group_perm": {
+        "ntests": 21
+    },
+    "sage.groups.generic": {
+        "ntests": 113
+    },
+    "sage.groups.group": {
+        "failed": true,
+        "ntests": 55
+    },
+    "sage.groups.libgap_mixin": {
+        "ntests": 13
+    },
+    "sage.groups.libgap_morphism": {
+        "ntests": 3
+    },
+    "sage.groups.libgap_wrapper": {
+        "ntests": 2
+    },
+    "sage.groups.matrix_gps.finitely_generated_gap": {
+        "ntests": 15
+    },
+    "sage.groups.matrix_gps.group_element_gap": {
+        "ntests": 1
+    },
+    "sage.groups.matrix_gps.isometries": {
+        "ntests": 4
+    },
+    "sage.groups.matrix_gps.matrix_group_gap": {
+        "ntests": 4
+    },
+    "sage.groups.matrix_gps.symplectic_gap": {
+        "ntests": 1
+    },
+    "sage.groups.old": {
+        "ntests": 35
+    },
+    "sage.groups.perm_gps.constructor": {
+        "ntests": 46
+    },
+    "sage.groups.perm_gps.cubegroup": {
+        "ntests": 137
+    },
+    "sage.groups.perm_gps.partn_ref.automorphism_group_canonical_label": {
+        "ntests": 32
+    },
+    "sage.groups.perm_gps.partn_ref.canonical_augmentation": {
+        "ntests": 1
+    },
+    "sage.groups.perm_gps.partn_ref.data_structures": {
+        "ntests": 38
+    },
+    "sage.groups.perm_gps.partn_ref.double_coset": {
+        "ntests": 15
+    },
+    "sage.groups.perm_gps.partn_ref.refinement_lists": {
+        "ntests": 3
+    },
+    "sage.groups.perm_gps.partn_ref.refinement_python": {
+        "ntests": 101
+    },
+    "sage.groups.perm_gps.partn_ref.refinement_sets": {
+        "ntests": 156
+    },
+    "sage.groups.perm_gps.partn_ref2.refinement_generic": {
+        "ntests": 39
+    },
+    "sage.groups.perm_gps.permgroup": {
+        "ntests": 921
+    },
+    "sage.groups.perm_gps.permgroup_element": {
+        "ntests": 385
+    },
+    "sage.groups.perm_gps.permgroup_morphism": {
+        "ntests": 82
+    },
+    "sage.groups.perm_gps.permgroup_named": {
+        "failed": true,
+        "ntests": 544
+    },
+    "sage.groups.perm_gps.symgp_conjugacy_class": {
+        "ntests": 47
+    },
+    "sage.interfaces.abc": {
+        "ntests": 8
+    },
+    "sage.interfaces.gap": {
+        "ntests": 192
+    },
+    "sage.interfaces.gap3": {
+        "ntests": 35
+    },
+    "sage.interfaces.gap_workspace": {
+        "failed": true,
+        "ntests": 15
+    },
+    "sage.interfaces.interface": {
+        "ntests": 10
+    },
+    "sage.interfaces.process": {
+        "ntests": 39
+    },
+    "sage.interfaces.quit": {
+        "ntests": 16
+    },
+    "sage.interfaces.sage0": {
+        "ntests": 4
+    },
+    "sage.interfaces.sagespawn": {
+        "ntests": 34
+    },
+    "sage.interfaces.tab_completion": {
+        "ntests": 13
+    },
+    "sage.libs.gap.context_managers": {
+        "ntests": 14
+    },
+    "sage.libs.gap.element": {
+        "ntests": 519
+    },
+    "sage.libs.gap.libgap": {
+        "failed": true,
+        "ntests": 98
+    },
+    "sage.libs.gap.operations": {
+        "ntests": 15
+    },
+    "sage.libs.gap.saved_workspace": {
+        "ntests": 7
+    },
+    "sage.libs.gap.test": {
+        "ntests": 2
+    },
+    "sage.libs.gap.test_long": {
+        "ntests": 3
+    },
+    "sage.libs.gap.util": {
+        "ntests": 19
+    },
+    "sage.matrix.matrix_gap": {
+        "ntests": 1
+    },
+    "sage.misc.abstract_method": {
+        "ntests": 33
+    },
+    "sage.misc.banner": {
+        "ntests": 12
+    },
+    "sage.misc.binary_tree": {
+        "ntests": 61
+    },
+    "sage.misc.bindable_class": {
+        "ntests": 47
+    },
+    "sage.misc.c3_controlled": {
+        "ntests": 150
+    },
+    "sage.misc.cachefunc": {
+        "ntests": 692
+    },
+    "sage.misc.call": {
+        "ntests": 28
+    },
+    "sage.misc.callable_dict": {
+        "ntests": 12
+    },
+    "sage.misc.citation": {
+        "failed": true,
+        "ntests": 10
+    },
+    "sage.misc.classcall_metaclass": {
+        "ntests": 78
+    },
+    "sage.misc.classgraph": {
+        "ntests": 1
+    },
+    "sage.misc.constant_function": {
+        "ntests": 21
+    },
+    "sage.misc.converting_dict": {
+        "ntests": 53
+    },
+    "sage.misc.decorators": {
+        "ntests": 127
+    },
+    "sage.misc.defaults": {
+        "ntests": 14
+    },
+    "sage.misc.derivative": {
+        "ntests": 24
+    },
+    "sage.misc.dev_tools": {
+        "failed": true,
+        "ntests": 62
+    },
+    "sage.misc.edit_module": {
+        "ntests": 16
+    },
+    "sage.misc.explain_pickle": {
+        "failed": true,
+        "ntests": 400
+    },
+    "sage.misc.fast_methods": {
+        "ntests": 80
+    },
+    "sage.misc.flatten": {
+        "ntests": 15
+    },
+    "sage.misc.fpickle": {
+        "ntests": 13
+    },
+    "sage.misc.function_mangling": {
+        "ntests": 32
+    },
+    "sage.misc.functional": {
+        "failed": true,
+        "ntests": 273
+    },
+    "sage.misc.gperftools": {
+        "ntests": 17
+    },
+    "sage.misc.html": {
+        "ntests": 64
+    },
+    "sage.misc.inherit_comparison": {
+        "ntests": 2
+    },
+    "sage.misc.inline_fortran": {
+        "ntests": 12
+    },
+    "sage.misc.instancedoc": {
+        "ntests": 67
+    },
+    "sage.misc.latex": {
+        "failed": true,
+        "ntests": 212
+    },
+    "sage.misc.latex_macros": {
+        "ntests": 11
+    },
+    "sage.misc.latex_standalone": {
+        "ntests": 210
+    },
+    "sage.misc.lazy_attribute": {
+        "ntests": 100
+    },
+    "sage.misc.lazy_format": {
+        "ntests": 23
+    },
+    "sage.misc.lazy_import": {
+        "failed": true,
+        "ntests": 279
+    },
+    "sage.misc.lazy_import_cache": {
+        "ntests": 8
+    },
+    "sage.misc.lazy_list": {
+        "ntests": 227
+    },
+    "sage.misc.lazy_string": {
+        "ntests": 131
+    },
+    "sage.misc.map_threaded": {
+        "ntests": 1
+    },
+    "sage.misc.messaging": {
+        "ntests": 2
+    },
+    "sage.misc.method_decorator": {
+        "ntests": 13
+    },
+    "sage.misc.misc": {
+        "failed": true,
+        "ntests": 162
+    },
+    "sage.misc.misc_c": {
+        "ntests": 121
+    },
+    "sage.misc.mrange": {
+        "ntests": 96
+    },
+    "sage.misc.multireplace": {
+        "ntests": 4
+    },
+    "sage.misc.namespace_package": {
+        "ntests": 7
+    },
+    "sage.misc.nested_class": {
+        "ntests": 67
+    },
+    "sage.misc.object_multiplexer": {
+        "ntests": 15
+    },
+    "sage.misc.package": {
+        "ntests": 45
+    },
+    "sage.misc.package_dir": {
+        "ntests": 32
+    },
+    "sage.misc.parser": {
+        "ntests": 136
+    },
+    "sage.misc.persist": {
+        "ntests": 137
+    },
+    "sage.misc.prandom": {
+        "failed": true,
+        "ntests": 74
+    },
+    "sage.misc.python": {
+        "ntests": 7
+    },
+    "sage.misc.random_testing": {
+        "ntests": 18
+    },
+    "sage.misc.remote_file": {
+        "ntests": 1
+    },
+    "sage.misc.repr": {
+        "ntests": 31
+    },
+    "sage.misc.reset": {
+        "ntests": 29
+    },
+    "sage.misc.rest_index_of_methods": {
+        "ntests": 22
+    },
+    "sage.misc.sage_eval": {
+        "failed": true,
+        "ntests": 31
+    },
+    "sage.misc.sage_input": {
+        "ntests": 732
+    },
+    "sage.misc.sage_ostools": {
+        "ntests": 41
+    },
+    "sage.misc.sage_timeit": {
+        "ntests": 44
+    },
+    "sage.misc.sage_timeit_class": {
+        "ntests": 6
+    },
+    "sage.misc.sage_unittest": {
+        "ntests": 88
+    },
+    "sage.misc.sagedoc": {
+        "ntests": 102
+    },
+    "sage.misc.sageinspect": {
+        "ntests": 318
+    },
+    "sage.misc.search": {
+        "ntests": 4
+    },
+    "sage.misc.session": {
+        "failed": true,
+        "ntests": 59
+    },
+    "sage.misc.sh": {
+        "ntests": 1
+    },
+    "sage.misc.stopgap": {
+        "ntests": 11
+    },
+    "sage.misc.superseded": {
+        "failed": true,
+        "ntests": 59
+    },
+    "sage.misc.table": {
+        "ntests": 66
+    },
+    "sage.misc.temporary_file": {
+        "ntests": 80
+    },
+    "sage.misc.test_nested_class": {
+        "ntests": 18
+    },
+    "sage.misc.timing": {
+        "ntests": 35
+    },
+    "sage.misc.trace": {
+        "ntests": 5
+    },
+    "sage.misc.unknown": {
+        "ntests": 22
+    },
+    "sage.misc.verbose": {
+        "ntests": 22
+    },
+    "sage.misc.viewer": {
+        "ntests": 49
+    },
+    "sage.misc.weak_dict": {
+        "ntests": 251
+    },
+    "sage.modules.module": {
+        "ntests": 37
+    },
+    "sage.monoids.indexed_free_monoid": {
+        "ntests": 2
+    },
+    "sage.numerical.backends.generic_backend": {
+        "ntests": 8
+    },
+    "sage.numerical.backends.generic_sdp_backend": {
+        "ntests": 3
+    },
+    "sage.parallel.decorate": {
+        "ntests": 85
+    },
+    "sage.parallel.map_reduce": {
+        "ntests": 284
+    },
+    "sage.parallel.multiprocessing_sage": {
+        "ntests": 9
+    },
+    "sage.parallel.ncpus": {
+        "ntests": 1
+    },
+    "sage.parallel.parallelism": {
+        "ntests": 53
+    },
+    "sage.parallel.reference": {
+        "ntests": 5
+    },
+    "sage.parallel.use_fork": {
+        "failed": true,
+        "ntests": 28
+    },
+    "sage.repl.attach": {
+        "ntests": 135
+    },
+    "sage.repl.configuration": {
+        "ntests": 22
+    },
+    "sage.repl.display.fancy_repr": {
+        "ntests": 27
+    },
+    "sage.repl.display.formatter": {
+        "ntests": 58
+    },
+    "sage.repl.display.jsmol_iframe": {
+        "ntests": 25
+    },
+    "sage.repl.display.pretty_print": {
+        "ntests": 21
+    },
+    "sage.repl.display.util": {
+        "ntests": 7
+    },
+    "sage.repl.inputhook": {
+        "ntests": 7
+    },
+    "sage.repl.interface_magic": {
+        "ntests": 20
+    },
+    "sage.repl.interpreter": {
+        "failed": true,
+        "ntests": 114
+    },
+    "sage.repl.ipython_extension": {
+        "failed": true,
+        "ntests": 76
+    },
+    "sage.repl.ipython_kernel.install": {
+        "failed": true,
+        "ntests": 35
+    },
+    "sage.repl.ipython_kernel.interact": {
+        "ntests": 42
+    },
+    "sage.repl.ipython_kernel.kernel": {
+        "ntests": 12
+    },
+    "sage.repl.ipython_kernel.widgets": {
+        "failed": true,
+        "ntests": 98
+    },
+    "sage.repl.ipython_kernel.widgets_sagenb": {
+        "failed": true,
+        "ntests": 77
+    },
+    "sage.repl.ipython_tests": {
+        "failed": true,
+        "ntests": 26
+    },
+    "sage.repl.load": {
+        "failed": true,
+        "ntests": 40
+    },
+    "sage.repl.preparse": {
+        "ntests": 353
+    },
+    "sage.repl.rich_output.backend_base": {
+        "ntests": 96
+    },
+    "sage.repl.rich_output.backend_doctest": {
+        "ntests": 58
+    },
+    "sage.repl.rich_output.backend_emacs": {
+        "ntests": 15
+    },
+    "sage.repl.rich_output.backend_ipython": {
+        "ntests": 75
+    },
+    "sage.repl.rich_output.buffer": {
+        "ntests": 49
+    },
+    "sage.repl.rich_output.display_manager": {
+        "ntests": 86
+    },
+    "sage.repl.rich_output.output_basic": {
+        "ntests": 47
+    },
+    "sage.repl.rich_output.output_browser": {
+        "ntests": 12
+    },
+    "sage.repl.rich_output.output_graphics": {
+        "ntests": 38
+    },
+    "sage.repl.rich_output.output_graphics3d": {
+        "ntests": 46
+    },
+    "sage.repl.rich_output.output_video": {
+        "ntests": 25
+    },
+    "sage.repl.rich_output.preferences": {
+        "ntests": 68
+    },
+    "sage.repl.rich_output.pretty_print": {
+        "ntests": 41
+    },
+    "sage.repl.rich_output.test_backend": {
+        "ntests": 37
+    },
+    "sage.rings.abc": {
+        "ntests": 91
+    },
+    "sage.rings.algebraic_closure_finite_field": {
+        "ntests": 1
+    },
+    "sage.rings.big_oh": {
+        "ntests": 22
+    },
+    "sage.rings.continued_fraction": {
+        "ntests": 286
+    },
+    "sage.rings.continued_fraction_gosper": {
+        "ntests": 34
+    },
+    "sage.rings.factorint": {
+        "ntests": 10
+    },
+    "sage.rings.finite_rings.conway_polynomials": {
+        "ntests": 20
+    },
+    "sage.rings.finite_rings.element_base": {
+        "ntests": 14
+    },
+    "sage.rings.finite_rings.finite_field_base": {
+        "ntests": 32
+    },
+    "sage.rings.finite_rings.finite_field_constructor": {
+        "ntests": 22
+    },
+    "sage.rings.finite_rings.finite_field_prime_modn": {
+        "ntests": 28
+    },
+    "sage.rings.finite_rings.galois_group": {
+        "ntests": 1
+    },
+    "sage.rings.finite_rings.hom_finite_field": {
+        "ntests": 7
+    },
+    "sage.rings.finite_rings.hom_prime_finite_field": {
+        "ntests": 15
+    },
+    "sage.rings.finite_rings.integer_mod": {
+        "ntests": 541
+    },
+    "sage.rings.finite_rings.integer_mod_ring": {
+        "failed": true,
+        "ntests": 362
+    },
+    "sage.rings.finite_rings.residue_field": {
+        "ntests": 41
+    },
+    "sage.rings.fraction_field": {
+        "failed": true,
+        "ntests": 193
+    },
+    "sage.rings.fraction_field_element": {
+        "failed": true,
+        "ntests": 193
+    },
+    "sage.rings.function_field.constructor": {
+        "ntests": 34
+    },
+    "sage.rings.function_field.element": {
+        "ntests": 148
+    },
+    "sage.rings.function_field.element_rational": {
+        "ntests": 71
+    },
+    "sage.rings.function_field.extensions": {
+        "ntests": 7
+    },
+    "sage.rings.function_field.function_field": {
+        "ntests": 160
+    },
+    "sage.rings.function_field.function_field_rational": {
+        "ntests": 135
+    },
+    "sage.rings.function_field.ideal": {
+        "ntests": 92
+    },
+    "sage.rings.function_field.ideal_rational": {
+        "ntests": 82
+    },
+    "sage.rings.function_field.jacobian_hess": {
+        "ntests": 1
+    },
+    "sage.rings.function_field.maps": {
+        "ntests": 55
+    },
+    "sage.rings.function_field.order": {
+        "ntests": 29
+    },
+    "sage.rings.function_field.order_basis": {
+        "ntests": 20
+    },
+    "sage.rings.function_field.order_rational": {
+        "ntests": 69
+    },
+    "sage.rings.function_field.place": {
+        "ntests": 51
+    },
+    "sage.rings.function_field.place_rational": {
+        "ntests": 7
+    },
+    "sage.rings.generic": {
+        "ntests": 51
+    },
+    "sage.rings.homset": {
+        "ntests": 37
+    },
+    "sage.rings.ideal": {
+        "ntests": 336
+    },
+    "sage.rings.ideal_monoid": {
+        "ntests": 22
+    },
+    "sage.rings.infinity": {
+        "ntests": 313
+    },
+    "sage.rings.integer": {
+        "failed": true,
+        "ntests": 1069
+    },
+    "sage.rings.integer_fake.pxd": {
+        "ntests": 1
+    },
+    "sage.rings.integer_ring": {
+        "ntests": 201
+    },
+    "sage.rings.laurent_series_ring": {
+        "ntests": 151
+    },
+    "sage.rings.laurent_series_ring_element": {
+        "ntests": 335
+    },
+    "sage.rings.localization": {
+        "ntests": 110
+    },
+    "sage.rings.morphism": {
+        "failed": true,
+        "ntests": 446
+    },
+    "sage.rings.multi_power_series_ring": {
+        "ntests": 218
+    },
+    "sage.rings.multi_power_series_ring_element": {
+        "failed": true,
+        "ntests": 426
+    },
+    "sage.rings.number_field.number_field_base": {
+        "ntests": 2
+    },
+    "sage.rings.number_field.number_field_element_base": {
+        "ntests": 4
+    },
+    "sage.rings.number_field.number_field_ideal": {
+        "ntests": 4
+    },
+    "sage.rings.padics.local_generic": {
+        "ntests": 73
+    },
+    "sage.rings.padics.local_generic_element": {
+        "ntests": 12
+    },
+    "sage.rings.padics.misc": {
+        "ntests": 26
+    },
+    "sage.rings.padics.padic_generic": {
+        "ntests": 58
+    },
+    "sage.rings.padics.pow_computer": {
+        "ntests": 76
+    },
+    "sage.rings.polynomial.commutative_polynomial": {
+        "ntests": 7
+    },
+    "sage.rings.polynomial.cyclotomic": {
+        "ntests": 31
+    },
+    "sage.rings.polynomial.flatten": {
+        "failed": true,
+        "ntests": 133
+    },
+    "sage.rings.polynomial.ideal": {
+        "ntests": 13
+    },
+    "sage.rings.polynomial.infinite_polynomial_element": {
+        "failed": true,
+        "ntests": 0
+    },
+    "sage.rings.polynomial.infinite_polynomial_ring": {
+        "ntests": 275
+    },
+    "sage.rings.polynomial.laurent_polynomial": {
+        "failed": true,
+        "ntests": 417
+    },
+    "sage.rings.polynomial.laurent_polynomial_ideal": {
+        "ntests": 7
+    },
+    "sage.rings.polynomial.laurent_polynomial_ring": {
+        "ntests": 87
+    },
+    "sage.rings.polynomial.laurent_polynomial_ring_base": {
+        "ntests": 7
+    },
+    "sage.rings.polynomial.multi_polynomial": {
+        "failed": true,
+        "ntests": 488
+    },
+    "sage.rings.polynomial.multi_polynomial_element": {
+        "ntests": 251
+    },
+    "sage.rings.polynomial.multi_polynomial_ideal": {
+        "ntests": 101
+    },
+    "sage.rings.polynomial.multi_polynomial_ring": {
+        "failed": true,
+        "ntests": 149
+    },
+    "sage.rings.polynomial.multi_polynomial_ring_base": {
+        "failed": true,
+        "ntests": 230
+    },
+    "sage.rings.polynomial.multi_polynomial_sequence": {
+        "failed": true,
+        "ntests": 129
+    },
+    "sage.rings.polynomial.polydict": {
+        "ntests": 396
+    },
+    "sage.rings.polynomial.polynomial_element": {
+        "failed": true,
+        "ntests": 1823
+    },
+    "sage.rings.polynomial.polynomial_element_generic": {
+        "ntests": 194
+    },
+    "sage.rings.polynomial.polynomial_quotient_ring": {
+        "ntests": 36
+    },
+    "sage.rings.polynomial.polynomial_quotient_ring_element": {
+        "ntests": 13
+    },
+    "sage.rings.polynomial.polynomial_ring": {
+        "ntests": 397
+    },
+    "sage.rings.polynomial.polynomial_ring_constructor": {
+        "failed": true,
+        "ntests": 130
+    },
+    "sage.rings.polynomial.polynomial_ring_homomorphism": {
+        "ntests": 24
+    },
+    "sage.rings.polynomial.polynomial_singular_interface": {
+        "ntests": 42
+    },
+    "sage.rings.polynomial.symmetric_ideal": {
+        "ntests": 37
+    },
+    "sage.rings.polynomial.symmetric_reduction": {
+        "ntests": 9
+    },
+    "sage.rings.polynomial.term_order": {
+        "ntests": 319
+    },
+    "sage.rings.polynomial.toy_buchberger": {
+        "ntests": 32
+    },
+    "sage.rings.polynomial.toy_d_basis": {
+        "ntests": 51
+    },
+    "sage.rings.polynomial.toy_variety": {
+        "ntests": 24
+    },
+    "sage.rings.power_series_mpoly": {
+        "ntests": 4
+    },
+    "sage.rings.power_series_poly": {
+        "failed": true,
+        "ntests": 257
+    },
+    "sage.rings.power_series_ring": {
+        "ntests": 241
+    },
+    "sage.rings.power_series_ring_element": {
+        "ntests": 463
+    },
+    "sage.rings.puiseux_series_ring": {
+        "ntests": 72
+    },
+    "sage.rings.puiseux_series_ring_element": {
+        "ntests": 198
+    },
+    "sage.rings.quotient_ring": {
+        "failed": true,
+        "ntests": 185
+    },
+    "sage.rings.quotient_ring_element": {
+        "ntests": 100
+    },
+    "sage.rings.rational": {
+        "failed": true,
+        "ntests": 532
+    },
+    "sage.rings.rational_field": {
+        "ntests": 189
+    },
+    "sage.rings.real_double": {
+        "failed": true,
+        "ntests": 288
+    },
+    "sage.rings.real_lazy": {
+        "ntests": 19
+    },
+    "sage.rings.ring": {
+        "ntests": 160
+    },
+    "sage.rings.semirings.non_negative_integer_semiring": {
+        "ntests": 16
+    },
+    "sage.rings.semirings.tropical_mpolynomial": {
+        "ntests": 8
+    },
+    "sage.rings.semirings.tropical_polynomial": {
+        "ntests": 8
+    },
+    "sage.rings.semirings.tropical_semiring": {
+        "ntests": 120
+    },
+    "sage.rings.semirings.tropical_variety": {
+        "ntests": 6
+    },
+    "sage.rings.sum_of_squares": {
+        "ntests": 35
+    },
+    "sage.rings.tests": {
+        "ntests": 39
+    },
+    "sage.rings.universal_cyclotomic_field": {
+        "ntests": 7
+    },
+    "sage.schemes.affine.affine_homset": {
+        "ntests": 52
+    },
+    "sage.schemes.affine.affine_morphism": {
+        "failed": true,
+        "ntests": 289
+    },
+    "sage.schemes.affine.affine_point": {
+        "failed": true,
+        "ntests": 69
+    },
+    "sage.schemes.affine.affine_rational_point": {
+        "ntests": 26
+    },
+    "sage.schemes.affine.affine_space": {
+        "ntests": 167
+    },
+    "sage.schemes.affine.affine_subscheme": {
+        "ntests": 79
+    },
+    "sage.schemes.generic.algebraic_scheme": {
+        "failed": true,
+        "ntests": 339
+    },
+    "sage.schemes.generic.ambient_space": {
+        "ntests": 60
+    },
+    "sage.schemes.generic.divisor_group": {
+        "ntests": 40
+    },
+    "sage.schemes.generic.homset": {
+        "ntests": 121
+    },
+    "sage.schemes.generic.morphism": {
+        "failed": true,
+        "ntests": 387
+    },
+    "sage.schemes.generic.point": {
+        "ntests": 35
+    },
+    "sage.schemes.generic.scheme": {
+        "ntests": 178
+    },
+    "sage.schemes.generic.spec": {
+        "ntests": 32
+    },
+    "sage.schemes.product_projective.homset": {
+        "ntests": 26
+    },
+    "sage.schemes.product_projective.morphism": {
+        "ntests": 99
+    },
+    "sage.schemes.product_projective.point": {
+        "ntests": 111
+    },
+    "sage.schemes.product_projective.rational_point": {
+        "ntests": 25
+    },
+    "sage.schemes.product_projective.space": {
+        "ntests": 153
+    },
+    "sage.schemes.product_projective.subscheme": {
+        "ntests": 62
+    },
+    "sage.schemes.projective.proj_bdd_height": {
+        "ntests": 21
+    },
+    "sage.schemes.projective.projective_homset": {
+        "ntests": 55
+    },
+    "sage.schemes.projective.projective_morphism": {
+        "failed": true,
+        "ntests": 468
+    },
+    "sage.schemes.projective.projective_point": {
+        "failed": true,
+        "ntests": 281
+    },
+    "sage.schemes.projective.projective_rational_point": {
+        "ntests": 29
+    },
+    "sage.schemes.projective.projective_space": {
+        "ntests": 382
+    },
+    "sage.schemes.projective.projective_subscheme": {
+        "ntests": 234
+    },
+    "sage.sets.cartesian_product": {
+        "ntests": 54
+    },
+    "sage.sets.condition_set": {
+        "ntests": 53
+    },
+    "sage.sets.disjoint_set": {
+        "ntests": 269
+    },
+    "sage.sets.disjoint_union_enumerated_sets": {
+        "ntests": 61
+    },
+    "sage.sets.family": {
+        "ntests": 378
+    },
+    "sage.sets.finite_enumerated_set": {
+        "ntests": 84
+    },
+    "sage.sets.finite_set_map_cy": {
+        "ntests": 111
+    },
+    "sage.sets.finite_set_maps": {
+        "ntests": 86
+    },
+    "sage.sets.image_set": {
+        "ntests": 58
+    },
+    "sage.sets.integer_range": {
+        "ntests": 166
+    },
+    "sage.sets.non_negative_integers": {
+        "ntests": 48
+    },
+    "sage.sets.positive_integers": {
+        "ntests": 14
+    },
+    "sage.sets.primes": {
+        "ntests": 39
+    },
+    "sage.sets.pythonclass": {
+        "ntests": 55
+    },
+    "sage.sets.real_set": {
+        "ntests": 23
+    },
+    "sage.sets.recursively_enumerated_set": {
+        "ntests": 336
+    },
+    "sage.sets.set": {
+        "ntests": 352
+    },
+    "sage.sets.set_from_iterator": {
+        "ntests": 157
+    },
+    "sage.sets.totally_ordered_finite_set": {
+        "ntests": 69
+    },
+    "sage.structure.category_object": {
+        "ntests": 140
+    },
+    "sage.structure.coerce": {
+        "failed": true,
+        "ntests": 309
+    },
+    "sage.structure.coerce_actions": {
+        "ntests": 138
+    },
+    "sage.structure.coerce_dict": {
+        "failed": true,
+        "ntests": 289
+    },
+    "sage.structure.coerce_maps": {
+        "ntests": 90
+    },
+    "sage.structure.debug_options": {
+        "ntests": 5
+    },
+    "sage.structure.dynamic_class": {
+        "ntests": 83
+    },
+    "sage.structure.element": {
+        "failed": true,
+        "ntests": 565
+    },
+    "sage.structure.element.pxd": {
+        "ntests": 18
+    },
+    "sage.structure.element_wrapper": {
+        "ntests": 160
+    },
+    "sage.structure.factorization": {
+        "failed": true,
+        "ntests": 200
+    },
+    "sage.structure.factorization_integer": {
+        "ntests": 6
+    },
+    "sage.structure.factory": {
+        "ntests": 99
+    },
+    "sage.structure.formal_sum": {
+        "ntests": 71
+    },
+    "sage.structure.global_options": {
+        "ntests": 145
+    },
+    "sage.structure.indexed_generators": {
+        "ntests": 90
+    },
+    "sage.structure.list_clone": {
+        "ntests": 380
+    },
+    "sage.structure.list_clone_demo": {
+        "ntests": 43
+    },
+    "sage.structure.list_clone_timings": {
+        "ntests": 18
+    },
+    "sage.structure.list_clone_timings_cy": {
+        "ntests": 12
+    },
+    "sage.structure.mutability": {
+        "ntests": 68
+    },
+    "sage.structure.nonexact": {
+        "ntests": 11
+    },
+    "sage.structure.parent": {
+        "ntests": 310
+    },
+    "sage.structure.parent_gens": {
+        "ntests": 24
+    },
+    "sage.structure.parent_old": {
+        "failed": true,
+        "ntests": 5
+    },
+    "sage.structure.proof.all": {
+        "ntests": 31
+    },
+    "sage.structure.proof.proof": {
+        "ntests": 50
+    },
+    "sage.structure.richcmp": {
+        "ntests": 56
+    },
+    "sage.structure.richcmp.pxd": {
+        "ntests": 24
+    },
+    "sage.structure.sage_object": {
+        "ntests": 84
+    },
+    "sage.structure.sequence": {
+        "ntests": 183
+    },
+    "sage.structure.set_factories": {
+        "ntests": 225
+    },
+    "sage.structure.set_factories_example": {
+        "ntests": 81
+    },
+    "sage.structure.support_view": {
+        "ntests": 38
+    },
+    "sage.structure.test_factory": {
+        "ntests": 6
+    },
+    "sage.structure.unique_representation": {
+        "ntests": 239
+    },
+    "sage.symbolic.function": {
+        "failed": true,
+        "ntests": 169
+    },
+    "sage.symbolic.symbols": {
+        "ntests": 3
+    },
+    "sage.tests.article_heuberger_krenn_kropf_fsm-in-sage": {
+        "ntests": 22
+    },
+    "sage.tests.book_schilling_zabrocki_kschur_primer": {
+        "ntests": 2
+    },
+    "sage.tests.book_stein_ent": {
+        "ntests": 8
+    },
+    "sage.tests.cmdline": {
+        "ntests": 116
+    },
+    "sage.tests.finite_poset": {
+        "ntests": 1
+    },
+    "sage.tests.functools_partial_src": {
+        "ntests": 3
+    },
+    "sage.tests.parigp": {
+        "ntests": 4
+    },
+    "sage.tests.startup": {
+        "ntests": 6
+    },
+    "sage.tests.test_deprecation": {
+        "ntests": 4
+    },
+    "sage.typeset.ascii_art": {
+        "ntests": 24
+    },
+    "sage.typeset.character_art": {
+        "ntests": 108
+    },
+    "sage.typeset.character_art_factory": {
+        "ntests": 53
+    },
+    "sage.typeset.symbols": {
+        "ntests": 28
+    },
+    "sage.typeset.unicode_art": {
+        "ntests": 18
+    },
+    "sage.typeset.unicode_characters": {
+        "ntests": 27
+    }
+}

--- a/pkgs/sagemath-gap/pyproject.toml.m4
+++ b/pkgs/sagemath-gap/pyproject.toml.m4
@@ -10,7 +10,6 @@ requires = [
     SPKG_INSTALL_REQUIRES_cython
     SPKG_INSTALL_REQUIRES_gmpy2
     SPKG_INSTALL_REQUIRES_cysignals
-    SPKG_INSTALL_REQUIRES_sagemath_pari
     SPKG_INSTALL_REQUIRES_memory_allocator
     SPKG_INSTALL_REQUIRES_pkgconfig
 ]
@@ -20,7 +19,6 @@ build-backend = "setuptools.build_meta"
 name = "passagemath-gap"
 description = "passagemath: Computational Group Theory with GAP"
 dependencies = [
-    SPKG_INSTALL_REQUIRES_sagemath_pari
     SPKG_INSTALL_REQUIRES_cysignals
     SPKG_INSTALL_REQUIRES_memory_allocator
     SPKG_INSTALL_REQUIRES_sage_conf

--- a/pkgs/sagemath-gap/tox.ini
+++ b/pkgs/sagemath-gap/tox.ini
@@ -67,7 +67,7 @@ commands =
 
 
     bash -c 'cd $(python -c "import sys; \"\" in sys.path and sys.path.remove(\"\"); from sage.env import SAGE_LIB; print(SAGE_LIB)") \
-        && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_modules --probe all --baseline-stats-path=$KNOWN_TEST_FAILURES {posargs:--installed}'
+        && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_gap --probe all --baseline-stats-path=$KNOWN_TEST_FAILURES {posargs:--installed}'
 
 [testenv:.tox]
 # Allow access to PyPI for auto-provisioning a suitable tox version

--- a/pkgs/sagemath-groups/MANIFEST.in
+++ b/pkgs/sagemath-groups/MANIFEST.in
@@ -24,6 +24,8 @@ exclude sage/groups/misc_gps/argument_groups.p*
 exclude sage/groups/misc_gps/imaginary_groups.p*
 # exclude what is in sagemath-gap
 prune sage/groups/perm_gps
+exclude sage/groups/class_function.p*
+exclude sage/groups/conjugacy_classes.p*
 exclude sage/groups/*gap*.p*
 exclude sage/groups/galois_group_perm.p*
 

--- a/pkgs/sagemath-groups/known-test-failures.json
+++ b/pkgs/sagemath-groups/known-test-failures.json
@@ -1,7 +1,6 @@
 {
     "sage.algebras.clifford_algebra": {
-        "failed": true,
-        "ntests": 618
+        "ntests": 616
     },
     "sage.algebras.clifford_algebra_element": {
         "ntests": 148
@@ -10,16 +9,13 @@
         "ntests": 67
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra": {
-        "ntests": 167
+        "ntests": 160
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_element": {
-        "ntests": 98
-    },
-    "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_ideal": {
-        "ntests": 42
+        "ntests": 92
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_morphism": {
-        "ntests": 59
+        "ntests": 49
     },
     "sage.algebras.finite_gca": {
         "ntests": 88
@@ -46,16 +42,13 @@
     "sage.all__sagemath_modules": {
         "ntests": 4
     },
-    "sage.all__sagemath_pari": {
-        "ntests": 3
-    },
     "sage.arith.functions": {
         "failed": true,
         "ntests": 36
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 865
+        "ntests": 610
     },
     "sage.arith.numerical_approx": {
         "ntests": 3
@@ -96,7 +89,7 @@
     },
     "sage.categories.additive_magmas": {
         "failed": true,
-        "ntests": 161
+        "ntests": 157
     },
     "sage.categories.additive_monoids": {
         "ntests": 16
@@ -109,7 +102,7 @@
     },
     "sage.categories.algebra_functor": {
         "failed": true,
-        "ntests": 143
+        "ntests": 141
     },
     "sage.categories.algebra_ideals": {
         "ntests": 6
@@ -118,7 +111,7 @@
         "ntests": 8
     },
     "sage.categories.algebras": {
-        "ntests": 23
+        "ntests": 21
     },
     "sage.categories.algebras_with_basis": {
         "ntests": 10
@@ -139,7 +132,7 @@
         "ntests": 42
     },
     "sage.categories.category": {
-        "ntests": 423
+        "ntests": 419
     },
     "sage.categories.category_cy_helper": {
         "ntests": 27
@@ -154,7 +147,7 @@
         "ntests": 328
     },
     "sage.categories.chain_complexes": {
-        "ntests": 18
+        "ntests": 12
     },
     "sage.categories.coalgebras_with_basis": {
         "ntests": 19
@@ -163,7 +156,7 @@
         "ntests": 6
     },
     "sage.categories.commutative_additive_groups": {
-        "ntests": 21
+        "ntests": 17
     },
     "sage.categories.commutative_additive_monoids": {
         "ntests": 5
@@ -182,7 +175,7 @@
     },
     "sage.categories.commutative_rings": {
         "failed": true,
-        "ntests": 100
+        "ntests": 65
     },
     "sage.categories.complete_discrete_valuation": {
         "ntests": 8
@@ -217,10 +210,6 @@
     },
     "sage.categories.domains": {
         "ntests": 6
-    },
-    "sage.categories.drinfeld_modules": {
-        "failed": true,
-        "ntests": 226
     },
     "sage.categories.dual": {
         "ntests": 1
@@ -294,9 +283,6 @@
     "sage.categories.examples.semigroups_cython": {
         "ntests": 47
     },
-    "sage.categories.examples.sets_cat": {
-        "ntests": 155
-    },
     "sage.categories.examples.sets_with_grading": {
         "ntests": 14
     },
@@ -304,7 +290,7 @@
         "ntests": 27
     },
     "sage.categories.fields": {
-        "ntests": 129
+        "ntests": 105
     },
     "sage.categories.filtered_algebras": {
         "ntests": 4
@@ -326,7 +312,7 @@
         "ntests": 36
     },
     "sage.categories.finite_dimensional_algebras_with_basis": {
-        "ntests": 52
+        "ntests": 29
     },
     "sage.categories.finite_dimensional_bialgebras_with_basis": {
         "ntests": 4
@@ -346,7 +332,7 @@
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
         "failed": true,
-        "ntests": 145
+        "ntests": 133
     },
     "sage.categories.finite_dimensional_nilpotent_lie_algebras_with_basis": {
         "ntests": 12
@@ -358,7 +344,7 @@
         "ntests": 123
     },
     "sage.categories.finite_fields": {
-        "ntests": 14
+        "ntests": 12
     },
     "sage.categories.finite_groups": {
         "ntests": 34
@@ -394,7 +380,7 @@
         "ntests": 8
     },
     "sage.categories.functor": {
-        "ntests": 135
+        "ntests": 126
     },
     "sage.categories.g_sets": {
         "ntests": 7
@@ -455,7 +441,7 @@
     },
     "sage.categories.groups": {
         "failed": true,
-        "ntests": 73
+        "ntests": 71
     },
     "sage.categories.h_trivial_semigroups": {
         "ntests": 4
@@ -464,7 +450,7 @@
         "ntests": 15
     },
     "sage.categories.homset": {
-        "ntests": 250
+        "ntests": 230
     },
     "sage.categories.homsets": {
         "ntests": 56
@@ -479,8 +465,7 @@
         "ntests": 13
     },
     "sage.categories.integral_domains": {
-        "failed": true,
-        "ntests": 30
+        "ntests": 27
     },
     "sage.categories.isomorphic_objects": {
         "ntests": 2
@@ -546,7 +531,7 @@
     },
     "sage.categories.modules_with_basis": {
         "failed": true,
-        "ntests": 470
+        "ntests": 468
     },
     "sage.categories.monoid_algebras": {
         "ntests": 4
@@ -555,10 +540,10 @@
         "ntests": 83
     },
     "sage.categories.morphism": {
-        "ntests": 134
+        "ntests": 126
     },
     "sage.categories.noetherian_rings": {
-        "ntests": 17
+        "ntests": 16
     },
     "sage.categories.number_fields": {
         "ntests": 17
@@ -589,14 +574,13 @@
     },
     "sage.categories.pushout": {
         "failed": true,
-        "ntests": 743
+        "ntests": 706
     },
     "sage.categories.quantum_group_representations": {
         "ntests": 10
     },
     "sage.categories.quotient_fields": {
-        "failed": true,
-        "ntests": 103
+        "ntests": 53
     },
     "sage.categories.quotients": {
         "ntests": 2
@@ -615,7 +599,7 @@
     },
     "sage.categories.rings": {
         "failed": true,
-        "ntests": 194
+        "ntests": 182
     },
     "sage.categories.rngs": {
         "ntests": 6
@@ -624,7 +608,7 @@
         "ntests": 39
     },
     "sage.categories.semigroups": {
-        "ntests": 95
+        "ntests": 94
     },
     "sage.categories.semirings": {
         "ntests": 6
@@ -633,7 +617,7 @@
         "ntests": 12
     },
     "sage.categories.sets_cat": {
-        "ntests": 407
+        "ntests": 400
     },
     "sage.categories.sets_with_grading": {
         "ntests": 22
@@ -690,7 +674,7 @@
         "ntests": 4
     },
     "sage.categories.unique_factorization_domains": {
-        "ntests": 39
+        "ntests": 38
     },
     "sage.categories.unital_algebras": {
         "ntests": 22
@@ -701,125 +685,29 @@
     "sage.categories.with_realizations": {
         "ntests": 32
     },
-    "sage.coding.abstract_code": {
-        "ntests": 136
-    },
-    "sage.coding.bch_code": {
-        "failed": true,
-        "ntests": 82
-    },
-    "sage.coding.binary_code": {
-        "ntests": 356
-    },
     "sage.coding.bounds_catalog": {
         "ntests": 1
-    },
-    "sage.coding.channel": {
-        "ntests": 116
     },
     "sage.coding.channels_catalog": {
         "ntests": 1
     },
     "sage.coding.code_bounds": {
-        "ntests": 27
-    },
-    "sage.coding.code_constructions": {
-        "failed": true,
-        "ntests": 141
-    },
-    "sage.coding.codecan.autgroup_can_label": {
-        "ntests": 82
-    },
-    "sage.coding.codecan.codecan": {
-        "ntests": 71
+        "ntests": 15
     },
     "sage.coding.codes_catalog": {
         "ntests": 1
     },
-    "sage.coding.cyclic_code": {
-        "failed": true,
-        "ntests": 273
-    },
-    "sage.coding.databases": {
-        "ntests": 5
-    },
-    "sage.coding.decoder": {
-        "ntests": 62
-    },
     "sage.coding.decoders_catalog": {
         "ntests": 1
     },
-    "sage.coding.encoder": {
-        "ntests": 72
-    },
     "sage.coding.encoders_catalog": {
         "ntests": 1
-    },
-    "sage.coding.extended_code": {
-        "ntests": 81
-    },
-    "sage.coding.gabidulin_code": {
-        "ntests": 235
-    },
-    "sage.coding.golay_code": {
-        "ntests": 48
-    },
-    "sage.coding.goppa_code": {
-        "failed": true,
-        "ntests": 115
-    },
-    "sage.coding.grs_code": {
-        "ntests": 533
-    },
-    "sage.coding.guruswami_sudan.interpolation": {
-        "failed": true,
-        "ntests": 47
-    },
-    "sage.coding.guruswami_sudan.utils": {
-        "ntests": 17
-    },
-    "sage.coding.hamming_code": {
-        "ntests": 18
-    },
-    "sage.coding.information_set_decoder": {
-        "ntests": 172
-    },
-    "sage.coding.kasami_codes": {
-        "failed": true,
-        "ntests": 45
-    },
-    "sage.coding.linear_code": {
-        "failed": true,
-        "ntests": 0
-    },
-    "sage.coding.linear_code_no_metric": {
-        "ntests": 247
-    },
-    "sage.coding.linear_rank_metric": {
-        "ntests": 138
-    },
-    "sage.coding.parity_check_code": {
-        "ntests": 48
-    },
-    "sage.coding.punctured_code": {
-        "failed": true,
-        "ntests": 111
-    },
-    "sage.coding.reed_muller_code": {
-        "ntests": 168
     },
     "sage.coding.self_dual_codes": {
         "ntests": 26
     },
     "sage.coding.source_coding.huffman": {
         "ntests": 59
-    },
-    "sage.coding.subfield_subcode": {
-        "failed": true,
-        "ntests": 65
-    },
-    "sage.coding.two_weight_db": {
-        "ntests": 2
     },
     "sage.combinat.backtrack": {
         "ntests": 27
@@ -829,7 +717,7 @@
     },
     "sage.combinat.combinat": {
         "failed": true,
-        "ntests": 231
+        "ntests": 215
     },
     "sage.combinat.combinat_cython": {
         "ntests": 21
@@ -847,7 +735,7 @@
         "ntests": 65
     },
     "sage.combinat.free_module": {
-        "ntests": 369
+        "ntests": 358
     },
     "sage.combinat.integer_lists.base": {
         "ntests": 116
@@ -875,7 +763,7 @@
     },
     "sage.combinat.partition": {
         "failed": true,
-        "ntests": 1137
+        "ntests": 1130
     },
     "sage.combinat.partitions": {
         "ntests": 69
@@ -888,7 +776,8 @@
         "ntests": 39
     },
     "sage.combinat.q_analogues": {
-        "ntests": 117
+        "failed": true,
+        "ntests": 105
     },
     "sage.combinat.ranker": {
         "ntests": 48
@@ -930,7 +819,7 @@
         "ntests": 225
     },
     "sage.combinat.root_system.reflection_group_element": {
-        "ntests": 2
+        "ntests": 1
     },
     "sage.combinat.root_system.root_lattice_realization_algebras": {
         "failed": true,
@@ -943,7 +832,7 @@
         "ntests": 53
     },
     "sage.combinat.root_system.root_system": {
-        "ntests": 102
+        "ntests": 100
     },
     "sage.combinat.root_system.type_A": {
         "ntests": 43
@@ -1043,13 +932,13 @@
         "ntests": 2
     },
     "sage.combinat.tuple": {
-        "ntests": 33
+        "ntests": 30
     },
     "sage.cpython.atexit": {
         "ntests": 19
     },
     "sage.cpython.debug": {
-        "ntests": 13
+        "ntests": 12
     },
     "sage.cpython.dict_del_by_value": {
         "ntests": 21
@@ -1066,51 +955,27 @@
     "sage.cpython.wrapperdescr": {
         "ntests": 11
     },
-    "sage.crypto.block_cipher.des": {
-        "ntests": 156
-    },
-    "sage.crypto.block_cipher.present": {
-        "ntests": 138
-    },
     "sage.crypto.boolean_function": {
-        "ntests": 183
+        "ntests": 172
     },
     "sage.crypto.key_exchange.catalog": {
         "ntests": 1
     },
     "sage.crypto.key_exchange.diffie_hellman": {
-        "ntests": 38
+        "ntests": 35
     },
     "sage.crypto.key_exchange.key_exchange_scheme": {
         "ntests": 14
     },
     "sage.crypto.lattice": {
         "failed": true,
-        "ntests": 14
-    },
-    "sage.crypto.lfsr": {
-        "ntests": 29
+        "ntests": 12
     },
     "sage.crypto.mq.mpolynomialsystemgenerator": {
         "ntests": 29
     },
-    "sage.crypto.mq.rijndael_gf": {
-        "failed": true,
-        "ntests": 362
-    },
-    "sage.crypto.mq.sr": {
-        "failed": true,
-        "ntests": 333
-    },
-    "sage.crypto.sbox": {
-        "failed": true,
-        "ntests": 271
-    },
-    "sage.crypto.sboxes": {
-        "ntests": 27
-    },
     "sage.data_structures.bitset": {
-        "ntests": 430
+        "ntests": 419
     },
     "sage.data_structures.blas_dict": {
         "ntests": 61
@@ -1121,8 +986,8 @@
     "sage.data_structures.mutable_poset": {
         "ntests": 441
     },
-    "sage.databases.conway": {
-        "ntests": 42
+    "sage.data_structures.pairing_heap": {
+        "ntests": 281
     },
     "sage.databases.sql_db": {
         "ntests": 230
@@ -1131,7 +996,7 @@
         "ntests": 9
     },
     "sage.doctest.external": {
-        "ntests": 45
+        "ntests": 41
     },
     "sage.doctest.fixtures": {
         "ntests": 59
@@ -1145,13 +1010,13 @@
     },
     "sage.doctest.parsing": {
         "failed": true,
-        "ntests": 232
+        "ntests": 230
     },
     "sage.doctest.reporting": {
         "ntests": 126
     },
     "sage.doctest.sources": {
-        "ntests": 343
+        "ntests": 341
     },
     "sage.doctest.test": {
         "ntests": 23
@@ -1168,9 +1033,6 @@
     },
     "sage.ext.fast_eval": {
         "ntests": 1
-    },
-    "sage.ext.memory": {
-        "ntests": 3
     },
     "sage.features": {
         "ntests": 135
@@ -1296,7 +1158,7 @@
         "ntests": 4
     },
     "sage.features.pari": {
-        "ntests": 4
+        "ntests": 3
     },
     "sage.features.pdf2svg": {
         "ntests": 4
@@ -1320,7 +1182,7 @@
         "ntests": 21
     },
     "sage.features.sagemath": {
-        "ntests": 135
+        "ntests": 132
     },
     "sage.features.sat": {
         "ntests": 12
@@ -1361,21 +1223,20 @@
     },
     "sage.functions.error": {
         "failed": true,
-        "ntests": 22
+        "ntests": 19
     },
     "sage.functions.exp_integral": {
         "failed": true,
-        "ntests": 66
+        "ntests": 59
     },
     "sage.functions.gamma": {
-        "failed": true,
-        "ntests": 48
+        "ntests": 31
     },
     "sage.functions.generalized": {
         "ntests": 14
     },
     "sage.functions.hyperbolic": {
-        "ntests": 13
+        "ntests": 12
     },
     "sage.functions.hypergeometric": {
         "failed": true,
@@ -1394,20 +1255,20 @@
     },
     "sage.functions.orthogonal_polys": {
         "failed": true,
-        "ntests": 92
+        "ntests": 90
     },
     "sage.functions.other": {
-        "ntests": 84
+        "ntests": 82
     },
     "sage.functions.special": {
-        "ntests": 27
+        "ntests": 26
     },
     "sage.functions.spike_function": {
         "ntests": 24
     },
     "sage.functions.transcendental": {
         "failed": true,
-        "ntests": 20
+        "ntests": 14
     },
     "sage.functions.trig": {
         "failed": true,
@@ -1424,7 +1285,7 @@
     },
     "sage.geometry.toric_lattice": {
         "failed": true,
-        "ntests": 295
+        "ntests": 254
     },
     "sage.geometry.toric_lattice_element": {
         "ntests": 79
@@ -1452,13 +1313,6 @@
     "sage.groups.abelian_gps.values": {
         "ntests": 59
     },
-    "sage.groups.additive_abelian.additive_abelian_group": {
-        "failed": true,
-        "ntests": 78
-    },
-    "sage.groups.additive_abelian.additive_abelian_wrapper": {
-        "ntests": 69
-    },
     "sage.groups.additive_abelian.qmodnz": {
         "ntests": 37
     },
@@ -1466,10 +1320,10 @@
         "ntests": 73
     },
     "sage.groups.affine_gps.affine_group": {
-        "ntests": 65
+        "ntests": 59
     },
     "sage.groups.affine_gps.euclidean_group": {
-        "ntests": 34
+        "ntests": 31
     },
     "sage.groups.affine_gps.group_element": {
         "ntests": 108
@@ -1480,14 +1334,14 @@
     },
     "sage.groups.braid": {
         "failed": true,
-        "ntests": 282
+        "ntests": 281
     },
     "sage.groups.conjugacy_classes": {
         "ntests": 120
     },
     "sage.groups.cubic_braid": {
         "failed": true,
-        "ntests": 159
+        "ntests": 130
     },
     "sage.groups.finitely_presented": {
         "ntests": 371
@@ -1504,16 +1358,16 @@
         "ntests": 186
     },
     "sage.groups.galois_group": {
-        "ntests": 28
+        "ntests": 15
     },
     "sage.groups.galois_group_perm": {
         "ntests": 5
     },
     "sage.groups.generic": {
-        "ntests": 177
+        "ntests": 81
     },
     "sage.groups.group": {
-        "ntests": 55
+        "ntests": 52
     },
     "sage.groups.group_exp": {
         "ntests": 73
@@ -1524,31 +1378,26 @@
     "sage.groups.kernel_subgroup": {
         "ntests": 27
     },
-    "sage.groups.libgap_group": {
-        "ntests": 13
-    },
     "sage.groups.libgap_mixin": {
-        "ntests": 173
+        "ntests": 167
     },
     "sage.groups.libgap_morphism": {
-        "ntests": 190
-    },
-    "sage.groups.libgap_wrapper": {
-        "ntests": 173
+        "ntests": 163
     },
     "sage.groups.matrix_gps.finitely_generated": {
         "ntests": 72
     },
     "sage.groups.matrix_gps.finitely_generated_gap": {
-        "ntests": 82
+        "ntests": 69
     },
     "sage.groups.matrix_gps.group_element": {
         "ntests": 13
     },
     "sage.groups.matrix_gps.group_element_gap": {
-        "ntests": 80
+        "ntests": 79
     },
     "sage.groups.matrix_gps.heisenberg": {
+        "failed": true,
         "ntests": 36
     },
     "sage.groups.matrix_gps.isometries": {
@@ -1556,61 +1405,54 @@
         "ntests": 99
     },
     "sage.groups.matrix_gps.linear": {
-        "ntests": 69
+        "ntests": 58
     },
     "sage.groups.matrix_gps.linear_gap": {
         "ntests": 3
     },
     "sage.groups.matrix_gps.matrix_group": {
-        "ntests": 76
+        "ntests": 66
     },
     "sage.groups.matrix_gps.matrix_group_gap": {
         "ntests": 35
     },
     "sage.groups.matrix_gps.named_group": {
-        "ntests": 28
+        "ntests": 21
     },
     "sage.groups.matrix_gps.named_group_gap": {
         "ntests": 3
     },
     "sage.groups.matrix_gps.orthogonal": {
-        "ntests": 56
+        "ntests": 55
     },
     "sage.groups.matrix_gps.orthogonal_gap": {
         "ntests": 19
     },
     "sage.groups.matrix_gps.symplectic": {
-        "ntests": 30
+        "ntests": 29
     },
     "sage.groups.matrix_gps.symplectic_gap": {
-        "ntests": 6
+        "ntests": 5
     },
     "sage.groups.matrix_gps.unitary": {
-        "ntests": 32
-    },
-    "sage.groups.matrix_gps.unitary_gap": {
-        "ntests": 5
+        "ntests": 6
     },
     "sage.groups.misc_gps.argument_groups": {
         "failed": true,
-        "ntests": 295
+        "ntests": 259
     },
     "sage.groups.misc_gps.imaginary_groups": {
         "failed": true,
-        "ntests": 67
+        "ntests": 66
     },
     "sage.groups.old": {
         "ntests": 35
-    },
-    "sage.groups.pari_group": {
-        "failed": true,
-        "ntests": 45
     },
     "sage.groups.perm_gps.constructor": {
         "ntests": 46
     },
     "sage.groups.perm_gps.cubegroup": {
-        "ntests": 117
+        "ntests": 112
     },
     "sage.groups.perm_gps.partn_ref.automorphism_group_canonical_label": {
         "ntests": 32
@@ -1623,9 +1465,6 @@
     },
     "sage.groups.perm_gps.partn_ref.double_coset": {
         "ntests": 15
-    },
-    "sage.groups.perm_gps.partn_ref.refinement_binary": {
-        "ntests": 75
     },
     "sage.groups.perm_gps.partn_ref.refinement_lists": {
         "ntests": 3
@@ -1643,31 +1482,24 @@
         "ntests": 39
     },
     "sage.groups.perm_gps.permgroup": {
-        "failed": true,
-        "ntests": 947
+        "ntests": 895
     },
     "sage.groups.perm_gps.permgroup_element": {
-        "ntests": 400
+        "ntests": 386
     },
     "sage.groups.perm_gps.permgroup_morphism": {
         "ntests": 82
     },
     "sage.groups.perm_gps.permgroup_named": {
-        "ntests": 519
+        "failed": true,
+        "ntests": 493
     },
     "sage.groups.perm_gps.symgp_conjugacy_class": {
         "ntests": 20
     },
-    "sage.groups.semimonomial_transformations.semimonomial_transformation": {
-        "ntests": 57
-    },
-    "sage.groups.semimonomial_transformations.semimonomial_transformation_group": {
-        "failed": true,
-        "ntests": 62
-    },
     "sage.homology.chain_complex": {
         "failed": true,
-        "ntests": 246
+        "ntests": 216
     },
     "sage.homology.chain_complex_morphism": {
         "ntests": 37
@@ -1682,14 +1514,13 @@
         "ntests": 23
     },
     "sage.homology.matrix_utils": {
-        "ntests": 5
+        "ntests": 3
     },
     "sage.interfaces.abc": {
         "ntests": 8
     },
     "sage.interfaces.gap": {
-        "failed": true,
-        "ntests": 198
+        "ntests": 188
     },
     "sage.interfaces.gap3": {
         "ntests": 8
@@ -1698,17 +1529,11 @@
         "failed": true,
         "ntests": 15
     },
-    "sage.interfaces.genus2reduction": {
-        "ntests": 23
-    },
-    "sage.interfaces.gp": {
-        "ntests": 139
-    },
     "sage.interfaces.process": {
         "ntests": 39
     },
     "sage.interfaces.quit": {
-        "ntests": 14
+        "ntests": 7
     },
     "sage.interfaces.sagespawn": {
         "ntests": 34
@@ -1720,11 +1545,11 @@
         "ntests": 14
     },
     "sage.libs.gap.element": {
-        "ntests": 508
+        "ntests": 488
     },
     "sage.libs.gap.libgap": {
         "failed": true,
-        "ntests": 96
+        "ntests": 94
     },
     "sage.libs.gap.operations": {
         "ntests": 15
@@ -1747,67 +1572,35 @@
     "sage.libs.mpmath.utils": {
         "ntests": 36
     },
-    "sage.libs.pari": {
-        "ntests": 33
-    },
-    "sage.libs.pari.convert_flint": {
-        "ntests": 2
-    },
-    "sage.libs.pari.convert_gmp": {
-        "ntests": 16
-    },
-    "sage.libs.pari.convert_sage": {
-        "ntests": 82
-    },
-    "sage.libs.pari.convert_sage_complex_double": {
-        "ntests": 20
-    },
-    "sage.libs.pari.convert_sage_matrix": {
-        "ntests": 19
-    },
-    "sage.libs.pari.convert_sage_real_double": {
-        "ntests": 2
-    },
-    "sage.libs.pari.convert_sage_real_mpfr": {
-        "ntests": 7
-    },
-    "sage.libs.pari.tests": {
-        "failed": true,
-        "ntests": 634
-    },
     "sage.matrix.action": {
-        "ntests": 105
+        "ntests": 100
     },
     "sage.matrix.args": {
-        "ntests": 166
+        "ntests": 154
     },
     "sage.matrix.berlekamp_massey": {
-        "ntests": 7
-    },
-    "sage.matrix.compute_J_ideal": {
-        "failed": true,
-        "ntests": 99
+        "ntests": 6
     },
     "sage.matrix.constructor": {
-        "ntests": 124
+        "ntests": 123
     },
     "sage.matrix.docs": {
         "ntests": 55
     },
     "sage.matrix.echelon_matrix": {
-        "ntests": 12
+        "ntests": 9
     },
     "sage.matrix.matrix0": {
         "failed": true,
-        "ntests": 808
+        "ntests": 781
     },
     "sage.matrix.matrix1": {
         "failed": true,
-        "ntests": 391
+        "ntests": 375
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 1920
+        "ntests": 1652
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 3
@@ -1826,7 +1619,7 @@
         "ntests": 51
     },
     "sage.matrix.matrix_generic_sparse": {
-        "ntests": 91
+        "ntests": 90
     },
     "sage.matrix.matrix_laurent_mpolynomial_dense": {
         "failed": true,
@@ -1837,14 +1630,14 @@
     },
     "sage.matrix.matrix_polynomial_dense": {
         "failed": true,
-        "ntests": 535
+        "ntests": 516
     },
     "sage.matrix.matrix_space": {
         "failed": true,
-        "ntests": 404
+        "ntests": 392
     },
     "sage.matrix.matrix_sparse": {
-        "ntests": 162
+        "ntests": 157
     },
     "sage.matrix.misc_mpfr": {
         "failed": true,
@@ -1855,17 +1648,17 @@
     },
     "sage.matrix.special": {
         "failed": true,
-        "ntests": 422
+        "ntests": 405
     },
     "sage.matrix.strassen": {
         "failed": true,
         "ntests": 69
     },
     "sage.matrix.symplectic_basis": {
-        "ntests": 46
+        "ntests": 44
     },
     "sage.matrix.tests": {
-        "ntests": 15
+        "ntests": 13
     },
     "sage.matroids.advanced": {
         "ntests": 1
@@ -1877,19 +1670,16 @@
         "ntests": 147
     },
     "sage.matroids.circuit_closures_matroid": {
-        "ntests": 83
+        "ntests": 71
     },
     "sage.matroids.circuits_matroid": {
-        "ntests": 119
-    },
-    "sage.matroids.constructor": {
         "ntests": 107
     },
-    "sage.matroids.database_collections": {
-        "ntests": 8
+    "sage.matroids.constructor": {
+        "ntests": 99
     },
     "sage.matroids.database_matroids": {
-        "ntests": 517
+        "ntests": 347
     },
     "sage.matroids.dual_matroid": {
         "ntests": 77
@@ -1897,15 +1687,11 @@
     "sage.matroids.extension": {
         "ntests": 48
     },
-    "sage.matroids.lean_matrix": {
-        "ntests": 282
-    },
     "sage.matroids.linear_matroid": {
-        "failed": true,
-        "ntests": 629
+        "ntests": 549
     },
     "sage.matroids.matroid": {
-        "ntests": 857
+        "ntests": 837
     },
     "sage.matroids.minor_matroid": {
         "ntests": 73
@@ -1920,7 +1706,7 @@
         "ntests": 40
     },
     "sage.matroids.unpickling": {
-        "ntests": 64
+        "ntests": 57
     },
     "sage.matroids.utilities": {
         "ntests": 45
@@ -1945,7 +1731,7 @@
     },
     "sage.misc.cachefunc": {
         "failed": true,
-        "ntests": 645
+        "ntests": 640
     },
     "sage.misc.call": {
         "ntests": 26
@@ -2005,7 +1791,7 @@
         "ntests": 32
     },
     "sage.misc.functional": {
-        "ntests": 215
+        "ntests": 181
     },
     "sage.misc.html": {
         "ntests": 64
@@ -2021,7 +1807,7 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 217
+        "ntests": 216
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -2043,10 +1829,10 @@
         "ntests": 8
     },
     "sage.misc.lazy_list": {
-        "ntests": 237
+        "ntests": 208
     },
     "sage.misc.lazy_string": {
-        "ntests": 137
+        "ntests": 129
     },
     "sage.misc.map_threaded": {
         "ntests": 1
@@ -2091,7 +1877,7 @@
         "ntests": 133
     },
     "sage.misc.prandom": {
-        "ntests": 72
+        "ntests": 70
     },
     "sage.misc.python": {
         "ntests": 7
@@ -2116,7 +1902,7 @@
         "ntests": 11
     },
     "sage.misc.sage_eval": {
-        "ntests": 41
+        "ntests": 36
     },
     "sage.misc.sage_input": {
         "ntests": 727
@@ -2125,17 +1911,17 @@
         "ntests": 41
     },
     "sage.misc.sage_timeit": {
-        "ntests": 33
+        "ntests": 32
     },
     "sage.misc.sage_timeit_class": {
-        "ntests": 6
+        "ntests": 5
     },
     "sage.misc.sage_unittest": {
         "ntests": 88
     },
     "sage.misc.sagedoc": {
         "failed": true,
-        "ntests": 88
+        "ntests": 87
     },
     "sage.misc.sageinspect": {
         "ntests": 281
@@ -2169,7 +1955,7 @@
         "ntests": 18
     },
     "sage.misc.timing": {
-        "ntests": 29
+        "ntests": 25
     },
     "sage.misc.trace": {
         "ntests": 4
@@ -2184,7 +1970,7 @@
         "ntests": 49
     },
     "sage.misc.weak_dict": {
-        "ntests": 281
+        "ntests": 247
     },
     "sage.modules.fg_pid.fgp_element": {
         "failed": true,
@@ -2192,41 +1978,41 @@
     },
     "sage.modules.fg_pid.fgp_module": {
         "failed": true,
-        "ntests": 423
+        "ntests": 420
     },
     "sage.modules.fg_pid.fgp_morphism": {
         "failed": true,
         "ntests": 117
     },
     "sage.modules.filtered_vector_space": {
-        "ntests": 166
+        "ntests": 161
     },
     "sage.modules.free_module": {
         "failed": true,
-        "ntests": 1443
+        "ntests": 1423
     },
     "sage.modules.free_module_element": {
         "failed": true,
-        "ntests": 776
+        "ntests": 739
     },
     "sage.modules.free_module_homspace": {
         "ntests": 60
     },
     "sage.modules.free_module_morphism": {
         "failed": true,
-        "ntests": 154
+        "ntests": 153
     },
     "sage.modules.free_quadratic_module": {
         "failed": true,
-        "ntests": 306
+        "ntests": 304
     },
     "sage.modules.free_quadratic_module_integer_symmetric": {
         "failed": true,
-        "ntests": 97
+        "ntests": 93
     },
     "sage.modules.matrix_morphism": {
         "failed": true,
-        "ntests": 387
+        "ntests": 383
     },
     "sage.modules.misc": {
         "ntests": 20
@@ -2242,7 +2028,7 @@
         "ntests": 122
     },
     "sage.modules.quotient_module": {
-        "ntests": 124
+        "ntests": 120
     },
     "sage.modules.real_double_vector": {
         "ntests": 2
@@ -2256,7 +2042,7 @@
     },
     "sage.modules.torsion_quadratic_module": {
         "failed": true,
-        "ntests": 150
+        "ntests": 144
     },
     "sage.modules.tutorial_free_modules": {
         "ntests": 43
@@ -2265,7 +2051,7 @@
         "ntests": 43
     },
     "sage.modules.vector_modn_dense": {
-        "ntests": 74
+        "ntests": 57
     },
     "sage.modules.vector_rational_dense": {
         "ntests": 45
@@ -2274,7 +2060,7 @@
         "ntests": 78
     },
     "sage.modules.vector_space_morphism": {
-        "ntests": 144
+        "ntests": 138
     },
     "sage.modules.with_basis.indexed_element": {
         "ntests": 150
@@ -2298,7 +2084,7 @@
         "ntests": 47
     },
     "sage.parallel.decorate": {
-        "ntests": 85
+        "ntests": 78
     },
     "sage.parallel.map_reduce": {
         "ntests": 284
@@ -2324,91 +2110,52 @@
         "ntests": 239
     },
     "sage.probability.random_variable": {
-        "ntests": 19
+        "ntests": 17
     },
     "sage.quadratic_forms.binary_qf": {
-        "ntests": 355
-    },
-    "sage.quadratic_forms.bqf_class_group": {
         "failed": true,
-        "ntests": 143
+        "ntests": 258
     },
     "sage.quadratic_forms.constructions": {
         "ntests": 4
     },
     "sage.quadratic_forms.count_local_2": {
-        "ntests": 23
+        "ntests": 16
     },
     "sage.quadratic_forms.extras": {
         "failed": true,
-        "ntests": 17
-    },
-    "sage.quadratic_forms.genera.genus": {
-        "failed": true,
-        "ntests": 525
-    },
-    "sage.quadratic_forms.genera.spinor_genus": {
-        "ntests": 30
-    },
-    "sage.quadratic_forms.qfsolve": {
-        "ntests": 38
+        "ntests": 16
     },
     "sage.quadratic_forms.quadratic_form": {
-        "ntests": 190
-    },
-    "sage.quadratic_forms.quadratic_form__automorphisms": {
-        "ntests": 52
+        "ntests": 176
     },
     "sage.quadratic_forms.quadratic_form__count_local_2": {
         "ntests": 19
     },
     "sage.quadratic_forms.quadratic_form__equivalence_testing": {
-        "ntests": 72
+        "ntests": 38
     },
     "sage.quadratic_forms.quadratic_form__evaluate": {
         "ntests": 9
     },
-    "sage.quadratic_forms.quadratic_form__genus": {
-        "ntests": 10
-    },
     "sage.quadratic_forms.quadratic_form__local_density_congruence": {
-        "ntests": 130
-    },
-    "sage.quadratic_forms.quadratic_form__local_density_interfaces": {
-        "ntests": 18
+        "ntests": 129
     },
     "sage.quadratic_forms.quadratic_form__local_field_invariants": {
-        "ntests": 138
-    },
-    "sage.quadratic_forms.quadratic_form__local_normal_form": {
-        "ntests": 18
-    },
-    "sage.quadratic_forms.quadratic_form__mass": {
-        "ntests": 4
-    },
-    "sage.quadratic_forms.quadratic_form__mass__Conway_Sloane_masses": {
-        "ntests": 53
-    },
-    "sage.quadratic_forms.quadratic_form__mass__Siegel_densities": {
-        "ntests": 9
+        "failed": true,
+        "ntests": 100
     },
     "sage.quadratic_forms.quadratic_form__neighbors": {
-        "failed": true,
-        "ntests": 32
+        "ntests": 23
     },
     "sage.quadratic_forms.quadratic_form__reduction_theory": {
         "ntests": 17
     },
     "sage.quadratic_forms.quadratic_form__split_local_covering": {
-        "failed": true,
-        "ntests": 13
-    },
-    "sage.quadratic_forms.quadratic_form__ternary_Tornaria": {
-        "failed": true,
-        "ntests": 97
+        "ntests": 10
     },
     "sage.quadratic_forms.quadratic_form__theta": {
-        "ntests": 18
+        "ntests": 13
     },
     "sage.quadratic_forms.quadratic_form__variable_substitutions": {
         "ntests": 23
@@ -2416,15 +2163,11 @@
     "sage.quadratic_forms.random_quadraticform": {
         "ntests": 13
     },
-    "sage.quadratic_forms.special_values": {
-        "failed": true,
-        "ntests": 15
-    },
     "sage.quadratic_forms.ternary": {
-        "ntests": 111
+        "ntests": 97
     },
     "sage.quadratic_forms.ternary_qf": {
-        "ntests": 309
+        "ntests": 285
     },
     "sage.repl.attach": {
         "ntests": 135
@@ -2540,106 +2283,64 @@
     "sage.rings.abc": {
         "ntests": 51
     },
-    "sage.rings.algebraic_closure_finite_field": {
-        "failed": true,
-        "ntests": 213
-    },
     "sage.rings.big_oh": {
         "ntests": 12
+    },
+    "sage.rings.cfinite_sequence": {
+        "ntests": 147
     },
     "sage.rings.complex_conversion": {
         "ntests": 3
     },
     "sage.rings.complex_double": {
         "failed": true,
-        "ntests": 285
+        "ntests": 255
     },
     "sage.rings.complex_mpc": {
-        "ntests": 389
+        "ntests": 366
     },
     "sage.rings.complex_mpfr": {
-        "failed": true,
-        "ntests": 494
+        "ntests": 404
     },
     "sage.rings.continued_fraction": {
         "failed": true,
-        "ntests": 165
+        "ntests": 164
     },
     "sage.rings.continued_fraction_gosper": {
         "ntests": 21
     },
     "sage.rings.derivation": {
-        "ntests": 403
+        "ntests": 381
     },
     "sage.rings.factorint": {
-        "ntests": 11
-    },
-    "sage.rings.factorint_pari": {
-        "ntests": 3
-    },
-    "sage.rings.fast_arith": {
-        "ntests": 20
+        "ntests": 8
     },
     "sage.rings.finite_rings.conway_polynomials": {
-        "ntests": 43
-    },
-    "sage.rings.finite_rings.element_base": {
-        "failed": true,
-        "ntests": 240
-    },
-    "sage.rings.finite_rings.element_pari_ffelt": {
-        "ntests": 300
-    },
-    "sage.rings.finite_rings.finite_field_base": {
-        "failed": true,
-        "ntests": 319
-    },
-    "sage.rings.finite_rings.finite_field_constructor": {
-        "failed": true,
-        "ntests": 102
-    },
-    "sage.rings.finite_rings.finite_field_pari_ffelt": {
-        "ntests": 41
+        "ntests": 16
     },
     "sage.rings.finite_rings.finite_field_prime_modn": {
-        "ntests": 37
-    },
-    "sage.rings.finite_rings.galois_group": {
-        "ntests": 20
-    },
-    "sage.rings.finite_rings.hom_finite_field": {
-        "failed": true,
-        "ntests": 201
+        "ntests": 26
     },
     "sage.rings.finite_rings.hom_prime_finite_field": {
-        "ntests": 21
-    },
-    "sage.rings.finite_rings.homset": {
-        "failed": true,
-        "ntests": 67
+        "ntests": 10
     },
     "sage.rings.finite_rings.integer_mod": {
-        "ntests": 576
+        "failed": true,
+        "ntests": 491
     },
     "sage.rings.finite_rings.integer_mod_ring": {
-        "ntests": 417
-    },
-    "sage.rings.finite_rings.maps_finite_field": {
-        "ntests": 31
+        "failed": true,
+        "ntests": 328
     },
     "sage.rings.finite_rings.residue_field": {
-        "ntests": 115
-    },
-    "sage.rings.finite_rings.residue_field_pari_ffelt": {
-        "ntests": 8
+        "ntests": 12
     },
     "sage.rings.fraction_field": {
         "failed": true,
-        "ntests": 212
+        "ntests": 190
     },
     "sage.rings.fraction_field_element": {
-        "failed": true,
-        "ntests": 183
+        "ntests": 170
     },
     "sage.rings.function_field.constructor": {
         "ntests": 26
@@ -2651,64 +2352,55 @@
         "ntests": 19
     },
     "sage.rings.function_field.differential": {
-        "ntests": 67
+        "ntests": 51
     },
     "sage.rings.function_field.element": {
-        "ntests": 112
+        "ntests": 99
     },
     "sage.rings.function_field.element_rational": {
-        "ntests": 82
+        "ntests": 62
     },
     "sage.rings.function_field.extensions": {
-        "ntests": 3
+        "ntests": 1
     },
     "sage.rings.function_field.function_field": {
-        "ntests": 91
+        "ntests": 75
     },
     "sage.rings.function_field.function_field_rational": {
-        "failed": true,
-        "ntests": 127
+        "ntests": 104
     },
     "sage.rings.function_field.hermite_form_polynomial": {
         "ntests": 21
     },
     "sage.rings.function_field.ideal": {
-        "ntests": 113
+        "ntests": 77
     },
     "sage.rings.function_field.ideal_rational": {
-        "ntests": 150
+        "ntests": 76
     },
     "sage.rings.function_field.maps": {
-        "ntests": 59
+        "ntests": 55
     },
     "sage.rings.function_field.order": {
-        "ntests": 27
+        "ntests": 26
     },
     "sage.rings.function_field.order_basis": {
         "ntests": 35
     },
     "sage.rings.function_field.order_rational": {
-        "ntests": 102
+        "ntests": 60
     },
     "sage.rings.function_field.place": {
-        "ntests": 18
-    },
-    "sage.rings.function_field.place_rational": {
-        "failed": true,
-        "ntests": 23
-    },
-    "sage.rings.function_field.valuation": {
-        "failed": true,
-        "ntests": 224
+        "ntests": 16
     },
     "sage.rings.generic": {
-        "ntests": 78
+        "ntests": 47
     },
     "sage.rings.homset": {
-        "ntests": 38
+        "ntests": 26
     },
     "sage.rings.ideal": {
-        "ntests": 330
+        "ntests": 292
     },
     "sage.rings.ideal_monoid": {
         "failed": true,
@@ -2716,42 +2408,42 @@
     },
     "sage.rings.infinity": {
         "failed": true,
-        "ntests": 274
+        "ntests": 272
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1102
+        "ntests": 968
     },
     "sage.rings.integer_ring": {
-        "ntests": 214
+        "ntests": 189
     },
     "sage.rings.invariants.invariant_theory": {
         "failed": true,
-        "ntests": 883
+        "ntests": 877
     },
     "sage.rings.invariants.reconstruction": {
-        "ntests": 59
+        "ntests": 58
     },
     "sage.rings.laurent_series_ring": {
-        "ntests": 153
+        "ntests": 138
     },
     "sage.rings.laurent_series_ring_element": {
-        "ntests": 389
+        "ntests": 324
     },
     "sage.rings.localization": {
         "failed": true,
-        "ntests": 164
+        "ntests": 88
     },
     "sage.rings.morphism": {
-        "ntests": 425
+        "failed": true,
+        "ntests": 338
     },
     "sage.rings.multi_power_series_ring": {
-        "failed": true,
-        "ntests": 230
+        "ntests": 209
     },
     "sage.rings.multi_power_series_ring_element": {
         "failed": true,
-        "ntests": 425
+        "ntests": 413
     },
     "sage.rings.noncommutative_ideals": {
         "ntests": 23
@@ -2759,195 +2451,108 @@
     "sage.rings.number_field.number_field_element_base": {
         "ntests": 2
     },
-    "sage.rings.number_field.totallyreal": {
-        "ntests": 18
-    },
-    "sage.rings.number_field.totallyreal_data": {
-        "ntests": 29
-    },
-    "sage.rings.number_field.totallyreal_phc": {
-        "ntests": 3
-    },
-    "sage.rings.padics.CA_template.pxi": {
-        "ntests": 194
-    },
-    "sage.rings.padics.CR_template.pxi": {
-        "ntests": 313
-    },
-    "sage.rings.padics.FM_template.pxi": {
-        "ntests": 175
-    },
-    "sage.rings.padics.FP_template.pxi": {
-        "ntests": 239
-    },
-    "sage.rings.padics.eisenstein_extension_generic": {
-        "ntests": 10
-    },
-    "sage.rings.padics.factory": {
-        "failed": true,
-        "ntests": 259
-    },
-    "sage.rings.padics.generic_nodes": {
-        "ntests": 143
-    },
-    "sage.rings.padics.lattice_precision": {
-        "failed": true,
-        "ntests": 427
-    },
     "sage.rings.padics.misc": {
         "ntests": 21
     },
-    "sage.rings.padics.padic_base_generic": {
-        "ntests": 41
-    },
-    "sage.rings.padics.padic_base_leaves": {
-        "ntests": 169
-    },
-    "sage.rings.padics.padic_extension_leaves": {
-        "ntests": 17
-    },
-    "sage.rings.padics.padic_generic_element": {
-        "failed": true,
-        "ntests": 535
-    },
-    "sage.rings.padics.padic_lattice_element": {
-        "ntests": 269
-    },
-    "sage.rings.padics.padic_printing": {
-        "ntests": 106
-    },
-    "sage.rings.padics.padic_relaxed_errors": {
-        "ntests": 5
-    },
-    "sage.rings.padics.padic_template_element.pxi": {
-        "ntests": 113
-    },
-    "sage.rings.padics.padic_valuation": {
-        "ntests": 102
-    },
     "sage.rings.padics.pow_computer": {
         "ntests": 76
-    },
-    "sage.rings.padics.pow_computer_relative": {
-        "ntests": 1
-    },
-    "sage.rings.padics.tests": {
-        "ntests": 8
-    },
-    "sage.rings.padics.tutorial": {
-        "ntests": 42
-    },
-    "sage.rings.padics.unramified_extension_generic": {
-        "ntests": 2
-    },
-    "sage.rings.pari_ring": {
-        "ntests": 46
     },
     "sage.rings.polynomial.commutative_polynomial": {
         "ntests": 7
     },
     "sage.rings.polynomial.cyclotomic": {
-        "ntests": 32
+        "ntests": 22
     },
     "sage.rings.polynomial.flatten": {
         "failed": true,
-        "ntests": 131
+        "ntests": 130
     },
     "sage.rings.polynomial.ideal": {
-        "ntests": 13
+        "ntests": 12
     },
     "sage.rings.polynomial.infinite_polynomial_element": {
         "failed": true,
         "ntests": 0
     },
     "sage.rings.polynomial.infinite_polynomial_ring": {
-        "ntests": 277
+        "ntests": 274
+    },
+    "sage.rings.polynomial.integer_valued_polynomials": {
+        "ntests": 229
     },
     "sage.rings.polynomial.laurent_polynomial": {
         "failed": true,
-        "ntests": 442
+        "ntests": 423
     },
     "sage.rings.polynomial.laurent_polynomial_mpair": {
         "failed": true,
-        "ntests": 367
+        "ntests": 362
     },
     "sage.rings.polynomial.laurent_polynomial_ring": {
         "failed": true,
         "ntests": 155
     },
     "sage.rings.polynomial.laurent_polynomial_ring_base": {
-        "ntests": 114
+        "ntests": 112
     },
     "sage.rings.polynomial.multi_polynomial": {
         "failed": true,
-        "ntests": 513
+        "ntests": 481
     },
     "sage.rings.polynomial.multi_polynomial_element": {
-        "failed": true,
-        "ntests": 183
+        "ntests": 160
     },
     "sage.rings.polynomial.multi_polynomial_ring": {
         "failed": true,
-        "ntests": 147
+        "ntests": 142
     },
     "sage.rings.polynomial.multi_polynomial_ring_base": {
         "failed": true,
-        "ntests": 226
+        "ntests": 222
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
         "failed": true,
-        "ntests": 66
+        "ntests": 62
     },
     "sage.rings.polynomial.ore_function_element": {
-        "ntests": 232
+        "ntests": 39
     },
     "sage.rings.polynomial.ore_function_field": {
         "failed": true,
-        "ntests": 223
-    },
-    "sage.rings.polynomial.padics.polynomial_padic": {
-        "ntests": 9
-    },
-    "sage.rings.polynomial.padics.polynomial_padic_flat": {
-        "ntests": 3
+        "ntests": 52
     },
     "sage.rings.polynomial.polydict": {
-        "ntests": 382
+        "ntests": 381
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 0
+        "ntests": 1597
     },
     "sage.rings.polynomial.polynomial_element_generic": {
-        "ntests": 192
-    },
-    "sage.rings.polynomial.polynomial_quotient_ring": {
-        "failed": true,
-        "ntests": 313
-    },
-    "sage.rings.polynomial.polynomial_quotient_ring_element": {
-        "ntests": 112
+        "ntests": 181
     },
     "sage.rings.polynomial.polynomial_real_mpfr_dense": {
         "failed": true,
-        "ntests": 114
+        "ntests": 111
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "failed": true,
-        "ntests": 417
+        "ntests": 322
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
-        "ntests": 102
+        "ntests": 97
     },
     "sage.rings.polynomial.polynomial_ring_homomorphism": {
-        "ntests": 30
+        "ntests": 24
     },
     "sage.rings.polynomial.polynomial_singular_interface": {
-        "ntests": 31
+        "ntests": 19
+    },
+    "sage.rings.polynomial.q_integer_valued_polynomials": {
+        "ntests": 202
     },
     "sage.rings.polynomial.term_order": {
-        "ntests": 243
+        "ntests": 240
     },
     "sage.rings.polynomial.toy_buchberger": {
         "ntests": 25
@@ -2956,23 +2561,20 @@
         "ntests": 41
     },
     "sage.rings.polynomial.toy_variety": {
-        "ntests": 43
+        "ntests": 22
     },
     "sage.rings.power_series_mpoly": {
         "ntests": 4
     },
-    "sage.rings.power_series_pari": {
-        "ntests": 177
-    },
     "sage.rings.power_series_poly": {
         "failed": true,
-        "ntests": 263
+        "ntests": 257
     },
     "sage.rings.power_series_ring": {
-        "ntests": 234
+        "ntests": 229
     },
     "sage.rings.power_series_ring_element": {
-        "ntests": 468
+        "ntests": 447
     },
     "sage.rings.puiseux_series_ring": {
         "ntests": 61
@@ -2982,22 +2584,22 @@
     },
     "sage.rings.quotient_ring": {
         "failed": true,
-        "ntests": 173
+        "ntests": 154
     },
     "sage.rings.quotient_ring_element": {
         "ntests": 25
     },
     "sage.rings.rational": {
         "failed": true,
-        "ntests": 509
+        "ntests": 493
     },
     "sage.rings.rational_field": {
         "failed": true,
-        "ntests": 174
+        "ntests": 162
     },
     "sage.rings.real_double": {
         "failed": true,
-        "ntests": 267
+        "ntests": 265
     },
     "sage.rings.real_double_element_gsl": {
         "failed": true,
@@ -3008,26 +2610,19 @@
     },
     "sage.rings.real_mpfr": {
         "failed": true,
-        "ntests": 929
+        "ntests": 901
     },
     "sage.rings.ring": {
-        "ntests": 150
+        "ntests": 128
     },
     "sage.rings.ring_extension": {
-        "ntests": 347
-    },
-    "sage.rings.ring_extension_conversion": {
-        "ntests": 75
+        "ntests": 97
     },
     "sage.rings.ring_extension_element": {
-        "failed": true,
-        "ntests": 242
-    },
-    "sage.rings.ring_extension_homset": {
-        "ntests": 9
+        "ntests": 38
     },
     "sage.rings.ring_extension_morphism": {
-        "ntests": 131
+        "ntests": 27
     },
     "sage.rings.semirings.non_negative_integer_semiring": {
         "ntests": 12
@@ -3036,79 +2631,39 @@
         "failed": true,
         "ntests": 132
     },
+    "sage.rings.species": {
+        "failed": true,
+        "ntests": 512
+    },
     "sage.rings.sum_of_squares": {
         "ntests": 35
     },
-    "sage.rings.tate_algebra": {
-        "failed": true,
-        "ntests": 267
-    },
-    "sage.rings.tate_algebra_element": {
-        "failed": true,
-        "ntests": 672
-    },
-    "sage.rings.tate_algebra_ideal": {
-        "failed": true,
-        "ntests": 121
-    },
     "sage.rings.tests": {
-        "ntests": 37
-    },
-    "sage.rings.valuation.augmented_valuation": {
-        "failed": true,
-        "ntests": 160
-    },
-    "sage.rings.valuation.developing_valuation": {
-        "ntests": 18
-    },
-    "sage.rings.valuation.gauss_valuation": {
-        "ntests": 81
-    },
-    "sage.rings.valuation.inductive_valuation": {
-        "ntests": 120
-    },
-    "sage.rings.valuation.limit_valuation": {
-        "ntests": 14
-    },
-    "sage.rings.valuation.scaled_valuation": {
-        "ntests": 40
-    },
-    "sage.rings.valuation.trivial_valuation": {
-        "ntests": 53
-    },
-    "sage.rings.valuation.valuation": {
-        "ntests": 137
-    },
-    "sage.rings.valuation.valuation_space": {
-        "ntests": 198
-    },
-    "sage.rings.valuation.value_group": {
-        "ntests": 100
+        "ntests": 26
     },
     "sage.schemes.affine.affine_homset": {
         "ntests": 42
     },
     "sage.schemes.affine.affine_morphism": {
         "failed": true,
-        "ntests": 276
+        "ntests": 258
     },
     "sage.schemes.affine.affine_point": {
         "failed": true,
-        "ntests": 62
+        "ntests": 60
     },
     "sage.schemes.affine.affine_rational_point": {
         "ntests": 24
     },
     "sage.schemes.affine.affine_space": {
-        "failed": true,
-        "ntests": 151
+        "ntests": 147
     },
     "sage.schemes.affine.affine_subscheme": {
         "ntests": 51
     },
     "sage.schemes.generic.algebraic_scheme": {
         "failed": true,
-        "ntests": 276
+        "ntests": 273
     },
     "sage.schemes.generic.ambient_space": {
         "ntests": 59
@@ -3117,7 +2672,7 @@
         "ntests": 36
     },
     "sage.schemes.generic.homset": {
-        "ntests": 115
+        "ntests": 109
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
@@ -3127,10 +2682,10 @@
         "ntests": 35
     },
     "sage.schemes.generic.scheme": {
-        "ntests": 164
+        "ntests": 156
     },
     "sage.schemes.generic.spec": {
-        "ntests": 31
+        "ntests": 29
     },
     "sage.schemes.product_projective.homset": {
         "ntests": 17
@@ -3145,31 +2700,31 @@
         "ntests": 24
     },
     "sage.schemes.product_projective.space": {
-        "ntests": 144
+        "ntests": 143
     },
     "sage.schemes.product_projective.subscheme": {
-        "ntests": 49
+        "ntests": 44
     },
     "sage.schemes.projective.proj_bdd_height": {
         "ntests": 21
     },
     "sage.schemes.projective.projective_homset": {
-        "ntests": 37
+        "ntests": 36
     },
     "sage.schemes.projective.projective_morphism": {
         "failed": true,
-        "ntests": 421
+        "ntests": 392
     },
     "sage.schemes.projective.projective_point": {
         "failed": true,
-        "ntests": 247
+        "ntests": 233
     },
     "sage.schemes.projective.projective_rational_point": {
-        "ntests": 29
+        "ntests": 25
     },
     "sage.schemes.projective.projective_space": {
         "failed": true,
-        "ntests": 336
+        "ntests": 333
     },
     "sage.schemes.projective.projective_subscheme": {
         "ntests": 182
@@ -3211,7 +2766,7 @@
         "ntests": 13
     },
     "sage.sets.primes": {
-        "ntests": 38
+        "ntests": 32
     },
     "sage.sets.pythonclass": {
         "ntests": 55
@@ -3220,8 +2775,7 @@
         "ntests": 332
     },
     "sage.sets.set": {
-        "failed": true,
-        "ntests": 377
+        "ntests": 326
     },
     "sage.sets.set_from_iterator": {
         "ntests": 150
@@ -3238,17 +2792,17 @@
     },
     "sage.stats.distributions.discrete_gaussian_lattice": {
         "failed": true,
-        "ntests": 141
+        "ntests": 104
     },
     "sage.stats.distributions.discrete_gaussian_polynomial": {
         "ntests": 21
     },
     "sage.structure.category_object": {
         "failed": true,
-        "ntests": 148
+        "ntests": 146
     },
     "sage.structure.coerce": {
-        "ntests": 314
+        "ntests": 303
     },
     "sage.structure.coerce_actions": {
         "ntests": 132
@@ -3257,7 +2811,7 @@
         "ntests": 289
     },
     "sage.structure.coerce_maps": {
-        "ntests": 88
+        "ntests": 83
     },
     "sage.structure.debug_options": {
         "ntests": 5
@@ -3267,7 +2821,7 @@
     },
     "sage.structure.element": {
         "failed": true,
-        "ntests": 635
+        "ntests": 601
     },
     "sage.structure.element.pxd": {
         "ntests": 23
@@ -3277,16 +2831,16 @@
     },
     "sage.structure.factorization": {
         "failed": true,
-        "ntests": 198
+        "ntests": 157
     },
     "sage.structure.factorization_integer": {
         "ntests": 6
     },
     "sage.structure.factory": {
-        "ntests": 104
+        "ntests": 96
     },
     "sage.structure.formal_sum": {
-        "ntests": 70
+        "ntests": 69
     },
     "sage.structure.global_options": {
         "ntests": 132
@@ -3313,20 +2867,20 @@
         "ntests": 11
     },
     "sage.structure.parent": {
-        "ntests": 300
+        "ntests": 292
     },
     "sage.structure.parent_gens": {
-        "ntests": 41
+        "ntests": 29
     },
     "sage.structure.parent_old": {
         "failed": true,
-        "ntests": 10
+        "ntests": 6
     },
     "sage.structure.proof.all": {
         "ntests": 31
     },
     "sage.structure.proof.proof": {
-        "ntests": 50
+        "ntests": 49
     },
     "sage.structure.richcmp": {
         "ntests": 56
@@ -3353,7 +2907,7 @@
         "ntests": 6
     },
     "sage.structure.unique_representation": {
-        "ntests": 233
+        "ntests": 230
     },
     "sage.symbolic.function": {
         "failed": true,
@@ -3381,7 +2935,7 @@
         "ntests": 170
     },
     "sage.tensor.modules.free_module_automorphism": {
-        "ntests": 266
+        "ntests": 254
     },
     "sage.tensor.modules.free_module_basis": {
         "ntests": 187
@@ -3396,7 +2950,7 @@
         "ntests": 112
     },
     "sage.tensor.modules.free_module_morphism": {
-        "ntests": 325
+        "ntests": 320
     },
     "sage.tensor.modules.free_module_tensor": {
         "ntests": 638
@@ -3416,18 +2970,11 @@
     "sage.tensor.modules.tensor_with_indices": {
         "ntests": 233
     },
-    "sage.tests.book_stein_ent": {
-        "failed": true,
-        "ntests": 237
-    },
     "sage.tests.cmdline": {
-        "ntests": 106
+        "ntests": 101
     },
     "sage.tests.functools_partial_src": {
         "ntests": 3
-    },
-    "sage.tests.parigp": {
-        "ntests": 7
     },
     "sage.tests.startup": {
         "ntests": 6

--- a/src/sage/all__sagemath_gap.py
+++ b/src/sage/all__sagemath_gap.py
@@ -8,8 +8,13 @@ This distribution makes the following feature available::
     sage: sage__libs__gap().is_present()
     FeatureTestResult('sage.libs.gap', True)
 """
+from sage.all__sagemath_categories import *
+
+import sage.groups.perm_gps.permgroup_element
 
 from sage.geometry.all__sagemath_gap import *
+
+from sage.groups.all__sagemath_gap import *
 
 import sage.libs.gap.element
 

--- a/src/sage/all__sagemath_groups.py
+++ b/src/sage/all__sagemath_groups.py
@@ -9,8 +9,8 @@ This distribution makes the following feature available::
     FeatureTestResult('sage.groups', True)
 """
 
-from .all__sagemath_modules import *
 from .all__sagemath_gap import *
+from .all__sagemath_modules import *
 
 try:  # extra
     from sage.all__sagemath_combinat import *

--- a/src/sage/categories/groups.py
+++ b/src/sage/categories/groups.py
@@ -126,6 +126,8 @@ class Groups(CategoryWithAxiom):
                 sage: A = AlternatingGroup(4)
                 sage: A.monoid_generators()
                 Family ((1,2,3), (2,3,4))
+
+                sage: # needs sage.combinat
                 sage: F.<x,y> = FreeGroup()
                 sage: F.monoid_generators()
                 Family (x, y, x^-1, y^-1)
@@ -249,7 +251,7 @@ class Groups(CategoryWithAxiom):
             Permutation groups, matrix groups and abelian groups
             can all compute their multiplication tables.  ::
 
-                sage: # needs sage.groups
+                sage: # needs sage.groups sage.modules
                 sage: G = DiCyclicGroup(3)
                 sage: T = G.cayley_table()
                 sage: T.column_keys()
@@ -443,9 +445,9 @@ class Groups(CategoryWithAxiom):
 
             EXAMPLES::
 
-                sage: A = AbelianGroup([2, 2])                                          # needs sage.groups
-                sage: c = A.conjugacy_class(A.an_element())                             # needs sage.groups
-                sage: type(c)                                                           # needs sage.groups
+                sage: A = AbelianGroup([2, 2])                                          # needs sage.modules
+                sage: c = A.conjugacy_class(A.an_element())                             # needs sage.groups sage.modules
+                sage: type(c)                                                           # needs sage.groups sage.modules
                 <class 'sage.groups.conjugacy_classes.ConjugacyClass_with_category'>
             """
             from sage.groups.conjugacy_classes import ConjugacyClass

--- a/src/sage/categories/homset.py
+++ b/src/sage/categories/homset.py
@@ -535,7 +535,7 @@ def End(X, category=None):
     groups currently implement nothing more than unital magmas about
     their homsets, we have::
 
-        sage: # needs sage.groups
+        sage: # needs sage.groups sage.modules
         sage: G = GL(3, 3)
         sage: G.category()
         Category of finite groups
@@ -912,7 +912,7 @@ class Homset(Set_generic):
 
         TESTS::
 
-            sage: # needs sage.groups
+            sage: # needs sage.combinat sage.groups
             sage: G.<x,y,z> = FreeGroup()
             sage: H = Hom(G, G)
             sage: H(H.identity())

--- a/src/sage/combinat/root_system/reflection_group_element.pyx
+++ b/src/sage/combinat/root_system/reflection_group_element.pyx
@@ -1174,7 +1174,7 @@ def _gap_factorization(w, gens):
 
     EXAMPLES::
 
-        sage: from sage.combinat.root_system.reflection_group_element import _gap_factorization
+        sage: from sage.combinat.root_system.reflection_group_element import _gap_factorization  # optional - gap3
         sage: W = ReflectionGroup((1,1,3))                              # optional - gap3
         sage: gens = [W.simple_reflection(i) for i in W.index_set()]    # optional - gap3
         sage: [_gap_factorization(w,gens) for w in W]                   # optional - gap3
@@ -1248,7 +1248,7 @@ def _gap_return(S, coerce_obj='self'):
 
     TESTS::
 
-        sage: from sage.combinat.root_system.reflection_group_complex import _gap_return
+        sage: from sage.combinat.root_system.reflection_group_complex import _gap_return  # optional - gap3
         sage: _gap_return("[ (), (1,4)(2,3)(5,6), (1,6,2)(3,5,4) ]")    # optional - gap3
         ['()', '(1,4)(2,3)(5,6)', '(1,6,2)(3,5,4)']
     """

--- a/src/sage/groups/abelian_gps/abelian_aut.py
+++ b/src/sage/groups/abelian_gps/abelian_aut.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Automorphisms of abelian groups
 

--- a/src/sage/groups/abelian_gps/abelian_group_gap.py
+++ b/src/sage/groups/abelian_gps/abelian_group_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Finitely generated abelian groups with GAP.
 

--- a/src/sage/groups/abelian_gps/abelian_group_morphism.py
+++ b/src/sage/groups/abelian_gps/abelian_group_morphism.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 """
 Homomorphisms of abelian groups
 

--- a/src/sage/groups/all__sagemath_gap.py
+++ b/src/sage/groups/all__sagemath_gap.py
@@ -2,3 +2,10 @@
 
 from sage.groups.perm_gps.all import *
 from sage.groups.abelian_gps.all__sagemath_gap import *
+
+from sage.misc.lazy_import import lazy_import
+
+lazy_import('sage.groups.class_function', 'ClassFunction')
+lazy_import('sage.groups.conjugacy_classes', ['ConjugacyClass', 'ConjugacyClassGAP'])
+
+del lazy_import

--- a/src/sage/groups/all__sagemath_groups.py
+++ b/src/sage/groups/all__sagemath_groups.py
@@ -10,10 +10,6 @@ from sage.groups.all__sagemath_gap import *
 
 from sage.misc.lazy_import import lazy_import
 
-lazy_import('sage.groups.class_function', 'ClassFunction')
-
-lazy_import('sage.groups.conjugacy_classes', ['ConjugacyClass', 'ConjugacyClassGAP'])
-
 lazy_import('sage.groups.free_group', 'FreeGroup')
 lazy_import('sage.groups.braid', 'BraidGroup')
 lazy_import('sage.groups.cubic_braid', 'CubicBraidGroup')

--- a/src/sage/groups/class_function.py
+++ b/src/sage/groups/class_function.py
@@ -1,4 +1,4 @@
-# sage_setup: distribution = sagemath-groups
+# sage_setup: distribution = sagemath-gap
 # sage.doctest: needs sage.rings.number_field
 r"""
 Class functions of groups.

--- a/src/sage/groups/conjugacy_classes.py
+++ b/src/sage/groups/conjugacy_classes.py
@@ -1,4 +1,5 @@
-# sage_setup: distribution = sagemath-groups
+# sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Conjugacy classes of groups
 

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -1689,9 +1689,9 @@ def structure_description(G, latex=False):
 
     Works for finitely presented groups (:issue:`17573`)::
 
-        sage: F.<x, y> = FreeGroup()                                                    # needs sage.groups
-        sage: G = F / [x^2*y^-1, x^3*y^2, x*y*x^-1*y^-1]                                # needs sage.groups
-        sage: G.structure_description()                                                 # needs sage.groups
+        sage: F.<x, y> = FreeGroup()                                                    # needs sage.combinat sage.groups
+        sage: G = F / [x^2*y^-1, x^3*y^2, x*y*x^-1*y^-1]                                # needs sage.combinat sage.groups
+        sage: G.structure_description()                                                 # needs sage.combinat sage.groups
         'C7'
 
     And matrix groups (:issue:`17573`)::

--- a/src/sage/groups/group.pyx
+++ b/src/sage/groups/group.pyx
@@ -39,8 +39,8 @@ def is_Group(x):
         doctest:warning...DeprecationWarning: use instead G in Groups()
         See https://github.com/sagemath/sage/issues/37449 for details.
         False
-        sage: F.<a,b> = FreeGroup()                                                     # needs sage.groups
-        sage: is_Group(F)                                                               # needs sage.groups
+        sage: F.<a,b> = FreeGroup()                                                     # needs sage.combinat
+        sage: is_Group(F)                                                               # needs sage.combinat
         True
     """
     deprecation(37449, 'use instead G in Groups()')

--- a/src/sage/groups/libgap_group.py
+++ b/src/sage/groups/libgap_group.py
@@ -11,6 +11,7 @@ from this but directly from
 
 EXAMPLES::
 
+    sage: # needs sage.combinat
     sage: F.<a,b> = FreeGroup()
     sage: G_gap = libgap.Group([ (a*b^2).gap() ])
     sage: from sage.groups.libgap_group import GroupLibGAP
@@ -52,6 +53,7 @@ class GroupLibGAP(GroupMixinLibGAP, Group, ParentLibGAP):
 
         TESTS::
 
+            sage: # needs sage.combinat
             sage: F.<a,b> = FreeGroup()
             sage: G_gap = libgap.Group([ (a*b^2).gap() ])
             sage: from sage.groups.libgap_group import GroupLibGAP

--- a/src/sage/groups/libgap_morphism.py
+++ b/src/sage/groups/libgap_morphism.py
@@ -1,9 +1,11 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Group homomorphisms for groups with a GAP backend
 
 EXAMPLES::
 
+    sage: # needs sage.combinat
     sage: from sage.groups.abelian_gps.abelian_group_gap import AbelianGroupGap
     sage: A = AbelianGroupGap([2, 4])
     sage: F.<a,b> = FreeGroup()
@@ -70,6 +72,8 @@ class GroupMorphism_libgap(Morphism):
         [0 1]
         [1 0]
         )
+
+        sage: # needs sage.combinat
         sage: G.<a,b> = FreeGroup()
         sage: H = G / (G([1]), G([2])^3)
         sage: f = G.hom(H.gens())
@@ -708,6 +712,7 @@ class GroupHomset_libgap(HomsetWithBase):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: from sage.groups.abelian_gps.abelian_group_gap import AbelianGroupGap
             sage: A = AbelianGroupGap([2,4])
             sage: G.<a,b> = FreeGroup()

--- a/src/sage/groups/libgap_wrapper.pyx
+++ b/src/sage/groups/libgap_wrapper.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.combinat
 """
 LibGAP-based Groups
 

--- a/src/sage/groups/matrix_gps/finitely_generated_gap.py
+++ b/src/sage/groups/matrix_gps/finitely_generated_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 """
 Finitely Generated Matrix Groups with GAP
 """

--- a/src/sage/groups/matrix_gps/group_element_gap.pyx
+++ b/src/sage/groups/matrix_gps/group_element_gap.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Matrix group elements implemented in GAP
 """

--- a/src/sage/groups/matrix_gps/isometries.py
+++ b/src/sage/groups/matrix_gps/isometries.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Groups of isometries
 

--- a/src/sage/groups/matrix_gps/linear_gap.py
+++ b/src/sage/groups/matrix_gps/linear_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 """
 Linear Groups with GAP
 """

--- a/src/sage/groups/matrix_gps/matrix_group_gap.py
+++ b/src/sage/groups/matrix_gps/matrix_group_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Matrix group over a ring that GAP understands
 """

--- a/src/sage/groups/matrix_gps/named_group_gap.py
+++ b/src/sage/groups/matrix_gps/named_group_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 """
 Base for Classical Matrix Groups with GAP
 """

--- a/src/sage/groups/matrix_gps/orthogonal_gap.py
+++ b/src/sage/groups/matrix_gps/orthogonal_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Orthogonal Linear Groups with GAP
 """

--- a/src/sage/groups/matrix_gps/symplectic_gap.py
+++ b/src/sage/groups/matrix_gps/symplectic_gap.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 """
 Symplectic Linear Groups with GAP
 """

--- a/src/sage/groups/perm_gps/cubegroup.py
+++ b/src/sage/groups/perm_gps/cubegroup.py
@@ -137,8 +137,8 @@ def xproj(x, y, z, r):
     EXAMPLES::
 
         sage: from sage.groups.perm_gps.cubegroup import rotation_list, xproj
-        sage: rot = rotation_list(30, 45)
-        sage: xproj(1,2,3,rot)
+        sage: rot = rotation_list(30, 45)                                               # needs sage.symbolic
+        sage: xproj(1,2,3,rot)                                                          # needs sage.symbolic
         0.6123724356957945
     """
     return (y*r[1] - x*r[3])*r[2]
@@ -151,8 +151,8 @@ def yproj(x, y, z, r):
     EXAMPLES::
 
         sage: from sage.groups.perm_gps.cubegroup import rotation_list, yproj
-        sage: rot = rotation_list(30, 45)
-        sage: yproj(1,2,3,rot)
+        sage: rot = rotation_list(30, 45)                                               # needs sage.symbolic
+        sage: yproj(1,2,3,rot)                                                          # needs sage.symbolic
         1.378497416975604
     """
     return z*r[2] - (x*r[1] + y*r[2])*r[0]
@@ -166,7 +166,7 @@ def rotation_list(tilt, turn):
     EXAMPLES::
 
         sage: from sage.groups.perm_gps.cubegroup import rotation_list
-        sage: rotation_list(30, 45)
+        sage: rotation_list(30, 45)                                                     # needs sage.symbolic
         [0.49999999999999994, 0.7071067811865475, 0.8660254037844387, 0.7071067811865476]
     """
     from sage.functions.all import sin, cos

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -147,14 +147,16 @@ from sage.libs.gap.libgap import libgap
 from sage.libs.gap.element import GapElement as LibGapElement
 from sage.groups.perm_gps.permgroup_element import PermutationGroupElement
 from sage.groups.perm_gps.constructor import PermutationGroupElement as PermutationConstructor, standardize_generator
-from sage.groups.abelian_gps.abelian_group import AbelianGroup
 from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_import import lazy_import
 from sage.groups.class_function import ClassFunction_libgap
 from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.groups.conjugacy_classes import ConjugacyClassGAP
 from sage.structure.richcmp import (richcmp_method,
                                     richcmp, rich_to_bool, op_EQ, op_NE)
+
+lazy_import('sage.groups.abelian_gps.abelian_group', 'AbelianGroup')
 
 
 def load_hap():

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -730,6 +730,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         EXAMPLES::
 
+            sage: # needs sage.modules
             sage: G = GL(2,3)
             sage: P = G.as_permutation_group()
             sage: f = P.hom(G.gens())
@@ -1002,6 +1003,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         Check that :issue:`26903` is fixed::
 
+            sage: # needs sage.modules
             sage: G = SO(4,3,-1)
             sage: P = G.as_permutation_group(algorithm='smaller', seed=5)
             sage: P1 = G.as_permutation_group()
@@ -3147,6 +3149,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         EXAMPLES::
 
+            sage: # needs sage.combinat
             sage: CyclicPermutationGroup(50).as_finitely_presented_group()
             Finitely presented group < a | a^50 >
             sage: DihedralGroup(4).as_finitely_presented_group()
@@ -3159,13 +3162,14 @@ class PermutationGroup_generic(FiniteGroup):
             sage: G = PermutationGroup(['(1,2,3,4,5)', '(1,5)(2,4)'])
             sage: G.is_isomorphic(DihedralGroup(5))
             True
-            sage: K = G.as_finitely_presented_group(); K
+            sage: K = G.as_finitely_presented_group(); K                                # needs sage.combinat
             Finitely presented group < a, b | b^2, (b*a)^2, b*a^-3*b*a^2 >
-            sage: K.as_permutation_group().is_isomorphic(DihedralGroup(5))
+            sage: K.as_permutation_group().is_isomorphic(DihedralGroup(5))              # needs sage.combinat
             True
 
         We can attempt to reduce the output presentation::
 
+            sage: # needs sage.combinat
             sage: H = PermutationGroup(['(1,2,3,4,5)', '(1,3,5,2,4)'])
             sage: H.as_finitely_presented_group()
             Finitely presented group < a, b | b^-2*a^-1, b*a^-2 >
@@ -3174,6 +3178,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         TESTS::
 
+            sage: # needs sage.combinat
             sage: PermutationGroup([]).as_finitely_presented_group()
             Finitely presented group < a | a >
             sage: S = SymmetricGroup(6)
@@ -3189,12 +3194,14 @@ class PermutationGroup_generic(FiniteGroup):
         `D_9` is the only non-Abelian group of order 18
         with an automorphism group of order 54 [TW1980]_::
 
+            sage: # needs sage.combinat
             sage: D = DihedralGroup(9).as_finitely_presented_group().gap()
             sage: D.Order(), D.IsAbelian(), D.AutomorphismGroup().Order()
             (18, false, 54)
 
         `S_3` is the only non-Abelian group of order 6 [TW1980]_::
 
+            sage: # needs sage.combinat
             sage: S = SymmetricGroup(3).as_finitely_presented_group().gap()
             sage: S.Order(), S.IsAbelian()
             (6, false)
@@ -3202,6 +3209,7 @@ class PermutationGroup_generic(FiniteGroup):
         We can manually construct a permutation representation using GAP
         coset enumeration methods::
 
+            sage: # needs sage.combinat
             sage: D = GeneralDihedralGroup([3,3,4]).as_finitely_presented_group().gap()
             sage: ctab = D.CosetTable(D.Subgroup([]))
             sage: gen_ls = gap.List(ctab, gap.PermList)
@@ -5065,6 +5073,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         EXAMPLES::
 
+            sage: # needs sage.modules
             sage: G = groups.permutation.Dihedral(4)
             sage: G.sign_representation()
             Sign representation of Dihedral group of order 8

--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -1227,6 +1227,7 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             sage: (f*sigma)*tau
             2*x^2 - y^2 + z^2 + u^2
 
+            sage: # needs sage.modules
             sage: M = matrix(ZZ,[[1,0,0,0,0],[0,2,0,0,0],[0,0,3,0,0],[0,0,0,4,0],[0,0,0,0,5]])
             sage: sigma * M
             [0 2 0 0 0]
@@ -1977,7 +1978,7 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
 
             sage: G = PermutationGroup(['(1,2,3)(4,5)'])
             sage: g = G.gen(0)
-            sage: g.matrix()
+            sage: g.matrix()                                                            # needs sage.modules
             [0 1 0 0 0]
             [0 0 1 0 0]
             [1 0 0 0 0]

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -814,7 +814,7 @@ class CyclicPermutationGroup(PermutationGroup_unique):
             sage: C.is_abelian()
             True
             sage: C = CyclicPermutationGroup(10)
-            sage: C.as_AbelianGroup()
+            sage: C.as_AbelianGroup()                                                   # needs sage.modules
             Multiplicative Abelian group isomorphic to C2 x C5
 
         TESTS::
@@ -868,7 +868,7 @@ class CyclicPermutationGroup(PermutationGroup_unique):
         EXAMPLES::
 
             sage: C = CyclicPermutationGroup(8)
-            sage: C.as_AbelianGroup()
+            sage: C.as_AbelianGroup()                                                   # needs sage.modules
             Multiplicative Abelian group isomorphic to C8
         """
         n = self.order()

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -90,7 +90,6 @@ from pathlib import Path
 
 from sage.arith.misc import factor, valuation
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
-from sage.groups.abelian_gps.abelian_group import AbelianGroup
 from sage.groups.perm_gps.permgroup import PermutationGroup_generic
 from sage.groups.perm_gps.permgroup_element import SymmetricGroupElement
 from sage.libs.gap.libgap import libgap
@@ -108,6 +107,7 @@ from sage.structure.parent import Parent
 from sage.structure.richcmp import richcmp
 from sage.structure.unique_representation import CachedRepresentation
 
+lazy_import('sage.groups.abelian_gps.abelian_group', 'AbelianGroup')
 lazy_import('sage.groups.cactus_group', 'CactusGroup')
 
 

--- a/src/sage/groups/perm_gps/symgp_conjugacy_class.py
+++ b/src/sage/groups/perm_gps/symgp_conjugacy_class.py
@@ -10,10 +10,12 @@ AUTHORS:
 from sage.groups.conjugacy_classes import ConjugacyClass, ConjugacyClassGAP
 from sage.groups.perm_gps.permgroup_element import PermutationGroupElement
 from sage.combinat.partition import Partitions_n, _Partitions
-from sage.combinat.set_partition import SetPartitions
 from sage.combinat.permutation import Permutation, from_cycles
+from sage.misc.lazy_import import lazy_import
 from sage.sets.set import Set
 import itertools
+
+lazy_import('sage.combinat.set_partition', 'SetPartitions')
 
 
 class SymmetricGroupConjugacyClassMixin:

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -1023,7 +1023,7 @@ class GapElement_generic(ModuleElement, ExtraTabCompletion, ExpectElement):
 
             sage: s = gap("(Z(7)^0)*[[1,2,3],[4,5,6]]"); s
             [ [ Z(7)^0, Z(7)^2, Z(7) ], [ Z(7)^4, Z(7)^5, Z(7)^3 ] ]
-            sage: s._matrix_(GF(7))
+            sage: s._matrix_(GF(7))                                                     # needs sage.modules
             [1 2 3]
             [4 5 6]
 
@@ -1031,16 +1031,16 @@ class GapElement_generic(ModuleElement, ExtraTabCompletion, ExpectElement):
 
             sage: s = gap("[[1,2], [3/4, 5/6]]"); s
             [ [ 1, 2 ], [ 3/4, 5/6 ] ]
-            sage: m = s._matrix_(QQ); m
+            sage: m = s._matrix_(QQ); m                                                 # needs sage.modules
             [  1   2]
             [3/4 5/6]
-            sage: parent(m)
+            sage: parent(m)                                                             # needs sage.modules
             Full MatrixSpace of 2 by 2 dense matrices over Rational Field
 
         ::
 
             sage: s = gap('[[Z(16),Z(16)^2],[Z(16)^3,Z(16)]]')
-            sage: s._matrix_(GF(16,'a'))                                                # needs sage.rings.finite_rings
+            sage: s._matrix_(GF(16,'a'))                                                # needs sage.modules sage.rings.finite_rings
             [  a a^2]
             [a^3   a]
         """

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -1323,13 +1323,13 @@ cdef class GapElement(RingElement):
 
             sage: G0 = libgap.SymplecticGroup(4,2)
             sage: P = G0.IsomorphismFpGroup().Range()
-            sage: G = P.sage()
-            sage: G.gap() == P
+            sage: G = P.sage()                                                          # needs sage.combinat
+            sage: G.gap() == P                                                          # needs sage.combinat
             True
 
             sage: F0 = libgap.FreeGroup(2)
-            sage: F = F0.sage()
-            sage: F.gap() is F0
+            sage: F = F0.sage()                                                         # needs sage.combinat
+            sage: F.gap() is F0                                                         # needs sage.combinat
             True
 
         TESTS:
@@ -1830,7 +1830,7 @@ cdef class GapElement_FiniteField(GapElement):
             Traceback (most recent call last):
             ...
             ValueError: the given ring is incompatible ...
-            sage: n.sage(ring=CC)
+            sage: n.sage(ring=CC)                                                       # needs sage.rings.real_mpfr
             Traceback (most recent call last):
             ...
             ValueError: the given ring is incompatible ...
@@ -1838,7 +1838,7 @@ cdef class GapElement_FiniteField(GapElement):
             Traceback (most recent call last):
             ...
             ValueError: the given ring is incompatible ...
-            sage: n.sage(ring=GF(2^3))
+            sage: n.sage(ring=GF(2^3))                                                  # needs sage.rings.finite_rings
             Traceback (most recent call last):
             ...
             ValueError: the given ring is incompatible ...
@@ -2912,7 +2912,7 @@ cdef class GapElement_List(GapElement):
             Z(5)^2
             sage: M.IsMatrix()
             true
-            sage: M.matrix()
+            sage: M.matrix()                                                            # needs sage.modules
             [4 1]
             [4 0]
         """

--- a/src/sage/matrix/matrix_gap.pyx
+++ b/src/sage/matrix/matrix_gap.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.modules
 r"""
 Wrappers on GAP matrices
 """

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -357,8 +357,8 @@ def gen(x):
         x
         sage: gen(GF(7))
         1
-        sage: A = AbelianGroup(1, [23])                                                 # needs sage.groups
-        sage: gen(A)                                                                    # needs sage.groups
+        sage: A = AbelianGroup(1, [23])                                                 # needs sage.modules
+        sage: gen(A)                                                                    # needs sage.modules
         f
     """
     return x.gen()
@@ -376,8 +376,8 @@ def gens(x):
         sage: gens(R)                                                                   # needs sage.symbolic
         (x, y)
 
-        sage: A = AbelianGroup(5, [5,5,7,8,9])                                          # needs sage.groups
-        sage: gens(A)                                                                   # needs sage.groups
+        sage: A = AbelianGroup(5, [5,5,7,8,9])                                          # needs sage.modules
+        sage: gens(A)                                                                   # needs sage.modules
         (f0, f1, f2, f3, f4)
     """
     return x.gens()
@@ -1223,8 +1223,8 @@ def ngens(x):
         Multivariate Polynomial Ring in x, y over Symbolic Ring
         sage: ngens(R)                                                                  # needs sage.symbolic
         2
-        sage: A = AbelianGroup(5, [5,5,7,8,9])                                          # needs sage.groups
-        sage: ngens(A)                                                                  # needs sage.groups
+        sage: A = AbelianGroup(5, [5,5,7,8,9])                                          # needs sage.modules
+        sage: ngens(A)                                                                  # needs sage.modules
         5
         sage: ngens(ZZ)
         1

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -1222,7 +1222,7 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
 
             sage: A2 = IntegralLattice(matrix.identity(3),
             ....:                      Matrix(ZZ, 2, 3, [1,-1,0,0,1,-1]))
-            sage: A2.orthogonal_group()                                                 # needs sage.libs.gap
+            sage: A2.orthogonal_group()                                                 # needs sage.libs.gap sage.libs.pari
             Group of isometries with 2 generators (
             [ 2/3  2/3 -1/3]  [1 0 0]
             [ 2/3 -1/3  2/3]  [0 0 1]
@@ -1232,8 +1232,8 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
         It can be negative definite as well::
 
             sage: A2m = IntegralLattice(-Matrix(ZZ, 2, [2,1,1,2]))
-            sage: G = A2m.orthogonal_group()                                            # needs sage.libs.gap
-            sage: G.order()                                                             # needs sage.libs.gap
+            sage: G = A2m.orthogonal_group()                                            # needs sage.libs.gap sage.libs.pari
+            sage: G.order()                                                             # needs sage.libs.gap sage.libs.pari
             12
 
         If the lattice is indefinite, sage does not know how to compute generators.
@@ -1474,7 +1474,7 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
             sage: G = matrix(ZZ, 3, [0,1,0, 1,0,0, 0,0,7])
             sage: V = matrix(ZZ, 3, [-14,-15,-15, -4,1,16, -5,-5,-4])
             sage: L = IntegralLattice(V * G * V.T)
-            sage: L.lll().gram_matrix()                                                 # needs sage.libs.gap
+            sage: L.lll().gram_matrix()                                                 # needs sage.libs.gap sage.libs.pari
             [0 0 1]
             [0 7 0]
             [1 0 0]

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1,5 +1,5 @@
 # sage_setup: distribution = sagemath-gap
-# sage.doctest: needs sage.libs.gap sage.modules
+# sage.doctest: needs sage.combinat sage.libs.gap sage.modules
 r"""
 Polynomial virtual weighted multisort species
 

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-gap
+# sage.doctest: needs sage.libs.gap sage.modules
 r"""
 Polynomial virtual weighted multisort species
 

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-gap
 r"""
 Polynomial virtual weighted multisort species
 

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -40,11 +40,9 @@ from sage.categories.monoids import Monoids
 from sage.categories.sets_cat import cartesian_product
 from sage.categories.sets_with_grading import SetsWithGrading
 from sage.categories.tensor import tensor
-from sage.combinat.cyclic_sieving_phenomenon import orbit_decomposition
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.combinat.integer_vector import IntegerVectors
 from sage.combinat.partition import Partitions, _Partitions
-from sage.combinat.sf.sf import SymmetricFunctions
 from sage.groups.perm_gps.constructor import PermutationGroupElement
 from sage.groups.perm_gps.permgroup import PermutationGroup, PermutationGroup_generic
 from sage.groups.perm_gps.permgroup_named import SymmetricGroup
@@ -52,6 +50,7 @@ from sage.libs.gap.libgap import libgap
 from sage.misc.cachefunc import cached_method
 from sage.misc.fast_methods import WithEqualityById
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
+from sage.misc.lazy_import import lazy_import
 from sage.modules.free_module_element import vector
 from sage.monoids.indexed_free_monoid import (IndexedFreeAbelianMonoid,
                                               IndexedFreeAbelianMonoidElement)
@@ -66,6 +65,9 @@ from sage.structure.parent import Parent
 from sage.structure.richcmp import op_LT, op_LE, op_EQ, op_NE, op_GT, op_GE
 from sage.structure.unique_representation import (UniqueRepresentation,
                                                   WithPicklingByInitArgs)
+
+lazy_import('sage.combinat.cyclic_sieving_phenomenon', 'orbit_decomposition')
+lazy_import('sage.combinat.sf.sf', 'SymmetricFunctions')
 
 GAP_FAIL = libgap.eval('fail')
 

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -1776,15 +1776,15 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
         EXAMPLES::
 
             sage: S3 = AlternatingGroup(3)                                              # needs sage.groups
-            sage: G = SL(3, QQ)                                                         # needs sage.groups
-            sage: p = S3[2]; p.matrix()                                                 # needs sage.groups
+            sage: G = SL(3, QQ)                                                         # needs sage.groups sage.modules
+            sage: p = S3[2]; p.matrix()                                                 # needs sage.groups sage.modules
             [0 0 1]
             [1 0 0]
             [0 1 0]
 
         In general one cannot mix matrices and permutations::
 
-            sage: # needs sage.groups
+            sage: # needs sage.groups sage.modules
             sage: G(p)
             Traceback (most recent call last):
             ...
@@ -1800,11 +1800,11 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
         By :issue:`14711`, coerce maps should be copied when using outside of
         the coercion system::
 
-            sage: phi = copy(S3.coerce_embedding()); phi                                # needs sage.groups
+            sage: phi = copy(S3.coerce_embedding()); phi                                # needs sage.groups sage.modules
             Generic morphism:
               From: Alternating group of order 3!/2 as a permutation group
               To:   Special Linear Group of degree 3 over Rational Field
-            sage: phi(p)                                                                # needs sage.groups
+            sage: phi(p)                                                                # needs sage.groups sage.modules
             [0 0 1]
             [1 0 0]
             [0 1 0]
@@ -1816,7 +1816,7 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
 
         Though one can have a permutation act on the rows of a matrix::
 
-            sage: G(1) * p                                                              # needs sage.groups
+            sage: G(1) * p                                                              # needs sage.groups sage.modules
             [0 0 1]
             [1 0 0]
             [0 1 0]


### PR DESCRIPTION
- **pkgs/sagemath-gap: Add sage.rings.species**
- **src/sage/rings/species.py: Use lazy_import**
- **src/sage/categories: Add # needs**
- **src/sage/combinat/root_system/reflection_group_element.pyx: Add # needs**
- **src/sage/groups/abelian_gps: Add # needs**
- **src/sage/structure/parent.pyx: Add # needs**
- **src/sage/misc/functional.py: Add # needs**
- **src/sage/groups/perm_gps/cubegroup.py: Add # needs**
- **pkgs/sagemath-gap: Remove dependencies on sagemath-pari**
- **src/sage/groups/matrix_gps: Add # needs**
- **src/sage/matrix/matrix_gap.pyx: Add # needs**
- **src/sage/rings/species.py: Add # needs**
- **src/sage/libs/gap/element.pyx: Add # needs**
- **src/sage/interfaces/gap.py: Add # needs**
- **pkgs/sagemath-gap: Move sage.groups.{class_function,conjugacy_classes} here from sagemath-groups**
- **src/sage/groups/perm_gps/permgroup.py: Use lazy_import**
- **src/sage/groups/perm_gps/permgroup_named.py: Use lazy_import**
- **src/sage/groups: Add # needs**
- **pkgs/sagemath-gap/tox.ini: Test with sage.all__sagemath_gap**
- **./sage --fixdoctests --distribution 'sagemath-gap' --update-known-test-failures**
- **src/sage/all__sagemath_groups.py: Import all__sagemath_modules later**
- **src/sage/groups/perm_gps/symgp_conjugacy_class.py: Use lazy_import**
- **src/sage/modules/free_quadratic_module_integer_symmetric.py: Add # needs**
- **src/sage/rings/species.py: Add # needs**
- **./sage --fixdoctests --distribution 'sagemath-groups' --update-known-test-failures**
