### PR TITLE
fedora: Add gawk to minimal requirements

### DIFF
--- a/build/pkgs/_prereq/distros/fedora.txt
+++ b/build/pkgs/_prereq/distros/fedora.txt
@@ -11,6 +11,7 @@
 binutils
 make
 m4
+gawk
 # a system python is needed for downloading the sage packages, https://github.com/sagemath/sage/issues/29090
 python3
 perl


### PR DESCRIPTION
`awk` is missing in the fedora-42 Docker images.

https://github.com/passagemath/passagemath/actions/runs/14580835120/job/40896989229#step:11:3122