### PR TITLE
pkgs/sagemath-repl: Require typing_extensions (on older Python)

### DIFF
--- a/pkgs/sagemath-repl/pyproject.toml.m4
+++ b/pkgs/sagemath-repl/pyproject.toml.m4
@@ -16,6 +16,7 @@ dependencies = [
     SPKG_INSTALL_REQUIRES_ipython
     SPKG_INSTALL_REQUIRES_ipywidgets
     SPKG_INSTALL_REQUIRES_jupyter_client
+    SPKG_INSTALL_REQUIRES_typing_extensions
 ]
 dynamic = ["version"]
 include(`pyproject_toml_metadata.m4')dnl'


### PR DESCRIPTION
This fixes the following:
```
[sagemath_categories-10.5.25] [spkg-check] Traceback (most recent call last):
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/repl/rich_output/display_manager.py", line 41, in <module>
  [sagemath_categories-10.5.25] [spkg-check]     from typing import Self  # type: ignore (Python >= 3.11)
  [sagemath_categories-10.5.25] [spkg-check] ImportError: cannot import name 'Self' from 'typing' (/usr/lib/python3.10/typing.py)
  [sagemath_categories-10.5.25] [spkg-check] 
  [sagemath_categories-10.5.25] [spkg-check] During handling of the above exception, another exception occurred:
  [sagemath_categories-10.5.25] [spkg-check] 
  [sagemath_categories-10.5.25] [spkg-check] Traceback (most recent call last):
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/bin/sage-runtests", line 9, in <module>
  [sagemath_categories-10.5.25] [spkg-check]     sys.exit(main())
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/doctest/__main__.py", line 193, in main
  [sagemath_categories-10.5.25] [spkg-check]     err = DC.run()
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/doctest/control.py", line 1612, in run
  [sagemath_categories-10.5.25] [spkg-check]     self.run_doctests()
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/doctest/control.py", line 1196, in run_doctests
  [sagemath_categories-10.5.25] [spkg-check]     self.dispatcher = DocTestDispatcher(self)
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/doctest/forker.py", line 1[74](https://github.com/passagemath/passagemath/actions/runs/14624868135/job/41035941645?pr=688#step:11:75)7, in __init__
  [sagemath_categories-10.5.25] [spkg-check]     init_sage(controller)
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/doctest/forker.py", line 234, in init_sage
  [sagemath_categories-10.5.25] [spkg-check]     from sage.repl.rich_output import get_display_manager
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/repl/rich_output/__init__.py", line 3, in <module>
  [sagemath_categories-10.5.25] [spkg-check]     from .display_manager import get_display_manager
  [sagemath_categories-10.5.25] [spkg-check]   File "/sage/pkgs/sagemath-categories/.tox/sagepython-sagewheels-nopypi-norequirements/lib/python3.10/site-packages/sage/repl/rich_output/display_manager.py", line 43, in <module>
  [sagemath_categories-10.5.25] [spkg-check]     from typing_extensions import Self  # type: ignore (Python 3.9, 3.10)
  [sagemath_categories-10.5.25] [spkg-check] ModuleNotFoundError: No module named 'typing_extensions'
```