### PR TITLE
build/pkgs/patch: Recognize 2-part version numbers, find homebrew patch

### DIFF
--- a/.homebrew-build-env
+++ b/.homebrew-build-env
@@ -7,6 +7,11 @@ for l in bzip2 texinfo polymake; do
         PATH="$HOMEBREW/opt/$l/bin:$PATH"
     fi
 done
+for l in gpatch; do
+    if [ -d "$HOMEBREW/opt/$l/libexec/gnubin" ]; then
+        PATH="$HOMEBREW/opt/$l/libexec/gnubin:$PATH"
+    fi
+done
 export PATH
 PKG_CONFIG_PATH="$HOMEBREW/lib/pkgconfig:$PKG_CONFIG_PATH"
 # libpng.pc depends on zlib.pc

--- a/build/pkgs/patch/spkg-configure.m4
+++ b/build/pkgs/patch/spkg-configure.m4
@@ -3,7 +3,7 @@ SAGE_SPKG_CONFIGURE(
         AC_CACHE_CHECK([for GNU patch >= 2.7.0], [ac_cv_path_PATCH], [
         AC_PATH_PROGS_FEATURE_CHECK([PATCH], [patch], [
             patch_version=`$ac_path_PATCH --version 2>&1 \
-                | $SED -n -e 's/GNU patch *\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\)/\1/p'`
+                | $SED -n -e 's/GNU patch *\([[0-9]]*\.[[0-9.]]*\)/\1/p'`
             AS_IF([test -n "$patch_version"], [
                 AX_COMPARE_VERSION([$patch_version], [ge], [2.7.0], [
                     ac_cv_path_PATCH="$ac_path_PATCH"


### PR DESCRIPTION
regex fix in `spkg-configure.m4`

- Fixes https://github.com/sagemath/sage/issues/39941

This alone does not suffice to make current homebrew's `gpatch` to be recognized:
Since October 2024 (https://github.com/Homebrew/homebrew-core/commits/229400baf382d26981998bbe78dd490caa97830b/Formula/g/gpatch.rb), the `gpatch` packages no longer installs a `patch` binary in the normal PATH, only `gpatch`.

Here we also update `.homebrew-build-env` to supply `/usr/local/opt/gpatch/libexec/gnubin`, where the `patch` binary is installed.
