### PR TITLE
tox.ini: Allow use of GCC spkg on archlinux, fedora-42

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -616,6 +616,8 @@ setenv =
     #
     #  - toolchain
     #
+    # allow GCC spkg on these systems which already bring GCC 15
+    fedora-42,archlinux:      CONFIG_CONFIGURE_ARGS_2=--with-system-gcc
     gcc_spkg:                 CONFIG_CONFIGURE_ARGS_2=--without-system-gcc
     gcc_8:                    CONFIG_CONFIGURE_ARGS_2=--with-system-gcc=force CC=gcc-8 CXX=g++-8 FC=gfortran-8
     gcc_8:                      EXTRA_SAGE_PACKAGES_2=_gcc8


### PR DESCRIPTION
Until GCC 15 is supported by the Sage distribution.