### PR TITLE
build/pkgs/m4ri/spkg-configure.m4: Reject m4ri when m4ri.pc is broken as on current Debian

### DIFF
--- a/build/pkgs/m4ri/spkg-configure.m4
+++ b/build/pkgs/m4ri/spkg-configure.m4
@@ -1,6 +1,16 @@
-SAGE_SPKG_CONFIGURE([m4ri], [
-    SAGE_SPKG_DEPCHECK([libpng], [
-        PKG_CHECK_MODULES([M4RI], [m4ri >= 20140914], [], [
-           sage_spkg_install_m4ri=yes])
+SAGE_SPKG_CONFIGURE([m4ri], [dnl
+    SAGE_SPKG_DEPCHECK([libpng], [dnl
+        PKG_CHECK_MODULES([M4RI], [m4ri >= 20140914], [dnl
+           AC_MSG_CHECKING([whether m4ri.pc is sane])
+           AS_CASE(["$M4RI_CFLAGS"],
+                   [*@SIMD_CFLAGS@*], [dnl
+                       AC_MSG_RESULT([no, contaminated with SIMD_CFLAGS])
+                       sage_spkg_install_m4ri=yes
+                   ], [dnl
+                       AC_MSG_RESULT([yes])
+                   ])
+        ], [dnl
+           sage_spkg_install_m4ri=yes
+        ])
     ])
 ])


### PR DESCRIPTION
- Fixes #709