### PR TITLE
lidia: support modern compilers that default to C++17 by @isuruf, backported

### DIFF
--- a/build/pkgs/lidia/spkg-install.in
+++ b/build/pkgs/lidia/spkg-install.in
@@ -4,6 +4,9 @@ if [ -n "$SAGE_GMP_PREFIX" ]; then
    GMP_CONFIGURE="--with-extra-includes=$SAGE_GMP_PREFIX/include --with-extra-libs=$SAGE_GMP_PREFIX/lib"
 fi
 
+# Need std::auto_ptr removed in C++17
+export CXXFLAGS="$CXXFLAGS -std=c++11"
+
 sdh_configure --with-arithmetic=gmp \
               $GMP_CONFIGURE \
               --enable-shared=yes --enable-static=no


### PR DESCRIPTION
Backport of:
- https://github.com/sagemath/sage/pull/39919