### PR TITLE
README.md: Procedure for building missing wheels of 3rd party packages (Linux ARM, Python 3.13, ...)

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -121,7 +121,7 @@ jobs:
           esac
           if [ -n "$SAGE_CONF_TARGETS" ]; then
               sudo apt-get update
-              sudo apt-get install binutils make m4 perl flex bison tar bc gcc g++ ca-certificates libbz2-dev bzip2 xz-utils libffi-dev
+              sudo apt-get install binutils make m4 perl flex bison tar bc gcc g++ ca-certificates libbz2-dev bzip2 xz-utils liblzma-dev libffi-dev
               pip install --force-reinstall -v passagemath-conf
               export PIP_FIND_LINKS="$PIP_FIND_LINKS $(sage-config SAGE_SPKG_WHEELS)"
           fi

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -117,6 +117,13 @@ jobs:
            done) | tee constraints.txt
           export PIP_CONSTRAINT=$(pwd)/constraints.txt
           case "${{ matrix.os }}" in
+              ubuntu*-arm) SAGE_CONF_TARGETS="fpylll gmpy2 lrcalc_python pplpy";;
+          esac
+          if [ -n "$SAGE_CONF_TARGETS" ]; then
+              pip install --force-reinstall -v passagemath-conf
+              export PIP_FIND_LINKS="$PIP_FIND_LINKS $(sage-config SAGE_SPKG_WHEELS)"
+          fi
+          case "${{ matrix.os }}" in
               ubuntu*-arm) tag="manylinux*_aarch64";;
               ubuntu*)  tag="manylinux*_x86_64";;
               macos-13) tag="macosx_*_x86_64";;

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -120,6 +120,8 @@ jobs:
               ubuntu*-arm) SAGE_CONF_TARGETS="fpylll gmpy2 lrcalc_python pplpy";;
           esac
           if [ -n "$SAGE_CONF_TARGETS" ]; then
+              sudo apt-get update
+              sudo apt-get install binutils make m4 perl flex bison tar bc gcc g++ ca-certificates libbz2-dev bzip2 xz-utils libffi-dev
               pip install --force-reinstall -v passagemath-conf
               export PIP_FIND_LINKS="$PIP_FIND_LINKS $(sage-config SAGE_SPKG_WHEELS)"
           fi

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -117,7 +117,7 @@ jobs:
            done) | tee constraints.txt
           export PIP_CONSTRAINT=$(pwd)/constraints.txt
           case "${{ matrix.os }}" in
-              ubuntu*-arm) SAGE_CONF_TARGETS="fpylll gmpy2 lrcalc_python pplpy";;
+              ubuntu*-arm) export SAGE_CONF_TARGETS="fpylll gmpy2 lrcalc_python pplpy";;
           esac
           if [ -n "$SAGE_CONF_TARGETS" ]; then
               sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -45,26 +45,34 @@ passagemath attempts to support all major Linux distributions and recent version
 macOS. Use on Windows currently requires the use of Windows Subsystem for Linux or
 virtualization.
 
-Complete sets of binary wheels are provided on PyPI for Python versions 3.9.x-3.12.x.
-Python 3.13.x is also supported, but some third-party packages are still missing wheels,
-so compilation from source is triggered for those.
+Complete sets of binary wheels are provided on PyPI for Python versions 3.9.x-3.13.x
+for Linux and macOS, both for the x86_64 and ARM architectures.
 
 Unless you need to install passagemath into a specific existing environment, we recommend
-to create and activate a fresh virtual environment over a suitable Python (3.9.x-3.12.x),
+to create and activate a fresh virtual environment over a suitable Python (3.9.x-3.13.x),
 for example `~/passagemath-venv/`:
 
-            $ python3 --version
-            Python 3.12.7
-            $ python3 -m venv ~/passagemath-venv
-            $ source ~/passagemath-venv/bin/activate
+    $ python3 --version
+    Python 3.12.7
+    $ python3 -m venv ~/passagemath-venv
+    $ source ~/passagemath-venv/bin/activate
+
+For Python 3.13.x on any platform, and for any Python version on the Linux aarch64 (ARM)
+and macOS arm64 (Apple Silicon M1/M2/M3/M4) platforms,
+[some third-party packages are still missing wheels](https://github.com/passagemath/passagemath/issues/347).
+Build these wheels from source:
+
+    (passagemath-venv) $ export SAGE_CONF_TARGETS="fpylll gmpy2 lrcalc_python pplpy"
+    (passagemath-venv) $ pip install --force-reinstall -v passagemath-conf
+    (passagemath-venv) $ export PIP_FIND_LINKS=$(sage-config SAGE_SPKG_WHEELS)
 
 Then install the meta-package [![PyPI: passagemath-standard](https://img.shields.io/pypi/v/passagemath-standard.svg?label=passagemath-standard)](https://pypi.python.org/pypi/passagemath-standard)
 
-            $ pip install -v --prefer-binary passagemath-standard
+    (passagemath-venv) $ pip install -v --prefer-binary passagemath-standard
 
 Start the Sage REPL:
 
-            $ sage
+    (passagemath-venv) $ sage
 
 Alternatively, use a Python or IPython REPL, or use a Python or Sage kernel in Jupyter.
 


### PR DESCRIPTION
Since https://github.com/passagemath/passagemath/releases/tag/passagemath-10.5.32, Linux ARM wheels are available @xuluze but some 3rd party packages have not published wheels for this platform.

Here we document a robust procedure for building these wheels on the user's system.