### PR TITLE
pkgs/sage-conf_pypi/setup.py: Do not pass -j to top-level make

### DIFF
--- a/pkgs/sage-conf_pypi/setup.py
+++ b/pkgs/sage-conf_pypi/setup.py
@@ -102,7 +102,7 @@ class build_py(setuptools_build_py):
             #   (that use native libraries shared with other packages).
             SETMAKE = 'if [ -z "$MAKE" ]; then export MAKE="make -j$(PATH=build/bin:$PATH build/bin/sage-build-num-threads | cut -d" " -f 2)"; fi'
             TARGETS = 'base'
-            cmd = f'cd {SAGE_ROOT} && ({SETENV}; {SETMAKE} && $MAKE V=0 ${{SAGE_CONF_TARGETS-{TARGETS}}})'
+            cmd = f'cd {SAGE_ROOT} && ({SETENV}; {SETMAKE} && make V=0 ${{SAGE_CONF_TARGETS-{TARGETS}}})'
             print(f"Running {cmd}", flush=True)
             if os.system(cmd) != 0:
                 raise SetupError(f"make ${{SAGE_CONF_TARGETS-{TARGETS}}} failed")


### PR DESCRIPTION
This fixes a parallelization bug