### PR TITLE
build/pkgs/python3/spkg-configure.m4: Allow Python 3.13 if explicitly selected

### DIFF
--- a/build/pkgs/python3/spkg-configure.m4
+++ b/build/pkgs/python3/spkg-configure.m4
@@ -2,7 +2,7 @@ SAGE_SPKG_CONFIGURE([python3], [
    m4_pushdef([MIN_VERSION],               [3.9.0])
    m4_pushdef([MIN_NONDEPRECATED_VERSION], [3.9.0])
    m4_pushdef([LT_STABLE_VERSION],         [3.13.0])
-   m4_pushdef([LT_VERSION],                [3.13.0])
+   m4_pushdef([LT_VERSION],                [3.14.0])
    AC_ARG_WITH([python],
                [AS_HELP_STRING([--with-python=PYTHON3],
                                [Python 3 executable to use for the Sage venv; default: python3])])


### PR DESCRIPTION
In particular, this enables building a wheelhouse using passagemath-conf for 3.13 as already documented.
