### PR TITLE
.github/workflows/dist.yml: Replace use of softprops/action-gh-release

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -142,10 +142,35 @@ jobs:
     runs-on: ubuntu-latest
     if: (success() || failure()) && github.repository == 'passagemath/passagemath' && startsWith(github.ref, 'refs/tags/passagemath-')
     steps:
-      - uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest_release_tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+          | jq -r 'sort_by(.created_at) | last(.[]).tag_name')
+          release_notes=$(curl -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
+            -d "{
+              \"tag_name\": \"${{ github.ref_name }}\",
+              \"previous_tag_name\": \"$latest_release_tag\"
+            }" | jq -r '.body')
+          # escape special characters for json
+          release_notes=$(jq -R -s '.' <<< "$release_notes")
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
+            -d "{
+              \"tag_name\": \"${{ github.ref_name }}\",
+              \"prerelease\": ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }},
+              \"body\": $release_notes
+            }"
     permissions:
       contents: write
 


### PR DESCRIPTION
Failing persistenly with
```
Run softprops/action-gh-release@v2
⚠️ Unexpected error fetching GitHub release for tag refs/tags/passagemath-10.5.34: HttpError: We couldn't respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists.
Error: We couldn't respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists.
```