### PR TITLE
`sage.matrix.matrix2`: Add methods `is_unimodular`... delegating to `Matrix_cmr_sparse`

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -18189,8 +18189,36 @@ cdef class Matrix(Matrix1):
         return all(s * (self * x) == 0
                    for (x, s) in K.discrete_complementarity_set())
 
+    def _matrix_cmr(self):
+        r"""
+        Return ``self`` as a :class:`sage.matrix.matrix_cmr_sparse.Matrix_cmr_chr_sparse`.
+
+        EXAMPLES::
+
+            sage: # needs sage.libs.cmr
+            sage: M = matrix(ZZ, [[1, 0, 1], [0, 1, 1], [1, 2, 3]],
+            ....:            column_keys=['a', 'b', 'c'],
+            ....:            row_keys=['u', 'v', 'w'])
+            sage: M_cmr = M._matrix_cmr(); M_cmr
+            [1 0 1]
+            [0 1 1]
+            [1 2 3]
+            sage: type(M_cmr)
+            <class 'sage.matrix.matrix_cmr_sparse.Matrix_cmr_chr_sparse'>
+        """
+        from .matrix_cmr_sparse import Matrix_cmr_chr_sparse
+        from .matrix_space import MatrixSpace
+
+        MS = MatrixSpace(ZZ, self.nrows(), self.ncols(), sparse=True)
+        return Matrix_cmr_chr_sparse(MS, self)
+
     def is_unimodular(self):
         r"""
+        Return whether ``self`` is a unimodular matrix.
+
+        See :meth:`~sage.matrix.matrix_cmr_sparse.Matrix_cmr_sparse.is_unimodular` for
+        the detailed documentation.
+
         EXAMPLES::
 
             sage: # needs sage.libs.cmr
@@ -18205,12 +18233,7 @@ cdef class Matrix(Matrix1):
             sage: M.is_unimodular()
             False
         """
-        from .matrix_cmr_sparse import Matrix_cmr_chr_sparse
-        from .matrix_space import MatrixSpace
-
-        MS = MatrixSpace(ZZ, self.nrows(), self.ncols(), sparse=True)
-        M = Matrix_cmr_chr_sparse(MS, self)
-        return M.is_unimodular()
+        return self._matrix_cmr().is_unimodular()
 
     def LLL_gram(self, flag=0):
         """

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -18212,9 +18212,24 @@ cdef class Matrix(Matrix1):
         MS = MatrixSpace(ZZ, self.nrows(), self.ncols(), sparse=True)
         return Matrix_cmr_chr_sparse(MS, self)
 
-    def is_unimodular(self):
+    def is_unimodular(self, *args, **kwds):
         r"""
         Return whether ``self`` is a unimodular matrix.
+
+        A nonsingular square matrix `A` is called unimodular if it is integral
+        and has determinant `\pm1`, i.e., an element of
+        `\mathop{\operatorname{GL}}_n(\ZZ)` [Sch1986]_, Ch. 4.3.
+
+        A rectangular matrix `A` of full row rank is called unimodular if it
+        is integral and every basis `B` of `A` has determinant `\pm1`.
+        [Sch1986]_, Ch. 19.1.
+
+        More generally, a matrix `A` of rank `r` is called unimodular if it is
+        integral and for every submatrix `B` formed by `r` linearly independent columns,
+        the greatest common divisor of the determinants of all `r`-by-`r`
+        submatrices of `B` is `1`. [Sch1986]_, Ch. 21.4.
+
+        .. SEEALSO:: :meth:`is_k_equimodular`, :meth:`is_strongly_unimodular`, :meth:`is_totally_unimodular`
 
         See :meth:`~sage.matrix.matrix_cmr_sparse.Matrix_cmr_sparse.is_unimodular` for
         the detailed documentation.
@@ -18233,7 +18248,34 @@ cdef class Matrix(Matrix1):
             sage: M.is_unimodular()
             False
         """
-        return self._matrix_cmr().is_unimodular()
+        return self._matrix_cmr().is_unimodular(*args, **kwds)
+
+    def is_strongly_unimodular(self, *args, **kwds):
+        r"""
+        Return whether ``self`` is a strongly unimodular matrix.
+
+        A matrix is strongly unimodular if ``self`` and ``self.transpose()`` are both unimodular.
+
+        .. SEEALSO:: meth:`is_unimodular`, :meth:`is_strongly_k_equimodular`
+
+        EXAMPLES::
+
+            sage: from sage.matrix.matrix_cmr_sparse import Matrix_cmr_chr_sparse
+            sage: M = matrix([[1, 0, 1], [0, 1, 1], [1, 2, 3]]); M
+            [1 0 1]
+            [0 1 1]
+            [1 2 3]
+            sage: M.is_unimodular()
+            True
+            sage: M.is_strongly_unimodular()
+            False
+            sage: M = matrix([[1, 0, 0], [0, 1, 0]]); M
+            [1 0 0]
+            [0 1 0]
+            sage: M.is_strongly_unimodular()
+            True
+        """
+        return self._matrix_cmr().is_strongly_unimodular(*args, **kwds)
 
     def LLL_gram(self, flag=0):
         """

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -18189,6 +18189,29 @@ cdef class Matrix(Matrix1):
         return all(s * (self * x) == 0
                    for (x, s) in K.discrete_complementarity_set())
 
+    def is_unimodular(self):
+        r"""
+        EXAMPLES::
+
+            sage: # needs sage.libs.cmr
+            sage: M = matrix(ZZ, [[1, 0, 0], [0, 1, 0]]); M
+            [1 0 0]
+            [0 1 0]
+            sage: M.is_unimodular()
+            True
+            sage: M = matrix(ZZ, [[1, 1, 0], [-1, 1, 1]]); M
+            [ 1  1  0]
+            [-1  1  1]
+            sage: M.is_unimodular()
+            False
+        """
+        from .matrix_cmr_sparse import Matrix_cmr_chr_sparse
+        from .matrix_space import MatrixSpace
+
+        MS = MatrixSpace(ZZ, self.nrows(), self.ncols(), sparse=True)
+        M = Matrix_cmr_chr_sparse(MS, self)
+        return M.is_unimodular()
+
     def LLL_gram(self, flag=0):
         """
         Return the LLL transformation matrix for this Gram matrix.

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -18260,7 +18260,7 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: from sage.matrix.matrix_cmr_sparse import Matrix_cmr_chr_sparse
+            sage: # needs sage.libs.cmr
             sage: M = matrix([[1, 0, 1], [0, 1, 1], [1, 2, 3]]); M
             [1 0 1]
             [0 1 1]
@@ -18276,6 +18276,152 @@ cdef class Matrix(Matrix1):
             True
         """
         return self._matrix_cmr().is_strongly_unimodular(*args, **kwds)
+
+    def equimodulus(self, *args, **kwds):
+        r"""
+        Return the integer `k` such that ``self`` is
+        equimodular with determinant gcd `k`.
+
+        A matrix `M` of rank `r` is equimodular with determinant gcd `k`
+        if the following two conditions are satisfied:
+
+        - for some column basis `B` of `M`, the greatest common divisor of
+          the determinants of all `r`-by-`r` submatrices of `B` is `k`;
+
+        - the matrix `X` such that `M=BX` is totally unimodular.
+
+        OUTPUT:
+
+        - ``k``: ``self`` is equimodular with determinant gcd `k`
+        - ``None``: ``self`` is not equimodular for any `k`
+
+        .. SEEALSO:: :meth:`is_k_equimodular`, :meth:`strong_equimodulus`
+
+        EXAMPLES::
+
+            sage: # needs sage.libs.cmr
+            sage: M = matrix([[1, 0, 1], [0, 1, 1], [1, 2, 3]]); M
+            [1 0 1]
+            [0 1 1]
+            [1 2 3]
+            sage: M.equimodulus()
+            1
+            sage: M = matrix([[1, 1, 1], [0, 1, 3]]); M
+            [1 1 1]
+            [0 1 3]
+            sage: M.equimodulus()
+        """
+        return self._matrix_cmr().equimodulus(*args, **kwds)
+
+    def strong_equimodulus(self, *args, **kwds):
+        r"""
+        Return the integer `k` such that ``self`` is
+        strongly equimodular with determinant gcd `k`.
+
+        Return whether ``self`` is strongly `k`-equimodular.
+
+        A matrix is strongly equimodular if ``self`` and ``self.transpose()``
+        are both equimodular, which implies that they are equimodular for
+        the same determinant gcd `k`.
+        A matrix `M` of rank-`r` is `k`-equimodular if the following two conditions
+        are satisfied:
+
+        - for some column basis `B` of `M`, the greatest common divisor of the
+          determinants of all `r`-by-`r` submatrices of `B` is `k`;
+
+        - the matrix `X` such that `M=BX` is totally unimodular.
+
+        OUTPUT:
+
+        - ``k``: ``self`` is  `k`-equimodular
+        - ``None``: ``self`` is not `k`-equimodular for any `k`
+
+        .. SEEALSO:: :meth:`is_strongly_k_equimodular`, :meth:`equimodulus`
+
+        EXAMPLES::
+
+            sage: # needs sage.libs.cmr
+            sage: M = matrix([[1, 0, 1], [0, 1, 1], [1, 2, 3]]); M
+            [1 0 1]
+            [0 1 1]
+            [1 2 3]
+            sage: M.strong_equimodulus()
+            sage: M = matrix([[1, 0, 0], [0, 1, 0]]); M
+            [1 0 0]
+            [0 1 0]
+            sage: M.strong_equimodulus()
+            1
+        """
+        return self._matrix_cmr().strong_equimodulus(*args, **kwds)
+
+    def is_k_equimodular(self, k, *args, **kwds):
+        r"""
+        Return whether ``self`` is equimodular with determinant gcd `k`.
+
+        A matrix `M` of rank-`r` is `k`-equimodular if the following two
+        conditions are satisfied:
+
+        - for some column basis `B` of `M`, the greatest common divisor of
+          the determinants of all `r`-by-`r` submatrices of `B` is `k`;
+
+        - the matrix `X` such that `M=BX` is totally unimodular.
+
+        If the matrix has full row rank, it is `k`-equimodular if
+        every full rank minor of the matrix has determinant `0,\pm k`.
+
+        .. NOTE::
+
+            In parts of the literature, a matrix with the above properties
+            is called *strictly* `k`-modular.
+
+        .. SEEALSO:: :meth:`is_unimodular`, :meth:`is_strongly_k_equimodular`,
+                     :meth:`equimodulus`
+
+        EXAMPLES::
+
+            sage: # needs sage.libs.cmr
+            sage: M = matrix([[1, 0, 1], [0, 1, 1], [1, 2, 3]]); M
+            [1 0 1]
+            [0 1 1]
+            [1 2 3]
+            sage: M.is_k_equimodular(1)
+            True
+            sage: M.is_k_equimodular(2)
+            False
+            sage: M = matrix([[1, 1, 1], [0, 1, 3]]); M
+            [1 1 1]
+            [0 1 3]
+            sage: M.is_k_equimodular(1)
+            False
+        """
+        return self._matrix_cmr().is_k_equimodular(k, *args, **kwds)
+
+    def is_strongly_k_equimodular(self, k, *args, **kwds):
+        r"""
+        Return whether ``self`` is strongly `k`-equimodular.
+
+        A matrix is strongly `k`-equimodular if ``self`` and ``self.transpose()``
+        are both `k`-equimodular.
+
+        .. SEEALSO:: :meth:`is_k_equimodular`, :meth:`is_strongly_unimodular`,
+                     :meth:`strong_equimodulus`
+
+        EXAMPLES::
+
+            sage: # needs sage.libs.cmr
+            sage: M = matrix([[1, 0, 1], [0, 1, 1], [1, 2, 3]]); M
+            [1 0 1]
+            [0 1 1]
+            [1 2 3]
+            sage: M.is_strongly_k_equimodular(1)
+            False
+            sage: M = matrix([[1, 0, 0], [0, 1, 0]]); M
+            [1 0 0]
+            [0 1 0]
+            sage: M.is_strongly_k_equimodular(1)
+            True
+        """
+        return self._matrix_cmr().is_strongly_k_equimodular(k, *args, **kwds)
 
     def LLL_gram(self, flag=0):
         """

--- a/src/sage/matrix/matrix_cmr_sparse.pyx
+++ b/src/sage/matrix/matrix_cmr_sparse.pyx
@@ -4071,7 +4071,8 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
     def binary_pivot(self, row, column):
         r"""
-        Apply a pivot to ``self`` and returns the resulting matrix.
+        Apply a pivot to ``self`` and return the resulting matrix.
+
         Calculations are done over the binary field.
 
         Suppose a matrix is `\begin{bmatrix} 1 & c^T \\ b & D\end{bmatrix}`.
@@ -4130,7 +4131,8 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
     def binary_pivots(self, rows, columns):
         r"""
-        Apply a sequence of pivots to ``self`` and returns the resulting matrix.
+        Apply a sequence of pivots to ``self`` and return the resulting matrix.
+
         Calculations are done over the binary field.
 
         .. SEEALSO:: :meth:`binary_pivot`, :meth:`ternary_pivot`, :meth:`ternary_pivots`
@@ -4193,7 +4195,8 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
     def ternary_pivot(self, row, column):
         r"""
-        Apply a pivot to ``self`` and returns the resulting matrix.
+        Apply a pivot to ``self`` and return the resulting matrix.
+
         Calculations are done over the ternary field.
 
         Suppose a matrix is `\begin{bmatrix} \epsilon & c^T \\ b & D\end{bmatrix}`,
@@ -4289,7 +4292,8 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
     def ternary_pivots(self, rows, columns):
         r"""
-        Apply a sequence of pivots to ``self`` and returns the resulting matrix.
+        Apply a sequence of pivots to ``self`` and return the resulting matrix.
+
         Calculations are done over the ternary field.
 
         .. SEEALSO:: :meth:`binary_pivot`, :meth:`binary_pivots`, :meth:`ternary_pivot`
@@ -4371,7 +4375,7 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
         A matrix is strongly unimodular if ``self`` and ``self.transpose()`` are both unimodular.
 
-        .. SEEALSO:: meth:`is_unimodular`, :meth:`is_strongly_k_modular`
+        .. SEEALSO:: meth:`is_unimodular`, :meth:`is_strongly_k_equimodular`
 
         EXAMPLES::
 

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -3220,29 +3220,6 @@ cdef class Matrix_integer_dense(Matrix_dense):
         else:
             return R
 
-    def is_unimodular(self):
-        r"""
-        EXAMPLES::
-
-            sage: # needs sage.libs.cmr
-            sage: M = matrix(ZZ, [[1, 0, 0], [0, 1, 0]]); M
-            [1 0 0]
-            [0 1 0]
-            sage: M.is_unimodular()
-            True
-            sage: M = matrix(ZZ, [[1, 1, 0], [-1, 1, 1]]); M
-            [ 1  1  0]
-            [-1  1  1]
-            sage: M.is_unimodular()
-            False
-        """
-        from .matrix_cmr_sparse import Matrix_cmr_chr_sparse
-        from .matrix_space import MatrixSpace
-
-        MS = MatrixSpace(ZZ, self.nrows(), self.ncols(), sparse=True)
-        M = Matrix_cmr_chr_sparse(MS, self)
-        return M.is_unimodular()
-
     def is_LLL_reduced(self, delta=None, eta=None, algorithm='fpLLL'):
         r"""
         Return ``True`` if this lattice is `(\delta, \eta)`-LLL reduced.

--- a/src/sage/matrix/matrix_sparse.pyx
+++ b/src/sage/matrix/matrix_sparse.pyx
@@ -937,18 +937,18 @@ cdef class Matrix_sparse(matrix.Matrix):
 
         cdef Py_ssize_t nrows, ncols, k, i, j
 
-        ncols = PyList_GET_SIZE(columns)
-        nrows = PyList_GET_SIZE(rows)
+        ncols = len(columns)
+        nrows = len(rows)
         cdef Matrix_sparse A = self.new_matrix(nrows=nrows, ncols=ncols)
 
         tmp = [el for el in columns if 0 <= el < self._ncols]
         columns = tmp
-        if ncols != PyList_GET_SIZE(columns):
+        if ncols != len(columns):
             raise IndexError("column index out of range")
 
         tmp = [el for el in rows if 0 <= el < self._nrows]
         rows = tmp
-        if nrows != PyList_GET_SIZE(rows):
+        if nrows != len(rows):
             raise IndexError("row index out of range")
 
         row_map = {}


### PR DESCRIPTION
Also fixes the crash when calling `matrix_from_rows_and_columns` @xuluze @discopt 
