### PR TITLE
.github/workflows/dist.yml: Use 'secrets: inherit' when invoking pypi-publish.yml

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -873,6 +873,7 @@ jobs:
     needs: [sdists_for_pypi, noarch_wheels_for_pypi, build_wheels, build_optional_wheels]
     if: (success() || failure()) && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/pypi-publish.yml
+    secrets: inherit
 
   tox:
     needs: [sdists_for_pypi, noarch_wheels_for_pypi, build_wheels, build_optional_wheels]


### PR DESCRIPTION
- Fixes #864