### PR TITLE
sage.combinat: Mark various poset-related doctests # needs sage.modules

### DIFF
--- a/pkgs/sagemath-combinat/known-test-failures--graphs.json
+++ b/pkgs/sagemath-combinat/known-test-failures--graphs.json
@@ -5,6 +5,12 @@
     "sage.algebras.free_algebra": {
         "ntests": 7
     },
+    "sage.algebras.free_algebra_quotient": {
+        "ntests": 1
+    },
+    "sage.algebras.free_algebra_quotient_element": {
+        "ntests": 2
+    },
     "sage.algebras.hecke_algebras.cubic_hecke_algebra": {
         "ntests": 31
     },
@@ -29,7 +35,7 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 921
+        "ntests": 918
     },
     "sage.arith.numerical_approx": {
         "ntests": 1
@@ -333,7 +339,7 @@
         "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
-        "ntests": 61
+        "ntests": 62
     },
     "sage.categories.finite_dimensional_nilpotent_lie_algebras_with_basis": {
         "ntests": 19
@@ -564,7 +570,7 @@
         "ntests": 19
     },
     "sage.categories.number_fields": {
-        "ntests": 41
+        "ntests": 39
     },
     "sage.categories.objects": {
         "ntests": 12
@@ -1010,13 +1016,12 @@
     },
     "sage.combinat.permutation": {
         "failed": true,
-        "ntests": 1256
+        "ntests": 1252
     },
     "sage.combinat.permutation_cython": {
         "ntests": 39
     },
     "sage.combinat.plane_partition": {
-        "failed": true,
         "ntests": 352
     },
     "sage.combinat.posets.cartesian_product": {
@@ -1036,7 +1041,7 @@
     },
     "sage.combinat.posets.linear_extensions": {
         "failed": true,
-        "ntests": 174
+        "ntests": 169
     },
     "sage.combinat.posets.mobile": {
         "ntests": 36
@@ -1138,7 +1143,6 @@
         "ntests": 289
     },
     "sage.combinat.skew_tableau": {
-        "failed": true,
         "ntests": 372
     },
     "sage.combinat.species.characteristic_species": {
@@ -1232,7 +1236,6 @@
         "ntests": 121
     },
     "sage.combinat.tableau_tuple": {
-        "failed": true,
         "ntests": 658
     },
     "sage.combinat.tamari_lattices": {
@@ -1839,7 +1842,7 @@
         "ntests": 8
     },
     "sage.graphs.graph_generators": {
-        "ntests": 192
+        "ntests": 175
     },
     "sage.graphs.graph_generators_pyx": {
         "ntests": 7
@@ -2346,22 +2349,21 @@
         "ntests": 76
     },
     "sage.repl.ipython_kernel.install": {
-        "failed": true,
         "ntests": 35
     },
     "sage.repl.ipython_kernel.interact": {
-        "ntests": 42
+        "ntests": 40
     },
     "sage.repl.ipython_kernel.kernel": {
         "ntests": 12
     },
     "sage.repl.ipython_kernel.widgets": {
         "failed": true,
-        "ntests": 98
+        "ntests": 96
     },
     "sage.repl.ipython_kernel.widgets_sagenb": {
         "failed": true,
-        "ntests": 77
+        "ntests": 75
     },
     "sage.repl.ipython_tests": {
         "ntests": 26
@@ -2550,7 +2552,7 @@
     },
     "sage.rings.lazy_series": {
         "failed": true,
-        "ntests": 1514
+        "ntests": 1507
     },
     "sage.rings.lazy_series_ring": {
         "failed": true,
@@ -2654,7 +2656,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1845
+        "ntests": 1830
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 194
@@ -2809,7 +2811,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 387
+        "ntests": 381
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -3050,6 +3052,9 @@
     },
     "sage.tests.book_stein_ent": {
         "ntests": 8
+    },
+    "sage.tests.books.computational-mathematics-with-sagemath.graphtheory_doctest": {
+        "ntests": 1
     },
     "sage.tests.books.computational-mathematics-with-sagemath.sol.graphtheory_doctest": {
         "ntests": 6

--- a/pkgs/sagemath-combinat/known-test-failures--modules.json
+++ b/pkgs/sagemath-combinat/known-test-failures--modules.json
@@ -35,6 +35,7 @@
         "ntests": 98
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_morphism": {
+        "failed": true,
         "ntests": 59
     },
     "sage.algebras.finite_gca": {
@@ -47,11 +48,9 @@
         "ntests": 59
     },
     "sage.algebras.free_algebra_quotient": {
-        "failed": true,
         "ntests": 76
     },
     "sage.algebras.free_algebra_quotient_element": {
-        "failed": true,
         "ntests": 42
     },
     "sage.algebras.free_zinbiel_algebra": {
@@ -90,7 +89,7 @@
     },
     "sage.algebras.lie_algebras.lie_algebra_element": {
         "failed": true,
-        "ntests": 328
+        "ntests": 321
     },
     "sage.algebras.lie_algebras.morphism": {
         "ntests": 9
@@ -200,14 +199,6 @@
     "sage.algebras.quantum_oscillator": {
         "ntests": 114
     },
-    "sage.algebras.quaternion_algebra": {
-        "failed": true,
-        "ntests": 3
-    },
-    "sage.algebras.quaternion_algebra_element": {
-        "failed": true,
-        "ntests": 10
-    },
     "sage.algebras.rational_cherednik_algebra": {
         "failed": true,
         "ntests": 41
@@ -249,7 +240,7 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 931
+        "ntests": 928
     },
     "sage.arith.numerical_approx": {
         "ntests": 4
@@ -323,8 +314,7 @@
         "ntests": 9
     },
     "sage.categories.algebras": {
-        "failed": true,
-        "ntests": 36
+        "ntests": 31
     },
     "sage.categories.algebras_with_basis": {
         "ntests": 53
@@ -817,7 +807,7 @@
         "ntests": 19
     },
     "sage.categories.number_fields": {
-        "ntests": 41
+        "ntests": 39
     },
     "sage.categories.objects": {
         "ntests": 12
@@ -2361,7 +2351,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2008
+        "ntests": 2004
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -2771,12 +2761,14 @@
         "ntests": 52
     },
     "sage.modules.fp_graded.free_homspace": {
+        "failed": true,
         "ntests": 8
     },
     "sage.modules.fp_graded.free_module": {
         "ntests": 178
     },
     "sage.modules.fp_graded.free_morphism": {
+        "failed": true,
         "ntests": 54
     },
     "sage.modules.fp_graded.homspace": {
@@ -2889,6 +2881,7 @@
         "ntests": 222
     },
     "sage.modules.with_basis.morphism": {
+        "failed": true,
         "ntests": 353
     },
     "sage.modules.with_basis.subquotient": {
@@ -3066,22 +3059,21 @@
         "ntests": 76
     },
     "sage.repl.ipython_kernel.install": {
-        "failed": true,
         "ntests": 35
     },
     "sage.repl.ipython_kernel.interact": {
         "failed": true,
-        "ntests": 42
+        "ntests": 40
     },
     "sage.repl.ipython_kernel.kernel": {
         "ntests": 12
     },
     "sage.repl.ipython_kernel.widgets": {
-        "ntests": 98
+        "ntests": 96
     },
     "sage.repl.ipython_kernel.widgets_sagenb": {
         "failed": true,
-        "ntests": 77
+        "ntests": 75
     },
     "sage.repl.ipython_tests": {
         "ntests": 26
@@ -3445,11 +3437,10 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1944
+        "ntests": 1906
     },
     "sage.rings.polynomial.polynomial_element_generic": {
-        "failed": true,
-        "ntests": 204
+        "ntests": 198
     },
     "sage.rings.polynomial.polynomial_quotient_ring": {
         "ntests": 33
@@ -3462,8 +3453,7 @@
         "ntests": 128
     },
     "sage.rings.polynomial.polynomial_ring": {
-        "failed": true,
-        "ntests": 420
+        "ntests": 412
     },
     "sage.rings.polynomial.polynomial_ring_constructor": {
         "failed": true,
@@ -3633,7 +3623,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 391
+        "ntests": 385
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -3745,13 +3735,13 @@
     },
     "sage.stats.basic_stats": {
         "failed": true,
-        "ntests": 52
+        "ntests": 53
     },
     "sage.stats.distributions.catalog": {
         "ntests": 1
     },
     "sage.stats.distributions.discrete_gaussian_lattice": {
-        "ntests": 115
+        "ntests": 116
     },
     "sage.stats.distributions.discrete_gaussian_polynomial": {
         "ntests": 24
@@ -3953,6 +3943,9 @@
     },
     "sage.tests.book_stein_ent": {
         "ntests": 8
+    },
+    "sage.tests.books.computational-mathematics-with-sagemath.graphtheory_doctest": {
+        "ntests": 1
     },
     "sage.tests.books.judson-abstract-algebra.cyclic-sage": {
         "ntests": 5

--- a/pkgs/sagemath-combinat/known-test-failures.json
+++ b/pkgs/sagemath-combinat/known-test-failures.json
@@ -8,6 +8,12 @@
     "sage.algebras.free_algebra": {
         "ntests": 7
     },
+    "sage.algebras.free_algebra_quotient": {
+        "ntests": 1
+    },
+    "sage.algebras.free_algebra_quotient_element": {
+        "ntests": 2
+    },
     "sage.algebras.hecke_algebras.cubic_hecke_algebra": {
         "ntests": 31
     },
@@ -32,7 +38,7 @@
     },
     "sage.arith.misc": {
         "failed": true,
-        "ntests": 921
+        "ntests": 918
     },
     "sage.arith.numerical_approx": {
         "ntests": 1
@@ -325,7 +331,7 @@
         "ntests": 34
     },
     "sage.categories.finite_dimensional_modules_with_basis": {
-        "ntests": 63
+        "ntests": 64
     },
     "sage.categories.finite_dimensional_nilpotent_lie_algebras_with_basis": {
         "ntests": 19
@@ -550,7 +556,7 @@
         "ntests": 19
     },
     "sage.categories.number_fields": {
-        "ntests": 41
+        "ntests": 39
     },
     "sage.categories.objects": {
         "ntests": 12
@@ -1919,22 +1925,21 @@
         "ntests": 76
     },
     "sage.repl.ipython_kernel.install": {
-        "failed": true,
         "ntests": 35
     },
     "sage.repl.ipython_kernel.interact": {
-        "ntests": 42
+        "ntests": 40
     },
     "sage.repl.ipython_kernel.kernel": {
         "ntests": 12
     },
     "sage.repl.ipython_kernel.widgets": {
         "failed": true,
-        "ntests": 98
+        "ntests": 96
     },
     "sage.repl.ipython_kernel.widgets_sagenb": {
         "failed": true,
-        "ntests": 77
+        "ntests": 75
     },
     "sage.repl.ipython_tests": {
         "ntests": 26
@@ -2123,7 +2128,7 @@
     },
     "sage.rings.lazy_series": {
         "failed": true,
-        "ntests": 1514
+        "ntests": 1507
     },
     "sage.rings.lazy_series_ring": {
         "failed": true,
@@ -2227,7 +2232,7 @@
     },
     "sage.rings.polynomial.polynomial_element": {
         "failed": true,
-        "ntests": 1845
+        "ntests": 1830
     },
     "sage.rings.polynomial.polynomial_element_generic": {
         "ntests": 194
@@ -2376,7 +2381,7 @@
     },
     "sage.schemes.generic.morphism": {
         "failed": true,
-        "ntests": 387
+        "ntests": 381
     },
     "sage.schemes.generic.point": {
         "ntests": 35
@@ -2617,6 +2622,9 @@
     },
     "sage.tests.book_stein_ent": {
         "ntests": 8
+    },
+    "sage.tests.books.computational-mathematics-with-sagemath.graphtheory_doctest": {
+        "ntests": 1
     },
     "sage.tests.books.judson-abstract-algebra.cyclic-sage": {
         "ntests": 5

--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -365,11 +365,11 @@ class IncidenceStructure:
             True
             sage: ["Am", "I", "finally", "done ?"] in IS
             False
-            sage: IS = designs.ProjectiveGeometryDesign(3, 1, GF(2),                    # needs sage.combinat
+            sage: IS = designs.ProjectiveGeometryDesign(3, 1, GF(2),                    # needs sage.combinat sage.modules
             ....:                                       point_coordinates=False)
-            sage: [3,8,7] in IS                                                         # needs sage.combinat
+            sage: [3,8,7] in IS                                                         # needs sage.combinat sage.modules
             True
-            sage: [3,8,9] in IS                                                         # needs sage.combinat
+            sage: [3,8,9] in IS                                                         # needs sage.combinat sage.modules
             False
         """
         try:
@@ -1508,10 +1508,10 @@ class IncidenceStructure:
             sage: BD.is_t_design(0,6,3,7) or BD.is_t_design(0,7,4,7) or BD.is_t_design(0,7,3,8)
             False
 
-            sage: BD = designs.AffineGeometryDesign(3, 1, GF(2))                        # needs sage.combinat
-            sage: BD.is_t_design(1)                                                     # needs sage.combinat
+            sage: BD = designs.AffineGeometryDesign(3, 1, GF(2))                        # needs sage.combinat sage.modules
+            sage: BD.is_t_design(1)                                                     # needs sage.combinat sage.modules
             True
-            sage: BD.is_t_design(2)                                                     # needs sage.combinat
+            sage: BD.is_t_design(2)                                                     # needs sage.combinat sage.modules
             True
 
         Steiner triple and quadruple systems are other names for `2-(v,3,1)` and
@@ -1924,8 +1924,8 @@ class IncidenceStructure:
             sage: TD.is_resolvable()
             True
 
-            sage: AG = designs.AffineGeometryDesign(3,1,GF(2))                          # needs sage.combinat
-            sage: AG.is_resolvable()                                                    # needs sage.combinat
+            sage: AG = designs.AffineGeometryDesign(3,1,GF(2))                          # needs sage.combinat sage.modules
+            sage: AG.is_resolvable()                                                    # needs sage.combinat sage.modules
             True
 
         Their classes::

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -5510,7 +5510,7 @@ class Permutation(CombinatorialElement):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat sage.graphs
+            sage: # needs sage.combinat sage.graphs sage.modules
             sage: sigma = Permutations(5).identity()
             sage: list(sigma.nth_roots(3))
             [[1, 4, 3, 5, 2], [1, 5, 3, 2, 4], [1, 2, 4, 5, 3], [1, 2, 5, 3, 4],
@@ -8752,7 +8752,7 @@ class StandardPermutations_recoilsfatter(Permutations):
         TESTS::
 
             sage: P = Permutations(recoils_fatter=[2,2])
-            sage: TestSuite(P).run()                                                    # needs sage.graphs
+            sage: TestSuite(P).run()                                                    # needs sage.graphs sage.modules
         """
         Permutations.__init__(self, category=FiniteEnumeratedSets())
         self.recoils = recoils
@@ -8827,7 +8827,7 @@ class StandardPermutations_recoils(Permutations):
         TESTS::
 
             sage: P = Permutations(recoils=[2,2])
-            sage: TestSuite(P).run()                                                    # needs sage.graphs
+            sage: TestSuite(P).run()                                                    # needs sage.graphs sage.modules
         """
         Permutations.__init__(self, category=FiniteEnumeratedSets())
         self.recoils = recoils

--- a/src/sage/combinat/plane_partition.py
+++ b/src/sage/combinat/plane_partition.py
@@ -2117,7 +2117,7 @@ class PlanePartitions_CSPP(PlanePartitions):
             sage: PP = PlanePartitions([3,3,3], symmetry='CSPP')
             sage: PP.to_poset()                                                         # needs sage.graphs
             Finite poset containing 11 elements
-            sage: PP.to_poset().order_ideals_lattice().cardinality() == PP.cardinality()            # needs sage.graphs
+            sage: PP.to_poset().order_ideals_lattice().cardinality() == PP.cardinality()            # needs sage.graphs sage.modules
             True
         """
         a = self._box[0]

--- a/src/sage/combinat/posets/linear_extension_iterator.pyx
+++ b/src/sage/combinat/posets/linear_extension_iterator.pyx
@@ -160,6 +160,8 @@ def _linear_extension_gen(_D, list _le, list _a, list _b, list _is_plus, Py_ssiz
     if i == -1:
         return
 
+    import sage.matrix  # otherwise there will be a lot of "Exception ignored in: 'linear_extension_iterator._linear_extension_right_b'"
+
     for e in _linear_extension_gen(_D, _le, _a, _b, _is_plus, i-1):
         yield e
     mrb = 0

--- a/src/sage/combinat/posets/linear_extensions.py
+++ b/src/sage/combinat/posets/linear_extensions.py
@@ -532,7 +532,7 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
             True
             sage: L._poset is P
             True
-            sage: TestSuite(L).run()
+            sage: TestSuite(L).run()                                                    # needs sage.modules
 
             sage: P = Poset((divisors(15), attrcall("divides")))
             sage: L = P.linear_extensions()
@@ -732,6 +732,7 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
+            sage: # needs sage.modules
             sage: P = Poset(([1,2,3,4], [[1,3],[1,4],[2,3]]), linear_extension=True)
             sage: L = P.linear_extensions()
             sage: G = L.markov_chain_digraph(); G

--- a/src/sage/combinat/ribbon_shaped_tableau.py
+++ b/src/sage/combinat/ribbon_shaped_tableau.py
@@ -411,7 +411,7 @@ class StandardRibbonShapedTableaux_shape(StandardRibbonShapedTableaux):
         TESTS::
 
             sage: S = StandardRibbonShapedTableaux([2,2])
-            sage: TestSuite(S).run()                                                    # needs sage.graphs
+            sage: TestSuite(S).run()                                                    # needs sage.graphs sage.modules
         """
         self.shape = shape
         StandardRibbonShapedTableaux.__init__(self, FiniteEnumeratedSets())

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -2088,7 +2088,7 @@ class StandardSkewTableaux_all(StandardSkewTableaux):
         EXAMPLES::
 
             sage: s = StandardSkewTableaux()
-            sage: TestSuite(s).run()                                                    # needs sage.graphs
+            sage: TestSuite(s).run()                                                    # needs sage.graphs sage.modules
         """
         StandardSkewTableaux.__init__(self, category=InfiniteEnumeratedSets())
 

--- a/src/sage/combinat/tableau.py
+++ b/src/sage/combinat/tableau.py
@@ -7292,7 +7292,7 @@ class RowStandardTableaux_all(RowStandardTableaux, DisjointUnionEnumeratedSets):
         TESTS::
 
             sage: ST = RowStandardTableaux()
-            sage: TestSuite(ST).run()                                                   # needs sage.graphs
+            sage: TestSuite(ST).run()                                                   # needs sage.graphs sage.modules
         """
         RowStandardTableaux.__init__(self)
         DisjointUnionEnumeratedSets.__init__(self,
@@ -7317,9 +7317,9 @@ class RowStandardTableaux_size(RowStandardTableaux, DisjointUnionEnumeratedSets)
 
         sage: [t for t in RowStandardTableaux(1)]                                       # needs sage.graphs
         [[[1]]]
-        sage: [t for t in RowStandardTableaux(2)]                                       # needs sage.graphs
+        sage: [t for t in RowStandardTableaux(2)]                                       # needs sage.graphs sage.modules
         [[[1, 2]], [[2], [1]], [[1], [2]]]
-        sage: list(RowStandardTableaux(3))                                              # needs sage.graphs
+        sage: list(RowStandardTableaux(3))                                              # needs sage.graphs sage.modules
         [[[1, 2, 3]],
          [[2, 3], [1]],
          [[1, 2], [3]],
@@ -7356,8 +7356,8 @@ class RowStandardTableaux_size(RowStandardTableaux, DisjointUnionEnumeratedSets)
 
         TESTS::
 
-            sage: TestSuite(RowStandardTableaux(0)).run()                               # needs sage.graphs
-            sage: TestSuite(RowStandardTableaux(3)).run()                               # needs sage.graphs
+            sage: TestSuite(RowStandardTableaux(0)).run()                               # needs sage.graphs sage.modules
+            sage: TestSuite(RowStandardTableaux(3)).run()                               # needs sage.graphs sage.modules
         """
         RowStandardTableaux.__init__(self)
         from sage.combinat.partition import Partitions_n
@@ -7380,10 +7380,10 @@ class RowStandardTableaux_size(RowStandardTableaux, DisjointUnionEnumeratedSets)
         TESTS::
 
             sage: ST3 = RowStandardTableaux(3)
-            sage: all(st in ST3 for st in ST3)                                          # needs sage.graphs
+            sage: all(st in ST3 for st in ST3)                                          # needs sage.graphs sage.modules
             True
             sage: ST4 = RowStandardTableaux(4)
-            sage: [x for x in ST4 if x in ST3]                                          # needs sage.graphs
+            sage: [x for x in ST4 if x in ST3]                                          # needs sage.graphs sage.modules
             []
 
         Check that :issue:`14145` is fixed::
@@ -7426,7 +7426,7 @@ class RowStandardTableaux_shape(RowStandardTableaux):
 
         TESTS::
 
-            sage: TestSuite( RowStandardTableaux([2,1,1]) ).run()                       # needs sage.graphs
+            sage: TestSuite( RowStandardTableaux([2,1,1]) ).run()                       # needs sage.graphs sage.modules
         """
         super().__init__(category=FiniteEnumeratedSets())
         self.shape = p
@@ -7436,9 +7436,9 @@ class RowStandardTableaux_shape(RowStandardTableaux):
         EXAMPLES::
 
             sage: ST = RowStandardTableaux([2,1,1])
-            sage: all(st in ST for st in ST)                                            # needs sage.graphs
+            sage: all(st in ST for st in ST)                                            # needs sage.graphs sage.modules
             True
-            sage: len([x for x in RowStandardTableaux(4) if x in ST])                   # needs sage.graphs
+            sage: len([x for x in RowStandardTableaux(4) if x in ST])                   # needs sage.graphs sage.modules
             12
             sage: ST.cardinality()
             12
@@ -7461,14 +7461,14 @@ class RowStandardTableaux_shape(RowStandardTableaux):
 
         EXAMPLES::
 
-            sage: [t for t in RowStandardTableaux([2,2])]                               # needs sage.graphs
+            sage: [t for t in RowStandardTableaux([2,2])]                               # needs sage.graphs sage.modules
             [[[2, 4], [1, 3]],
              [[3, 4], [1, 2]],
              [[1, 4], [2, 3]],
              [[1, 3], [2, 4]],
              [[1, 2], [3, 4]],
              [[2, 3], [1, 4]]]
-            sage: [t for t in RowStandardTableaux([3,2])]                               # needs sage.graphs
+            sage: [t for t in RowStandardTableaux([3,2])]                               # needs sage.graphs sage.modules
             [[[2, 4, 5], [1, 3]],
              [[3, 4, 5], [1, 2]],
              [[1, 4, 5], [2, 3]],
@@ -7480,7 +7480,7 @@ class RowStandardTableaux_shape(RowStandardTableaux):
              [[2, 3, 4], [1, 5]],
              [[2, 3, 5], [1, 4]]]
             sage: st = RowStandardTableaux([2,1])
-            sage: st[0].parent() is st                                                  # needs sage.graphs
+            sage: st[0].parent() is st                                                  # needs sage.graphs sage.modules
             True
         """
         partial_sums = [sum(self.shape[:i]) for i in range(len(self.shape)+1)]

--- a/src/sage/combinat/tableau_tuple.py
+++ b/src/sage/combinat/tableau_tuple.py
@@ -3519,9 +3519,9 @@ class RowStandardTableauTuples_shape(RowStandardTableauTuples):
 
         EXAMPLES::
 
-            sage: RowStandardTableauTuples([[2],[2,1]]).an_element()                    # needs sage.graphs
+            sage: RowStandardTableauTuples([[2],[2,1]]).an_element()                    # needs sage.graphs sage.modules
             ([[4, 5]], [[1, 3], [2]])
-            sage: RowStandardTableauTuples([[10],[],[]]).an_element()                   # needs sage.graphs
+            sage: RowStandardTableauTuples([[10],[],[]]).an_element()                   # needs sage.graphs sage.modules
             ([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]], [], [])
         """
         c = self.cardinality()

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -2746,7 +2746,7 @@ def distance_regular_graph(list arr, existence=False, check=True):
         Graph on 1024 vertices
         sage: graphs.distance_regular_graph([6,5,5,5,1,1,1,6])  # optional - database_graphs
         Generalised octagon of order (1, 5): Graph on 312 vertices
-        sage: graphs.distance_regular_graph([64, 60, 1, 1, 15, 64], check=True)
+        sage: graphs.distance_regular_graph([64, 60, 1, 1, 15, 64], check=True)         # needs sage.libs.gap
         Graph on 325 vertices
     """
     from sage.misc.unknown import Unknown

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -379,7 +379,7 @@ suitable for inclusion in a `\LaTeX` document.  More details on this are at the
 
     sage: from sage.graphs.graph_latex import check_tkz_graph
     sage: check_tkz_graph()  # random - depends on TeX installation
-    sage: latex(G)
+    sage: latex(G)                                                                      # needs sage.plot
     \begin{tikzpicture}
     ...
     \end{tikzpicture}

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3130,7 +3130,7 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         sage: M = random_matrix(K, 3, 3, algorithm="diagonalizable")
         sage: M.parent()
         Full MatrixSpace of 3 by 3 dense matrices over Finite Field of size 3
-        sage: M.is_diagonalizable()
+        sage: M.is_diagonalizable()                                                     # needs sage.libs.pari
         True
         sage: M  # random
         [0 0 1]

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -529,7 +529,7 @@ def _default_engine():
         sage: def crash():
         ....:     raise ValueError
         sage: sage.misc.latex._default_engine = crash
-        sage: latex(matrix.identity(QQ, 2))
+        sage: latex(matrix.identity(QQ, 2))                                             # needs sage.modules
         \left(\begin{array}{rr}
         1 & 0 \\
         0 & 1


### PR DESCRIPTION
- **src/sage/combinat/designs/incidence_structures.py: Add # needs**
- **src/sage/combinat/posets/linear_extension_iterator.pyx: Explicitly import sage.matrix**
- **src/sage/combinat: Mark various poset-related doctests # needs sage.modules**
- **Various # needs**
- **./sage --fixdoctests --distribution 'sagemath-combinat[*]' --update-known-test-failures**
