### PR TITLE
fix a typo from sagemath-eclib to sagemath-ecl in constraints_pkgs.txt

### DIFF
--- a/constraints_pkgs.txt
+++ b/constraints_pkgs.txt
@@ -31,7 +31,7 @@ passagemath-categories            @ file://${SAGE_ROOT}/pkgs/sagemath-categories
 passagemath-cddlib                @ file://${SAGE_ROOT}/pkgs/sagemath-cddlib
 passagemath-combinat              @ file://${SAGE_ROOT}/pkgs/sagemath-combinat
 passagemath-coxeter3              @ file://${SAGE_ROOT}/pkgs/sagemath-coxeter3
-passagemath-ecl                   @ file://${SAGE_ROOT}/pkgs/sagemath-eclib
+passagemath-ecl                   @ file://${SAGE_ROOT}/pkgs/sagemath-ecl
 passagemath-eclib                 @ file://${SAGE_ROOT}/pkgs/sagemath-eclib
 passagemath-environment           @ file://${SAGE_ROOT}/pkgs/sagemath-environment
 passagemath-flint                 @ file://${SAGE_ROOT}/pkgs/sagemath-flint


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

I also need to `pip install jinja2` in the virtual environment to install `passagemath-standard` successfully for dependance of `passagemath-modules` and `passagemath-catagories`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


