### PR TITLE
exceptiongroup, importlib_metadata, importlib_resources, typing_extensions: Require 3.12 features

### DIFF
--- a/build/pkgs/exceptiongroup/version_requirements.txt
+++ b/build/pkgs/exceptiongroup/version_requirements.txt
@@ -1,1 +1,3 @@
-exceptiongroup; python_version<"3.11"
+# According to https://github.com/agronholm/exceptiongroup/blob/main/CHANGES.rst,
+# 1.20 provides a backport from Python 3.12.1
+exceptiongroup >=1.2.0

--- a/build/pkgs/importlib_resources/distros/gentoo.txt
+++ b/build/pkgs/importlib_resources/distros/gentoo.txt
@@ -1,1 +1,0 @@
-dev-python/importlib_resources

--- a/build/pkgs/typing_extensions/version_requirements.txt
+++ b/build/pkgs/typing_extensions/version_requirements.txt
@@ -1,1 +1,11 @@
+<<<<<<< HEAD
 typing_extensions
+||||||| parent of 5c8c557bf2d (build/pkgs/exceptiongroup: Require >= 1.2.0)
+# According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
+# version 4.4.0 adds another Python 3.11 typing backport
+typing_extensions >= 4.4.0; python_version<'3.11'
+=======
+# According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
+# version 4.7.0 adds another Python 3.12 typing backport
+typing_extensions >= 4.7.0; python_version<'3.12'
+>>>>>>> 5c8c557bf2d (build/pkgs/exceptiongroup: Require >= 1.2.0)

--- a/build/pkgs/typing_extensions/version_requirements.txt
+++ b/build/pkgs/typing_extensions/version_requirements.txt
@@ -1,11 +1,1 @@
-<<<<<<< HEAD
 typing_extensions
-||||||| parent of 5c8c557bf2d (build/pkgs/exceptiongroup: Require >= 1.2.0)
-# According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
-# version 4.4.0 adds another Python 3.11 typing backport
-typing_extensions >= 4.4.0; python_version<'3.11'
-=======
-# According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
-# version 4.7.0 adds another Python 3.12 typing backport
-typing_extensions >= 4.7.0; python_version<'3.12'
->>>>>>> 5c8c557bf2d (build/pkgs/exceptiongroup: Require >= 1.2.0)

--- a/src/doc/en/developer/coding_in_python.rst
+++ b/src/doc/en/developer/coding_in_python.rst
@@ -46,7 +46,7 @@ using one of two mechanisms:
     (to be used in place of ``typing``).
 
   The Sage library declares these packages as dependencies and ensures that
-  versions that provide features of Python 3.11 are available.
+  versions that provide features of Python 3.12 are available.
 
 Meta :issue:`29756` keeps track of newer Python features and serves
 as a starting point for discussions on how to make use of them in the

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -47,8 +47,8 @@ dependencies = [
     'primecountpy',
     'requests >=2.13.0',
     # According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
-    # version 4.4.0 adds another Python 3.11 typing backport
-    'typing_extensions >= 4.4.0; python_version<"3.11"',
+    # version 4.7.0 adds another Python 3.12 typing backport
+    'typing_extensions >= 4.7.0; python_version<"3.12"',
     # From Makefile.in: SAGERUNTIME
     'ipython >=7.13.0',
     'pexpect >=4.8.0',

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -33,11 +33,11 @@ dependencies = [
     'cython >=3.0, != 3.0.3, <4.0',
     'gmpy2 ~=2.1.b999',
     # According to https://pypi.org/project/importlib-metadata/,
-    # 4.13 provides the features of Python 3.11 importlib.metadata
-    'importlib_metadata >=4.13; python_version<"3.11"',
+    # 6.5 provides the features of Python 3.12 importlib.metadata
+    'importlib_metadata >=6.5; python_version<"3.12"',
     # According to https://pypi.org/project/importlib-resources/,
-    # version 5.7 provides the features of Python 3.11 importlib.resources
-    'importlib_resources >= 5.7; python_version<"3.11"',
+    # version 5.7 provides the features of Python 3.12 importlib.resources
+    'importlib_resources >= 5.12; python_version<"3.12"',
     'lrcalc ~=2.1',
     'memory_allocator',
     'numpy >=1.19',


### PR DESCRIPTION
We tighten the lower bounds of these backport packages in install-requires so that the features of Python 3.12 can be used.

Rebased from: 
- https://github.com/sagemath/sage/pull/37402