### PR TITLE
build/pkgs/_prereq/distros/arch.txt: Add bison (for macaulay2)

### DIFF
--- a/build/pkgs/_prereq/distros/arch.txt
+++ b/build/pkgs/_prereq/distros/arch.txt
@@ -19,3 +19,5 @@ gcc
 flex
 # Needed for 4ti2:
 which
+# Needed for macaulay2:
+bison


### PR DESCRIPTION
```
  [macaulay2-git]   [spkg-install] CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
  [macaulay2-git]   [spkg-install]   Could NOT find BISON (missing: BISON_EXECUTABLE)
```
https://github.com/passagemath/M2/actions/runs/15029437670/job/42822578109#step:11:6056