### PR TITLE
build/pkgs/normaliz: Disable use of cocoalib as a workaround for M2

### DIFF
--- a/build/pkgs/normaliz/spkg-install.in
+++ b/build/pkgs/normaliz/spkg-install.in
@@ -10,6 +10,8 @@ cd src
 
 export ac_cv_lib_flint_fmpz_poly_set_coeff_mpz=yes
 
-sdh_configure --with-flint --with-e-antic --with-nauty
+# --without-cocoalib is a workaround for https://github.com/Macaulay2/M2/issues/3849
+# It can be overridden by setting NORMALIZ_CONFIGURE
+sdh_configure --with-flint --with-e-antic --with-nauty --without-cocoalib $NORMALIZ_CONFIGURE
 sdh_make
 sdh_make_install


### PR DESCRIPTION
Workaround for:
- https://github.com/Macaulay2/M2/issues/3849
