### PR TITLE
build/pkgs/py4ti2: Switch to release on PyPI

### DIFF
--- a/build/pkgs/py4ti2/checksums.ini
+++ b/build/pkgs/py4ti2/checksums.ini
@@ -1,4 +1,4 @@
-tarball=VERSION.tar.gz
-sha1=60c1019ef63f7d76b8cb287a987713cbe067537d
-sha256=90ef5b24e4d48c81711441b6288a8e77edb899d50208daf60a6398c1e96c6ed8
-upstream_url=https://github.com/alfsan/Py4ti2/archive/VERSION.tar.gz
+tarball=py4ti2-VERSION.tar.gz
+sha1=80b81ce92288fb78d1a0125b6bea505ed391fd69
+sha256=37cfc3b495ac4e2cca0d1925062b774ff0f32ed131e1380b9d332e919f710f64
+upstream_url=https://files.pythonhosted.org/packages/source/p/py4ti2/py4ti2-VERSION.tar.gz

--- a/build/pkgs/py4ti2/package-version.txt
+++ b/build/pkgs/py4ti2/package-version.txt
@@ -1,1 +1,1 @@
-12c2a69c755b19eb3f3ff615ba830faccbd6f6e2
+0.5.1


### PR DESCRIPTION
https://pypi.org/project/Py4ti2/ is now up, thanks @alfsan