### PR TITLE
docbuild fixes

### DIFF
--- a/src/doc/en/developer/sage_manuals.rst
+++ b/src/doc/en/developer/sage_manuals.rst
@@ -120,9 +120,6 @@ for more information.
    * - :ref:`CVXpy <spkg_cvxpy>`
      - ``:class:`~cvxpy.atoms.log_det.log_det```
      - :class:`~cvxpy.atoms.log_det.log_det`
-   * - :ref:`cypari2 <spkg_cypari>`
-     - ``:class:`cypari2.gen.Gen```
-     - :class:`cypari2.gen.Gen`
    * - :ref:`cysignals <spkg_cysignals>`
      - ``:envvar:`CYSIGNALS_CRASH_DAYS```
      - :envvar:`CYSIGNALS_CRASH_DAYS`

--- a/src/doc/en/reference/interfaces/index.rst
+++ b/src/doc/en/reference/interfaces/index.rst
@@ -79,12 +79,13 @@ and testing to make sure nothing funny is going on).
 
    sage/interfaces/fricas
 
-.. ONLY:: feature_frobby
+..
+   .. ONLY:: feature_frobby
 
-   .. toctree::
-      :maxdepth: 1
+      .. toctree::
+         :maxdepth: 1
 
-      sage/interfaces/frobby
+         sage/interfaces/frobby
 
 .. toctree::
    :maxdepth: 1

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -677,8 +677,8 @@ class sage__libs__pari(JoinFeature):
     r"""
     A :class:`~sage.features.Feature` describing the presence of :mod:`sage.libs.pari`.
 
-    SageMath uses the :ref:`PARI <spkg_pari>` library (via :ref:`cypari2
-    <spkg_cypari>`) for numerous purposes.  Doctests that involves such features
+    SageMath uses the :ref:`PARI <spkg_pari>` library (via :mod:`cypari2`)
+    for numerous purposes.  Doctests that involves such features
     should be marked ``# needs sage.libs.pari``.
 
     In addition to the modularization purposes that this tag serves, it also

--- a/src/sage/matrix/matrix_cmr_sparse.pyx
+++ b/src/sage/matrix/matrix_cmr_sparse.pyx
@@ -624,6 +624,7 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
         Return the 2-sum matrix constructed from the given matrices ``first_mat`` and
         ``second_mat``, with index of the first matrix ``first_index`` and index
         of the second matrix ``second_index``.
+
         Suppose that ``first_index`` indicates the last column of ``first_mat`` and
         ``second_index`` indicates the first row of ``second_mat``,
         i.e., the first matrix is
@@ -635,8 +636,9 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
         M_1 \oplus_2 M_2 = \begin{bmatrix}
         A & ab^T \\
         0 & D
-        \end{bmatrix},
+        \end{bmatrix}.
         `
+
         Suppose that ``first_index`` indicates the last row of ``first_mat`` and
         ``second_index`` indicates the first column of ``second_mat``,
         i.e., the first matrix is
@@ -644,7 +646,8 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
         and the second matrix is
         `M_2=\begin{bmatrix} d & D\end{bmatrix}`.
         Then the two sum
-        `M_1 \oplus_2 M_2 = \begin{bmatrix}
+        `
+        M_1 \oplus_2 M_2 = \begin{bmatrix}
         A & 0 \\
         dc^T & D
         \end{bmatrix}.


### PR DESCRIPTION
- **src/doc/en/reference/interfaces/index.rst: Omit frobby for now**
- **Remove use of <spkg_cypari> in doc**
- **src/sage/matrix/matrix_cmr_sparse.pyx: Fix doctest markup**
