### PR TITLE
Replace module-level imports from sage.misc.misc

### DIFF
--- a/src/sage/databases/sql_db.py
+++ b/src/sage/databases/sql_db.py
@@ -79,7 +79,7 @@ AUTHORS:
 import sqlite3 as sqlite
 import os
 import re
-from sage.misc.temporary_file import tmp_filename
+
 from sage.structure.sage_object import SageObject
 
 sqlite_keywords = ['ABORT','ACTION','ADD','AFTER','ALL','ALTER','ANALYZE',
@@ -1087,6 +1087,7 @@ class SQLDatabase(SageObject):
         if filename is None:
             if read_only is None:
                 read_only = False
+            from sage.misc.temporary_file import tmp_filename
             filename = tmp_filename() + '.db'
         elif (filename[-3:] != '.db'):
             raise ValueError('Please enter a valid database path (file name '
@@ -1189,6 +1190,7 @@ class SQLDatabase(SageObject):
             4                    1                    978932
         """
         # copy .db file
+        from sage.misc.temporary_file import tmp_filename
         new_loc = tmp_filename() + '.db'
         if not self.__read_only__:
             self.commit()

--- a/src/sage/functions/transcendental.py
+++ b/src/sage/functions/transcendental.py
@@ -20,7 +20,6 @@ import math
 import sys
 
 from sage.misc.lazy_import import lazy_import
-from sage.misc.misc import increase_recursion_limit
 from sage.rings.integer_ring import ZZ
 from sage.symbolic.function import GinacFunction, BuiltinFunction
 
@@ -555,6 +554,9 @@ class DickmanRho(BuiltinFunction):
             return 1 - x.log()
         n = x.floor()
         if self._cur_prec < x.parent().prec() or n not in self._f:
+
+            from sage.misc.misc import increase_recursion_limit
+
             self._cur_prec = rel_prec = x.parent().prec()
             # Go a bit beyond so we're not constantly re-computing.
             max = x.parent()(1.1)*x + 10

--- a/src/sage/geometry/cone_critical_angles.py
+++ b/src/sage/geometry/cone_critical_angles.py
@@ -36,7 +36,6 @@ methods have been prefixed with an underscore.
 from sage.functions.trig import arccos, cos
 from sage.matrix.constructor import matrix
 from sage.misc.lazy_import import lazy_import
-from sage.misc.misc import powerset
 from sage.rings.integer_ring import ZZ
 from sage.rings.qqbar import AA
 from sage.rings.rational_field import QQ

--- a/src/sage/graphs/graph_list.py
+++ b/src/sage/graphs/graph_list.py
@@ -19,9 +19,6 @@ AUTHORS:
 # ****************************************************************************
 
 
-from sage.misc.misc import try_read
-
-
 def from_whatever(data):
     r"""
     Return a list of Sage Graphs, given a list of whatever kind of data.
@@ -78,6 +75,8 @@ def _from_whatever(data, fmt=None):
     if isinstance(data, str):
         lines = data.splitlines()
     else:
+        from sage.misc.misc import try_read
+
         lines = try_read(data, splitlines=True)
 
         if lines is not None and fmt is None:

--- a/src/sage/modular/hecke/morphism.py
+++ b/src/sage/modular/hecke/morphism.py
@@ -26,7 +26,6 @@ AUTHORS:
 # ****************************************************************************
 
 
-import sage.misc.misc as misc
 from sage.modules.matrix_morphism import MatrixMorphism
 from sage.categories.morphism import Morphism
 
@@ -165,9 +164,11 @@ class HeckeModuleMorphism_matrix(MatrixMorphism, HeckeModuleMorphism):
             sage: t.name('spam'); t._repr_()
             'Hecke module morphism spam defined by the matrix\n[0 1 2]\n[3 4 5]\n[6 7 8]\nDomain: Modular Symbols space of dimension 3 for Gamma_0(6) of weight ...\nCodomain: Modular Symbols space of dimension 3 for Gamma_0(6) of weight ...'
         """
+        from sage.misc.misc import strunc
+
         name = self.__name
         if name:
             name += ' '
-        return "Hecke module morphism %sdefined by the matrix\n%r\nDomain: %s\nCodomain: %s" % (name, self.matrix(), misc.strunc(self.domain()), misc.strunc(self.codomain()))
+        return "Hecke module morphism %sdefined by the matrix\n%r\nDomain: %s\nCodomain: %s" % (name, self.matrix(), strunc(self.domain()), strunc(self.codomain()))
 
 # __mul__ method removed by David Loeffler 2009-04-14 as it is an exact duplicate of sage.modules.matrix_morphism.__mul__

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -135,8 +135,6 @@ from sage.misc.fast_methods import WithEqualityById
 from sage.structure.sage_object import SageObject
 from sage.misc.temporary_file import tmp_dir, tmp_filename
 from . import plot
-import sage.misc.misc
-import sage.misc.viewer
 
 
 def animate(frames, **kwds):

--- a/src/sage/rings/complex_mpfr.pyx
+++ b/src/sage/rings/complex_mpfr.pyx
@@ -33,8 +33,6 @@ AUTHORS:
 import re
 import weakref
 
-import sage.misc.misc
-
 from sage.libs.mpfr cimport *
 
 from sage.structure.parent cimport Parent

--- a/src/sage/rings/number_field/number_field_ideal.py
+++ b/src/sage/rings/number_field/number_field_ideal.py
@@ -36,7 +36,6 @@ import sage.rings.rational_field as rational_field
 import sage.rings.integer_ring as integer_ring
 from sage.arith.misc import kronecker as kronecker_symbol
 from sage.arith.misc import GCD as gcd
-import sage.misc.misc as misc
 from sage.rings.finite_rings.finite_field_constructor import FiniteField
 
 from sage.rings.ideal import Ideal_generic, Ideal_fractional
@@ -1862,7 +1861,7 @@ class NumberFieldFractionalIdeal(MultiplicativeGroupElement, NumberFieldIdeal, I
             raise ValueError("gens must have length at least 1 (zero ideal is not a fractional ideal)")
         if len(gens) == 1 and isinstance(gens[0], (list, tuple)):
             gens = gens[0]
-        if misc.exists(gens,bool)[0]:
+        if any(bool(x) for x in gens):
             NumberFieldIdeal.__init__(self, field, gens)
         else:
             raise ValueError("gens must have a nonzero element (zero ideal is not a fractional ideal)")

--- a/src/sage/rings/number_field/totallyreal_phc.py
+++ b/src/sage/rings/number_field/totallyreal_phc.py
@@ -18,7 +18,6 @@ AUTHORS:
 # ****************************************************************************
 
 import os
-import sage.misc.misc
 
 
 def coefficients_to_power_sums(n, m, a):
@@ -101,7 +100,8 @@ def __lagrange_bounds_phc(n, m, a, tmpfile=None):
 
     # Initialization.
     if tmpfile is None:
-        tmpfile = sage.misc.misc.tmp_filename()
+        from sage.misc.temporary_file import tmp_filename
+        tmpfile = tmp_filename()
     f = open(tmpfile + '.phc', 'w')
     f.close()
 

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -1796,8 +1796,10 @@ cdef class Polynomial(CommutativePolynomial):
         except AttributeError:
             first_coeff = A(~const_term)
 
+        from sage.misc.misc import newton_method_sizes
+
         current = R(first_coeff)
-        for next_prec in sage.misc.misc.newton_method_sizes(prec)[1:]:
+        for next_prec in newton_method_sizes(prec)[1:]:
             z = current._mul_trunc_(self, next_prec)._mul_trunc_(current, next_prec)
             current = current + current - z
         return current

--- a/src/sage/rings/power_series_ring_element.pyx
+++ b/src/sage/rings/power_series_ring_element.pyx
@@ -102,7 +102,6 @@ from sage.rings.infinity import infinity, InfinityElement
 from sage.rings.rational_field import QQ
 
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-import sage.misc.misc
 import sage.arith.all as arith
 import sage.misc.latex
 from sage.rings.integer import Integer
@@ -1676,8 +1675,10 @@ cdef class PowerSeries(AlgebraElement):
             a = a.change_ring(R)
         half = ~R(2)
 
+        from sage.misc.misc import newton_method_sizes
+
         s = a.parent()([s])
-        for cur_prec in sage.misc.misc.newton_method_sizes(prec)[1:]:
+        for cur_prec in newton_method_sizes(prec)[1:]:
             (<PowerSeries>s)._prec = cur_prec
             s = half * (s + a/s)
 

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -593,7 +593,6 @@ from sage.categories.action import Action
 from sage.misc.cachefunc import cached_method
 from sage.misc.fast_methods import Singleton
 from sage.misc.lazy_string import lazy_string
-from sage.misc.misc import increase_recursion_limit
 from sage.rings import infinity
 from sage.rings.cc import CC
 from sage.rings.cif import CIF
@@ -8791,6 +8790,8 @@ class ANBinaryExpr(ANDescr):
             1000
             sage: sys.setrecursionlimit(old_recursion_limit)
         """
+        from sage.misc.misc import increase_recursion_limit
+
         with increase_recursion_limit(10):
             left = self._left
             right = self._right

--- a/src/sage/sandpiles/sandpile.py
+++ b/src/sage/sandpiles/sandpile.py
@@ -339,7 +339,6 @@ from sage.graphs.digraph import DiGraph
 from sage.graphs.graph import Graph
 from sage.misc.functional import det, denominator
 from sage.misc.lazy_import import lazy_import
-from sage.misc.misc import exists
 from sage.misc.misc_c import prod
 from sage.misc.temporary_file import tmp_filename
 from sage.rings.integer import Integer
@@ -1542,7 +1541,7 @@ class Sandpile(DiGraph):
         else:
             rec = list(self.recurrents())
             for r in self.recurrents():
-                if exists(rec, lambda x: r > x)[0]:
+                if any(r > x for x in rec):
                     rec.remove(r)
         self._min_recurrents = rec
 

--- a/src/sage/schemes/elliptic_curves/formal_group.py
+++ b/src/sage/schemes/elliptic_curves/formal_group.py
@@ -14,7 +14,6 @@ AUTHORS:
 
 from sage.structure.sage_object import SageObject
 
-import sage.misc.misc as misc
 from sage.rings.power_series_ring import PowerSeriesRing
 from sage.rings.laurent_series_ring import LaurentSeriesRing
 from sage.rings.big_oh import O
@@ -182,8 +181,10 @@ class EllipticCurveFormalGroup(SageObject):
         numerator_const = w.parent()([0, 0, 0, 1])      # z^3
         denominator_const = w.parent()([1, -a1, -a2])   # 1 - a_1 z - a_2 z^2
 
+        from sage.misc.misc import newton_method_sizes
+
         last_prec = 0
-        for next_prec in misc.newton_method_sizes(prec):
+        for next_prec in newton_method_sizes(prec):
             if next_prec > current_prec:
                 if w.degree() - 1 > last_prec:
                     # Here it's best to throw away some precision to get us

--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -29,7 +29,6 @@ from sage.arith.misc import valuation
 from sage.matrix.constructor import Matrix as matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
-from sage.misc.misc import newton_method_sizes
 from sage.rings.big_oh import O
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Integers
@@ -1790,6 +1789,8 @@ def _brent(F, p, N):
 
     # initial approximation:
     G = Rx.one()
+
+    from sage.misc.misc import newton_method_sizes
 
     # loop over an appropriate increasing sequence of lengths s
     for s in newton_method_sizes(N):

--- a/src/sage/schemes/generic/algebraic_scheme.py
+++ b/src/sage/schemes/generic/algebraic_scheme.py
@@ -123,7 +123,6 @@ from sage.rings.rational_field import RationalField
 from sage.rings.finite_rings.finite_field_base import FiniteField
 
 from sage.misc.latex import latex
-from sage.misc.misc import is_iterator
 
 from sage.structure.all import Sequence
 from sage.structure.richcmp import richcmp, richcmp_method
@@ -937,11 +936,13 @@ class AlgebraicScheme_subscheme(AlgebraicScheme):
             polynomials = I.gens()
             if I.ring() is R:  # Otherwise we will recompute I later after
                 self.__I = I  # converting generators to the correct ring
-        if isinstance(polynomials, (tuple, PolynomialSequence_generic)) or is_iterator(polynomials):
-            polynomials = list(polynomials)
-        elif not isinstance(polynomials, list):
+        try:
+            it = iter(polynomials)
+        except Exception:
             # Looks like we got a single polynomial
             polynomials = [polynomials]
+        else:
+            polynomials = list(polynomials)
         for n, f in enumerate(polynomials):
             try:
                 polynomials[n] = R(f)

--- a/src/sage/schemes/hyperelliptic_curves/monsky_washnitzer.py
+++ b/src/sage/schemes/hyperelliptic_curves/monsky_washnitzer.py
@@ -53,7 +53,6 @@ from sage.categories.integral_domains import IntegralDomains
 from sage.matrix.constructor import matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
-from sage.misc.misc import newton_method_sizes
 from sage.misc.profiler import Profiler
 from sage.misc.repr import repr_lincomb
 from sage.modules.free_module import FreeModule
@@ -3741,6 +3740,8 @@ class MonskyWashnitzerDifferentialRing(UniqueRepresentation, Module):
         #        t = self.base_ring()(1)
         t = self.base_ring()(three_halves) - half_a
         # first iteration trivial, start with prec 2
+
+        from sage.misc.misc import newton_method_sizes
 
         for cur_prec in newton_method_sizes(prec)[2:]:
             # newton_method_sizes = [1, 2, ...]


### PR DESCRIPTION
`sage.misc.misc` pulls in `sage.env`, thus a dependency on **passagemath-environment**.
