### PR TITLE
Allow running configure && make on mingw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ build/make/Makefile: configure $(SPKG_COLLECT_FILES) $(CONFIG_FILES:%=%.in)
 reconfigure:
 	rm -f config.log
 	mkdir -p logs/pkgs
+	touch logs/pkgs/config.log
 	ln -s logs/pkgs/config.log config.log
 	@if [ -x config.status ]; then \
 		./config.status --recheck && ./config.status; \

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ dnl The following are all supported platforms.
 *-*-freebsd*);;
 *-*-linux*);;
 *-*-darwin*);;
+*-*-mingw*);;
 
 dnl Wildcard for unsupported platforms
 *)

--- a/configure.ac
+++ b/configure.ac
@@ -554,16 +554,23 @@ AC_CONFIG_COMMANDS(mkdirs,
         mkdir -p "$SAGE_BUILD_DIR" || AC_MSG_ERROR([error creating directory $SAGE_BUILD_DIR (SAGE_BUILD_DIR)])
         rm -f "$SAGE_BUILD_DIR"/conftest
         touch "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([error creating a file in $SAGE_BUILD_DIR])
-        chmod +x "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([error setting file permissions +x in $SAGE_BUILD_DIR])
-        test -x "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([file permissions +x did not persist in $SAGE_BUILD_DIR])
-        chmod -x "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([error setting file permissions -x in $SAGE_BUILD_DIR])
-        test -x "$SAGE_BUILD_DIR"/conftest && AC_MSG_ERROR([file permissions -x did not persist in $SAGE_BUILD_DIR])
-        rm -f "$SAGE_BUILD_DIR"/conftest
+        case $host in
+            *-*-mingw*)
+                ;;
+            *)
+                chmod +x "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([error setting file permissions +x in $SAGE_BUILD_DIR])
+                test -x "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([file permissions +x did not persist in $SAGE_BUILD_DIR])
+                chmod -x "$SAGE_BUILD_DIR"/conftest || AC_MSG_ERROR([error setting file permissions -x in $SAGE_BUILD_DIR])
+                test -x "$SAGE_BUILD_DIR"/conftest && AC_MSG_ERROR([file permissions -x did not persist in $SAGE_BUILD_DIR])
+                rm -f "$SAGE_BUILD_DIR"/conftest
+                ;;
+        esac
     ],
     [
         SAGE_LOGS="$SAGE_ROOT/logs/pkgs"
         SAGE_LOCAL="$SAGE_LOCAL"
         SAGE_SHARE="$SAGE_LOCAL/share"
+        host="$host"
     ])
 
 AC_CONFIG_COMMANDS(links, [


### PR DESCRIPTION
- **configure.ac: Allow building on mingw**
- **configure.ac [mingw]: Disable file permissions test**
- **Makefile (reconfigure): Create logs/pkgs/config.log before symlinking to it (for mingw)**
