### PR TITLE
src/sage_setup: Use platform.system instead of os.uname (for mingw)

### DIFF
--- a/src/sage_setup/__init__.py
+++ b/src/sage_setup/__init__.py
@@ -45,8 +45,9 @@ def sage_setup(distributions, *,
 
     # Work around a Cython problem in Python 3.8.x on macOS
     # https://github.com/cython/cython/issues/3262
-    import os
-    if os.uname().sysname == 'Darwin':
+
+    import platform
+    if platform.system() == 'Darwin':
         import multiprocessing
         multiprocessing.set_start_method('fork', force=True)
 

--- a/src/sage_setup/__init__.py
+++ b/src/sage_setup/__init__.py
@@ -72,6 +72,7 @@ def sage_setup(distributions, *,
     import setuptools.command.egg_info
     setuptools.command.egg_info.walk_revctrl = lambda: ()
 
+    import os
     import sys
 
     from sage_setup.excepthook import excepthook


### PR DESCRIPTION
- **src/sage_setup/__init__.py: Use platform.system instead of os.uname (for mingw)**
- **src/sage_setup/__init__.py: Use platform.system instead of os.uname (for mingw), fixup**
