### PR TITLE
build/pkgs/gmp: Do not build static libs; import patches from gmpy2

### DIFF
--- a/build/pkgs/gmp/patches/fat_build_fix.patch
+++ b/build/pkgs/gmp/patches/fat_build_fix.patch
@@ -1,0 +1,18 @@
+--- mpn/x86_64/fat/fat.c
++++ mpn/x86_64/fat/fat.c
+@@ -375,6 +375,7 @@ __gmpn_cpuvec_init (void)
+	      CPUVEC_SETUP_core2;
+	      CPUVEC_SETUP_coreinhm;
+	      CPUVEC_SETUP_coreisbr;
++         __gmpn_cpuid (dummy_string, 7);
+	      if ((dummy_string[0 + BMI2_BIT / 8] & (1 << (BMI2_BIT % 8))) == 0)
+		break;
+	      CPUVEC_SETUP_coreihwl;
+@@ -388,6 +389,7 @@ __gmpn_cpuvec_init (void)
+	      CPUVEC_SETUP_core2;
+	      CPUVEC_SETUP_coreinhm;
+	      CPUVEC_SETUP_coreisbr;
++         __gmpn_cpuid (dummy_string, 7);
+	      if ((dummy_string[0 + BMI2_BIT / 8] & (1 << (BMI2_BIT % 8))) == 0)
+		break;
+	      if (gmp_workaround_skylake_cpuid_bug ())

--- a/build/pkgs/gmp/patches/fat_build_fix.patch
+++ b/build/pkgs/gmp/patches/fat_build_fix.patch
@@ -1,5 +1,5 @@
---- mpn/x86_64/fat/fat.c
-+++ mpn/x86_64/fat/fat.c
+--- a/mpn/x86_64/fat/fat.c
++++ b/mpn/x86_64/fat/fat.c
 @@ -375,6 +375,7 @@ __gmpn_cpuvec_init (void)
 	      CPUVEC_SETUP_core2;
 	      CPUVEC_SETUP_coreinhm;

--- a/build/pkgs/gmp/patches/mp_bitcnt_t.patch
+++ b/build/pkgs/gmp/patches/mp_bitcnt_t.patch
@@ -1,0 +1,25 @@
+--- gmp-h.in.orig	2024-03-24 10:55:03.711573465 +0300
++++ gmp-h.in	2024-03-24 10:58:02.762349548 +0300
+@@ -143,7 +143,11 @@
+ typedef long int		mp_limb_signed_t;
+ #endif
+ #endif
++#if defined(_WIN64)
++typedef unsigned long long int	mp_bitcnt_t;
++#else
+ typedef unsigned long int	mp_bitcnt_t;
++#endif
+ 
+ /* For reference, note that the name __mpz_struct gets into C++ mangled
+    function names, which means although the "__" suggests an internal, we
+--- mpz/millerrabin.c.orig	2024-03-24 10:59:05.420511561 +0300
++++ mpz/millerrabin.c	2024-03-24 10:59:11.428335102 +0300
+@@ -59,7 +59,7 @@
+ 
+ static int millerrabin (mpz_srcptr,
+ 			mpz_ptr, mpz_ptr,
+-			mpz_srcptr, unsigned long int);
++			mpz_srcptr, mp_bitcnt_t);
+ 
+ int
+ mpz_millerrabin (mpz_srcptr n, int reps)

--- a/build/pkgs/gmp/patches/mp_bitcnt_t.patch
+++ b/build/pkgs/gmp/patches/mp_bitcnt_t.patch
@@ -1,5 +1,5 @@
---- gmp-h.in.orig	2024-03-24 10:55:03.711573465 +0300
-+++ gmp-h.in	2024-03-24 10:58:02.762349548 +0300
+--- a/gmp-h.in	2024-03-24 10:55:03.711573465 +0300
++++ b/gmp-h.in	2024-03-24 10:58:02.762349548 +0300
 @@ -143,7 +143,11 @@
  typedef long int		mp_limb_signed_t;
  #endif
@@ -12,8 +12,8 @@
  
  /* For reference, note that the name __mpz_struct gets into C++ mangled
     function names, which means although the "__" suggests an internal, we
---- mpz/millerrabin.c.orig	2024-03-24 10:59:05.420511561 +0300
-+++ mpz/millerrabin.c	2024-03-24 10:59:11.428335102 +0300
+--- a/mpz/millerrabin.c	2024-03-24 10:59:05.420511561 +0300
++++ b/mpz/millerrabin.c	2024-03-24 10:59:11.428335102 +0300
 @@ -59,7 +59,7 @@
  
  static int millerrabin (mpz_srcptr,

--- a/build/pkgs/gmp/spkg-install.in
+++ b/build/pkgs/gmp/spkg-install.in
@@ -75,9 +75,8 @@ export ABI CFLAGS CXXFLAGS LDFLAGS # Partially redundant, but safe(r).
 
 GMP_CONFIGURE="--enable-shared $GMP_CONFIGURE"
 
-# Also build the static library to be used by e.g. ECM
-echo "Building GMP with the C++ interface and (also) static libraries."
-GMP_CONFIGURE="--enable-cxx --enable-static $GMP_CONFIGURE"
+echo "Building GMP with the C++ interface."
+GMP_CONFIGURE="--enable-cxx $GMP_CONFIGURE"
 
 # If SAGE_FAT_BINARY is enabled, then add --enable-fat to configure
 # options on Linux x86 systems.  On other systems, fat binaries are not

--- a/build/pkgs/gmp/spkg-install.in
+++ b/build/pkgs/gmp/spkg-install.in
@@ -73,7 +73,7 @@ export ABI CFLAGS CXXFLAGS LDFLAGS # Partially redundant, but safe(r).
 # Now configure GMP, eventually modifying CFLAGS [further]:
 ###############################################################################
 
-GMP_CONFIGURE="--enable-shared $GMP_CONFIGURE"
+GMP_CONFIGURE="--enable-shared --disable-static $GMP_CONFIGURE"
 
 echo "Building GMP with the C++ interface."
 GMP_CONFIGURE="--enable-cxx $GMP_CONFIGURE"


### PR DESCRIPTION
- **build/pkgs/gmp: Do not build static libraries**
- **build/pkgs/gmp: Do not build static libraries (fixup)**
- **build/pkgs/gmp: Import patches from https://github.com/aleaxit/gmpy/tree/master/scripts**
- **build/pkgs/gmp: Adjust patch format**
