### PR TITLE
sage.doctest: Properly set 'serial' on Windows, properly ensure DOT_SAGE exists

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -116,12 +116,7 @@ class DocTestDefaults(SageObject):
         # These are only basic defaults when invoking the doctest runner
         # from Python, which is not the typical use case.
         self.nthreads = 1
-        try:
-            from signal import SIGCHLD
-        except ImportError:
-            self.serial = True
-        else:
-            self.serial = False
+        self.serial = False
         self.timeout = -1
         self.die_timeout = -1
         self.all = False
@@ -465,6 +460,10 @@ class DocTestController(SageObject):
                 print("Debugging is not compatible with logging, disabling logfile.")
             options.serial = True
             options.logfile = None
+        try:
+            from signal import SIGCHLD
+        except ImportError:
+            options.serial = True
         if options.serial:
             options.nthreads = 1
         if options.verbose:

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -166,10 +166,6 @@ class DocTestDefaults(SageObject):
         # < 0: disable GC
         self.gc = 0
 
-        # Do not assume that sage.misc.misc has been loaded,
-        # which creates DOT_SAGE as a side effect.
-        os.makedirs(DOT_SAGE, mode=0o700, exist_ok=True)
-
         # We don't want to use the real stats file by default so that
         # we don't overwrite timings for the actual running doctests.
         self.stats_path = os.path.join(
@@ -584,6 +580,10 @@ class DocTestController(SageObject):
             self.logger = self._real_stdout
         else:
             self.logger = Logger(self._real_stdout, self.logfile)
+
+        # Do not assume that sage.misc.misc has been loaded,
+        # which creates DOT_SAGE as a side effect.
+        os.makedirs(DOT_SAGE, mode=0o700, exist_ok=True)
 
         self.stats = {}
         self.load_stats(options.stats_path)


### PR DESCRIPTION
- **src/sage/doctest/control.py: Set serial in DocTestController.__init__**
- **src/sage/doctest/control.py: Ensure DOT_SAGE exists in DocTestController.__init__**
