### PR TITLE
Fixes for Windows wheel build

### DIFF
--- a/.github/workflows/dist-wheels-windows.yml
+++ b/.github/workflows/dist-wheels-windows.yml
@@ -267,6 +267,23 @@ jobs:
           name: noarch-wheels-windows
           path: dist
 
+      - name: Retrieve SAGE_LOCAL cache
+        id:   cache-sage-local
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            config.status
+            sage-local
+          key: >-
+            ${{ runner.os }}-cibuildwheel-${{ matrix.arch }}-build=${{
+              hashFiles('build',
+                        'configure.ac',
+                        'm4',
+                        '!build/pkgs/*/src')
+            }}
+          restore-keys: |
+            ${{ runner.os }}-cibuildwheel-${{ matrix.arch }}
+
       - name: Retrieve configure tarball cache
         id: cache-configure
         uses: actions/cache/restore@v4
@@ -300,22 +317,6 @@ jobs:
             build/pkgs/configure
             upstream/configure*
           key: ${{ steps.cache-configure.outputs.cache-primary-key }}
-
-      - name: Retrieve SAGE_LOCAL cache
-        id:   cache-sage-local
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            config.status
-            sage-local
-          key: >-
-            ${{ runner.os }}-cibuildwheel-${{ matrix.arch }}-build=${{
-              hashFiles('build',
-                        'configure.ac',
-                        'm4')
-            }}
-          restore-keys: |
-            ${{ runner.os }}-cibuildwheel-${{ matrix.arch }}
 
       - name: Unpack and prepare
         id: unpack

--- a/.github/workflows/dist-wheels-windows.yml
+++ b/.github/workflows/dist-wheels-windows.yml
@@ -211,7 +211,7 @@ jobs:
       CIBW_PROJECT_REQUIRES_PYTHON: ${{ github.event_name == 'pull_request' && '>=3.10, <3.11' || '>=3.10, <3.14' }}
       # Run before wheel build
       CIBW_BEFORE_BUILD_WINDOWS: |
-        pip install delvewheel && msys2 -c "set -x; cat constraints.txt && (echo passagemath-conf @ file:///D:/a/sage/sage/pkgs/sage-conf && echo passagemath-setup @ file:///D:/a/sage/sage/pkgs/sage-setup && echo passagemath-environment @ file:///D:/a/sage/sage/pkgs/sagemath-environment) > constraints.txt && cat constraints.txt"
+        pip install delvewheel && msys2 -c "set -x; cat constraints.txt && (echo passagemath-conf @ file:///${GITHUB_WORKSPACE}/pkgs/sage-conf && echo passagemath-setup @ file:///${GITHUB_WORKSPACE}/pkgs/sage-setup && echo passagemath-environment @ file:///${GITHUB_WORKSPACE}/pkgs/sagemath-environment) > constraints.txt && cat constraints.txt"
       # Environment during wheel build
       # PYTHONUTF8=1 is for delvewheel
       CIBW_ENVIRONMENT: >-

--- a/build/pkgs/boost_cropped/spkg-install.in
+++ b/build/pkgs/boost_cropped/spkg-install.in
@@ -1,5 +1,7 @@
 cd src
 sdh_cmake -GNinja \
+      -DBUILD_STATIC_LIBS=OFF \
+      -DBUILD_SHARED_LIBS=ON \
       -DBOOST_INSTALL_LAYOUT=tagged \
       .
 cmake --build .

--- a/build/pkgs/boost_cropped/spkg-install.in
+++ b/build/pkgs/boost_cropped/spkg-install.in
@@ -1,8 +1,11 @@
 cd src
+# BOOST_EXCLUDE_LIBRARIES: A semicolon-separated list of libraries to exclude
+# - we exclude cobalt to avoid 'file INSTALL cannot find ".../libboost_cobalt-mt.a"'
 sdh_cmake -GNinja \
       -DBUILD_STATIC_LIBS=OFF \
       -DBUILD_SHARED_LIBS=ON \
       -DBOOST_INSTALL_LAYOUT=tagged \
+      -DBOOST_EXCLUDE_LIBRARIES="cobalt" \
       .
 cmake --build .
 DESTDIR=$SAGE_DESTDIR cmake --install .

--- a/build/pkgs/zlib/spkg-install.in
+++ b/build/pkgs/zlib/spkg-install.in
@@ -11,7 +11,7 @@ fi
 # incompatibilities
 ./configure --shared --prefix="$SAGE_LOCAL" --libdir="$SAGE_LOCAL/lib" || sdh_die "Error configuring $PKG_NAME"
 
-sdh_make
-sdh_make_install
+sdh_make -j1
+sdh_make_install -j1
 
 sdh_generate_windows_lib_files z

--- a/src/sage/all__sagemath_bliss.py
+++ b/src/sage/all__sagemath_bliss.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-bliss
+# delvewheel: patch

--- a/src/sage/all__sagemath_coxeter3.py
+++ b/src/sage/all__sagemath_coxeter3.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-coxeter3
+# delvewheel: patch

--- a/src/sage/all__sagemath_glpk.py
+++ b/src/sage/all__sagemath_glpk.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-glpk
+# delvewheel: patch

--- a/src/sage/all__sagemath_lcalc.py
+++ b/src/sage/all__sagemath_lcalc.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-lcalc
+# delvewheel: patch

--- a/src/sage/all__sagemath_libecm.py
+++ b/src/sage/all__sagemath_libecm.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-libecm
+# delvewheel: patch

--- a/src/sage/all__sagemath_linbox.py
+++ b/src/sage/all__sagemath_linbox.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-linbox
+# delvewheel: patch

--- a/src/sage/all__sagemath_mcqd.py
+++ b/src/sage/all__sagemath_mcqd.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-mcqd
+# delvewheel: patch

--- a/src/sage/all__sagemath_meataxe.py
+++ b/src/sage/all__sagemath_meataxe.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-meataxe
+# delvewheel: patch

--- a/src/sage/all__sagemath_tdlib.py
+++ b/src/sage/all__sagemath_tdlib.py
@@ -1,1 +1,2 @@
 # sage_setup: distribution = sagemath-tdlib
+# delvewheel: patch


### PR DESCRIPTION
- **.github/workflows/dist-wheels-windows.yml: Use GITHUB_WORKSPACE in constraints**
- **src/sage/all__*.py: Add missing '# delvewheel: patch' directives**
- **.github/workflows/dist-wheels-windows.yml: Compute SAGE_LOCAL cache hash key before bootstrapping**
- **build/pkgs/zlib/spkg-install.in: Build and install with -j1**
- **build/pkgs/boost_cropped/spkg-install.in: Disable static libs**
- **build/pkgs/boost_cropped: Disable cobalt**
