### PR TITLE
passagemath-flint: Remove dependency on passagemath-ntl

### DIFF
--- a/build/pkgs/sagemath_flint/dependencies
+++ b/build/pkgs/sagemath_flint/dependencies
@@ -1,1 +1,1 @@
-$(SAGE_ROOT)/pkgs/sagemath-flint/pyproject.toml $(SAGE_ROOT)/pkgs/sagemath-flint/MANIFEST.in $(PYTHON) sagemath_categories sagemath_ntl flint | $(PYTHON_TOOLCHAIN) sage_setup cython pkgconfig sage_conf
+$(SAGE_ROOT)/pkgs/sagemath-flint/pyproject.toml $(SAGE_ROOT)/pkgs/sagemath-flint/MANIFEST.in $(PYTHON) sagemath_categories flint | $(PYTHON_TOOLCHAIN) sage_setup cython pkgconfig sage_conf

--- a/pkgs/sagemath-flint/pyproject.toml.m4
+++ b/pkgs/sagemath-flint/pyproject.toml.m4
@@ -10,7 +10,6 @@ requires = [
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_modules
-    SPKG_INSTALL_REQUIRES_sagemath_ntl
     SPKG_INSTALL_REQUIRES_cython
     SPKG_INSTALL_REQUIRES_gmpy2
     SPKG_INSTALL_REQUIRES_cysignals
@@ -23,7 +22,6 @@ name = "passagemath-flint"
 description = "passagemath: Fast computations with MPFI and FLINT"
 dependencies = [
     SPKG_INSTALL_REQUIRES_sagemath_categories
-    SPKG_INSTALL_REQUIRES_sagemath_ntl
     SPKG_INSTALL_REQUIRES_numpy
 ]
 dynamic = ["version"]

--- a/src/sage/all__sagemath_flint.py
+++ b/src/sage/all__sagemath_flint.py
@@ -16,7 +16,7 @@ This distribution makes the following features available::
     FeatureTestResult('sage.rings.real_interval_field', True)
 """
 
-from .all__sagemath_ntl import *
+from .all__sagemath_categories import *
 
 from .libs.all__sagemath_flint import *
 

--- a/src/sage/rings/all__sagemath_flint.py
+++ b/src/sage/rings/all__sagemath_flint.py
@@ -1,6 +1,11 @@
 # sage_setup: distribution = sagemath-flint
 
-from sage.rings.all__sagemath_ntl import *
+from sage.rings.all__sagemath_categories import *
+
+try:
+    from sage.rings.all__sagemath_ntl import *
+except ImportError:
+    pass
 
 # Real numbers
 from sage.rings.real_arb import RealBallField, RBF

--- a/src/sage/rings/padics/all__sagemath_flint.py
+++ b/src/sage/rings/padics/all__sagemath_flint.py
@@ -1,3 +1,3 @@
 # sage_setup: distribution = sagemath-flint
 
-from sage.rings.padics.all__sagemath_ntl import *
+from sage.rings.padics.all__sagemath_categories import *


### PR DESCRIPTION
Biggest obstacle: Currently `sage.rings.number_field.number_field_element` depends on NTL.

(`sage.rings.number_field.number_field_element_quadratic` depends on both NTL and FLINT (arb)).