### PR TITLE
pkgs/sagemath-latte-4ti2: Fix for relocatable LattE/4ti2 binaries

### DIFF
--- a/pkgs/sagemath-latte-4ti2/repair_wheel.py
+++ b/pkgs/sagemath-latte-4ti2/repair_wheel.py
@@ -17,7 +17,7 @@ wheel = Path(sys.argv[1])
 
 # SAGE_LOCAL/bin/* --> sage_wheels/bin/*
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/{{ConvertCDDextToLatte,ConvertCDDineToLatte,count,count-linear-forms-from-polynomial,ehrhart,ehrhart3,hilbert-from-rays,hilbert-from-rays-symm,integrate,latte-maximize,latte-minimize,latte2ext,latte2ine,polyhedron-to-cones,top-ehrhart-knapsack,triangulate}} share/latte-int/{{m-knapsack.mpl,simplify*.add}} bin/{{4ti2gmp,4ti2int32,4ti2int64,circuits,genmodel,gensymm,graver,groebner,hilbert,markov,minimize,normalform,output,ppi,qsolve,rays,walk,zbasis,zsolve}}) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/{{ConvertCDDextToLatte,ConvertCDDineToLatte,count,count-linear-forms-from-polynomial,ehrhart,ehrhart3,hilbert-from-rays,hilbert-from-rays-symm,integrate,latte-maximize,latte-minimize,latte2ext,latte2ine,polyhedron-to-cones,top-ehrhart-knapsack,triangulate}}* share/latte-int/{{m-knapsack.mpl,simplify*.add}} bin/{{4ti2gmp,4ti2int32,4ti2int64,circuits,genmodel,gensymm,graver,groebner,hilbert,markov,minimize,normalform,output,ppi,qsolve,rays,walk,zbasis,zsolve}}*) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:


### PR DESCRIPTION
Report:

Following the example at [pypi.org/project/passagemath-polyhedra/](http://pypi.org/project/passagemath-polyhedra/), I defined P = polytopes.cube() and ran P.integral_points_count(). That worked fine. I then successively ran 

    (2*P).integral_points_count(), 
    (3*P).integral_points_count(), and 
    (4*P).integral_points_count(), 

and those all worked fine.

However, when I ran (5*P).integral_points_count(), I got an error: "[/Users/tmcal/passagemath-venv/lib/python3.9/site-packages/sage_wheels/bin/count](https://file+.vscode-resource.vscode-cdn.net/Users/tmcal/passagemath-venv/lib/python3.9/site-packages/sage_wheels/bin/count):
 could not execute [/Users/tmcal/passagemath-venv/lib/python3.9/site-packages/sage_wheels/bin/count.bin](https://file+.vscode-resource.vscode-cdn.net/Users/tmcal/passagemath-venv/lib/python3.9/site-packages/sage_wheels/bin/count.bin):
 No such file or directory"

Looking in the Finder, I do indeed find a binary called count in passagemath-venv/lib/python3.9/site-packages/sage_wheels/bin/, but there is no file or folder called count.bin there.