### PR TITLE
pkgs/sagemath-brial: Set runtime dependencies, set up testing

### DIFF
--- a/pkgs/sagemath-brial/pyproject.toml.m4
+++ b/pkgs/sagemath-brial/pyproject.toml.m4
@@ -28,6 +28,8 @@ content-type = "text/x-rst"
 
 [project.optional-dependencies]
 test = [
+     "passagemath-modules",
+     "passagemath-pari",
      "passagemath-repl",
 ]
 

--- a/pkgs/sagemath-brial/pyproject.toml.m4
+++ b/pkgs/sagemath-brial/pyproject.toml.m4
@@ -5,7 +5,6 @@ requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
     SPKG_INSTALL_REQUIRES_sage_setup
-    SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_objects
     SPKG_INSTALL_REQUIRES_cython
@@ -18,6 +17,7 @@ name = "passagemath-brial"
 description = "passagemath: Boolean Ring Algebra with BRiAl"
 dependencies = [
     SPKG_INSTALL_REQUIRES_cysignals
+    SPKG_INSTALL_REQUIRES_sagemath_categories
 ]
 dynamic = ["version"]
 include(`pyproject_toml_metadata.m4')dnl'
@@ -28,7 +28,6 @@ content-type = "text/x-rst"
 
 [project.optional-dependencies]
 test = [
-     "passagemath-categories",
      "passagemath-repl",
 ]
 

--- a/pkgs/sagemath-brial/tox.ini
+++ b/pkgs/sagemath-brial/tox.ini
@@ -66,6 +66,9 @@ commands =
     # Beware of the treacherous non-src layout. "./sage/" shadows the installed sage package.
     {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); import sage.all__sagemath_brial; import sage.rings.polynomial.pbori'
 
+    !notest:        bash -c 'cd $(python -c "import sys; \"\" in sys.path and sys.path.remove(\"\"); from sage.env import SAGE_LIB; print(SAGE_LIB)") \
+    !notest:                 && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_brial --probe all --baseline-stats-path=$KNOWN_TEST_FAILURES --optional=sage sage/crypto sage/rings/polynomial sage/sat'
+
 [testenv:.tox]
 # Allow access to PyPI for auto-provisioning a suitable tox version
 passenv =

--- a/src/sage/all__sagemath_brial.py
+++ b/src/sage/all__sagemath_brial.py
@@ -2,3 +2,8 @@
 # delvewheel: patch
 
 from .all__sagemath_categories import *
+
+try:
+    from .all__sagemath_modules import *
+except ImportError:
+    pass

--- a/src/sage/rings/polynomial/all.py
+++ b/src/sage/rings/polynomial/all.py
@@ -18,12 +18,5 @@ Polynomials
 
 from sage.rings.polynomial.all__sagemath_polyhedra import *
 
-from sage.misc.lazy_import import lazy_import
-
 # Generic convolution
 from sage.rings.polynomial.convolution import convolution
-
-# Boolean Polynomial Rings
-from sage.rings.polynomial.polynomial_ring_constructor import BooleanPolynomialRing_constructor as BooleanPolynomialRing
-
-del lazy_import

--- a/src/sage/rings/polynomial/all__sagemath_categories.py
+++ b/src/sage/rings/polynomial/all__sagemath_categories.py
@@ -8,6 +8,9 @@ from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.polynomial_ring import polygen, polygens
 from sage.rings.polynomial.polynomial_element import Polynomial
 
+# Boolean Polynomial Rings
+from sage.rings.polynomial.polynomial_ring_constructor import BooleanPolynomialRing_constructor as BooleanPolynomialRing
+
 # Multivariate Polynomial Rings
 from sage.rings.polynomial.term_order import TermOrder
 from sage.rings.polynomial.multi_polynomial_element import degree_lowest_rational_function


### PR DESCRIPTION
- **pkgs/sagemath-brial/pyproject.toml.m4: Make sagemath-categories a runtime dependency**
- **src/sage/all__sagemath_brial.py: Use try..except for import from passagemath-modules**
- **pkgs/sagemath-brial: Set up proper testing**
- **src/sage/rings/polynomial/all__sagemath_categories.py: Move import of BooleanPolynomialRing here**
