### PR TITLE
pkgs/sagemath-latte-4ti2: Fix for relocatable LattE/4ti2 binaries (fixup)

### DIFF
--- a/pkgs/sagemath-latte-4ti2/repair_wheel.py
+++ b/pkgs/sagemath-latte-4ti2/repair_wheel.py
@@ -17,7 +17,7 @@ wheel = Path(sys.argv[1])
 
 # SAGE_LOCAL/bin/* --> sage_wheels/bin/*
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/{{ConvertCDDextToLatte,ConvertCDDineToLatte,count,count-linear-forms-from-polynomial,ehrhart,ehrhart3,hilbert-from-rays,hilbert-from-rays-symm,integrate,latte-maximize,latte-minimize,latte2ext,latte2ine,polyhedron-to-cones,top-ehrhart-knapsack,triangulate}}* share/latte-int/{{m-knapsack.mpl,simplify*.add}} bin/{{4ti2gmp,4ti2int32,4ti2int64,circuits,genmodel,gensymm,graver,groebner,hilbert,markov,minimize,normalform,output,ppi,qsolve,rays,walk,zbasis,zsolve}}*) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/{{ConvertCDDextToLatte,ConvertCDDineToLatte,count,count-linear-forms-from-polynomial,ehrhart,ehrhart3,hilbert-from-rays,hilbert-from-rays-symm,integrate,latte-maximize,latte-minimize,latte2ext,latte2ine,polyhedron-to-cones,top-ehrhart-knapsack,triangulate}}{{,.bin}} share/latte-int/{{m-knapsack.mpl,simplify*.add}} bin/{{4ti2gmp,4ti2int32,4ti2int64,circuits,genmodel,gensymm,graver,groebner,hilbert,markov,minimize,normalform,output,ppi,qsolve,rays,walk,zbasis,zsolve}}) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:


### PR DESCRIPTION
After #1246, we see on musllinux
```
  Running set -o pipefail; (cd /host/sage-musllinux_1_2_aarch64 && tar cf - --dereference bin/{ConvertCDDextToLatte,ConvertCDDineToLatte,count,count-linear-forms-from-polynomial,ehrhart,ehrhart3,hilbert-from-rays,hilbert-from-rays-symm,integrate,latte-maximize,latte-minimize,latte2ext,latte2ine,polyhedron-to-cones,top-ehrhart-knapsack,triangulate}* share/latte-int/{m-knapsack.mpl,simplify*.add} bin/{4ti2gmp,4ti2int32,4ti2int64,circuits,genmodel,gensymm,graver,groebner,hilbert,markov,minimize,normalform,output,ppi,qsolve,rays,walk,zbasis,zsolve}*) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)
  tar: bin/ConvertCDDextToLatte*: Cannot stat: No such file or directory
  tar: bin/ConvertCDDineToLatte*: Cannot stat: No such file or directory
  bin/countg
  bin/countneg
  tar: bin/count-linear-forms-from-polynomial*: Cannot stat: No such file or directory
  bin/4ti2gmp
  tar: bin/ehrhart*: Cannot stat: No such file or directory
  tar: bin/ehrhart3*: Cannot stat: No such file or directory
  tar: bin/hilbert-from-rays*: Cannot stat: No such file or directory
  tar: bin/hilbert-from-rays-symm*: Cannot stat: No such file or directory
  tar: bin/integrate*: Cannot stat: No such file or directory
  tar: bin/latte-maximize*: Cannot stat: No such file or directory
  tar: bin/latte-minimize*: Cannot stat: No such file or directory
  tar: bin/latte2ext*: Cannot stat: No such file or directory
  tar: bin/latte2ine*: Cannot stat: No such file or directory
  tar: bin/polyhedron-to-cones*: Cannot stat: No such file or directory
  tar: bin/top-ehrhart-knapsack*: Cannot stat: No such file or directory
  tar: bin/triangulate*: Cannot stat: No such file or directory
  tar: share/latte-int/m-knapsack.mpl: Cannot stat: No such file or directory
  tar: share/latte-int/simplify*.add: Cannot stat: No such file or directory
  bin/4ti2int32
  bin/4ti2int64
  bin/circuits
  bin/genmodel
  bin/gensymm
  bin/graver
  bin/groebner
  bin/hilbert
  bin/markov
  bin/minimize
  bin/normalform
  bin/output
  bin/ppi
  bin/qsolve
  bin/rays
  bin/walk
  bin/zbasis
  bin/zsolve
  tar: Exiting with failure status due to previous errors
```