### PR TITLE
tox.ini (docker): Actually set the ...-failed tag before pushing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -852,7 +852,7 @@ commands =
     docker:            unset PUSH_TAGS; \
     docker:            if [ -n "$BUILD_TAG" ]; then \
     docker:              if [ $status != 0 ]; then \
-    docker:                BUILD_TAG="${BUILD_TAG%-failed}-failed"; PUSH_TAGS=$BUILD_IMAGE:$BUILD_TAG; \
+    docker:                BUILD_TAG_FAILED="${BUILD_TAG%-failed}-failed"; docker tag $BUILD_IMAGE:$BUILD_TAG $BUILD_IMAGE:$BUILD_TAG_FAILED; $BUILD_TAG=$BUILD_TAG_FAILED; PUSH_TAGS=$BUILD_IMAGE:$BUILD_TAG; \
     docker:              else \
     docker:                PUSH_TAGS=$(echo $BUILD_IMAGE:$BUILD_TAG; for tag in {env:EXTRA_DOCKER_TAGS:}; do echo "$BUILD_IMAGE:$tag"; done); \
     docker:              fi; \


### PR DESCRIPTION
Currently:
```
make: *** [Makefile:48: sagemath_doc_html-build-deps] Error 1
#29 DONE 7366.9s

#30 exporting to image
#30 exporting layers
#30 exporting layers 41.3s done
#30 writing image sha256:a63f3ab4e928904aec9c7271fae1da01ddc2b9e4385c08ccc5411cc6266493de done
#30 naming to ghcr.io/passagemath/passagemath/sage-fedora-42-minimal-with-targets:ddb4d795943 done
#30 naming to ghcr.io/passagemath/passagemath/sage-fedora-42-minimal-with-targets:dev done
#30 naming to ghcr.io/passagemath/passagemath/sage-fedora-42-minimal-with-targets:passagemath-10.6.1.rc10 done
#30 DONE 41.3s
Copying logs from the container to /home/runner/work/passagemath/passagemath/.tox/docker-fedora-42-minimal/sage/
Pushing ghcr.io/passagemath/passagemath/sage-fedora-42-minimal-with-targets:ddb4d795943-failed
The push refers to repository [ghcr.io/passagemath/passagemath/sage-fedora-42-minimal-with-targets]
tag does not exist: ghcr.io/passagemath/passagemath/sage-fedora-42-minimal-with-targets:ddb4d795943-failed
(ignoring errors)
```
