### PR TITLE
Remove unimplemented is_complement_totally_unimodular methods

### DIFF
--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -1230,19 +1230,6 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except AttributeError:
                 return NotImplemented
 
-        @lazy_attribute
-        def is_complement_totally_unimodular(self):
-            r"""
-            """
-            try:
-                matrix = self._matrix_cmr()
-            except (ImportError, TypeError):
-                matrix = self.matrix()
-            try:
-                return self._wrapped_method_with_certificate(matrix.is_complement_totally_unimodular)
-            except AttributeError:
-                return NotImplemented
-
     class Homsets(HomsetsCategory):
 
         class Endset(CategoryWithAxiom):

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -19356,9 +19356,6 @@ cdef class Matrix(Matrix1):
         """
         return self._matrix_cmr().is_totally_unimodular(*args, **kwds)
 
-    def is_complement_totally_unimodular(self, *args, **kwds):
-        return self._matrix_cmr().is_complement_totally_unimodular(*args, **kwds)
-
     def LLL_gram(self, flag=0):
         """
         Return the LLL transformation matrix for this Gram matrix.

--- a/src/sage/matrix/matrix_cmr_sparse.pyx
+++ b/src/sage/matrix/matrix_cmr_sparse.pyx
@@ -5500,18 +5500,6 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
         return result, (node, submat_tuple)
 
-    def is_complement_totally_unimodular(self, *, time_limit=60.0, certificate=False,
-                                         use_direct_graphicness_test=True,
-                                         series_parallel_ok=True,
-                                         check_graphic_minors_planar=False,
-                                         complete_tree='find_irregular',
-                                         construct_matrices=False,
-                                         construct_transposes=False,
-                                         construct_graphs=False,
-                                         row_keys=None,
-                                         column_keys=None):
-        raise NotImplementedError
-
 
 cdef _set_cmr_seymour_parameters(CMR_SEYMOUR_PARAMS *params, dict kwds):
     r"""


### PR DESCRIPTION
The removal can be reverted whenever we wish to implement these methods.