### PR TITLE
src/pyproject.toml [Windows]: Use cysignals < 1.12.4

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -10,6 +10,8 @@ requires = [
     'cypari2 >=2.2.1',
     # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212, https://github.com/passagemath/passagemath/issues/445
     'cysignals >=1.11.2, != 1.12.0',
+    # Exclude 1.12.4 because of https://github.com/passagemath/passagemath/issues/1318
+    'cysignals <1.12.4; sys_platform == "win32"',
     # per https://github.com/scipy/scipy/blob/maintenance/1.13.x/pyproject.toml
     'cython >=3.0.8,<3.1.0',
     'gmpy2 ~=2.1.b999',
@@ -31,6 +33,8 @@ dependencies = [
     'cypari2 >=2.1.1',
     # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212, https://github.com/passagemath/passagemath/issues/445
     'cysignals >=1.11.2, != 1.12.0',
+    # Exclude 1.12.4 because of https://github.com/passagemath/passagemath/issues/1318
+    'cysignals <1.12.4; sys_platform == "win32"',
     'cython >=3.0, != 3.0.3, <4.0',
     'gmpy2 ~=2.1.b999',
     # According to https://pypi.org/project/importlib-metadata/,


### PR DESCRIPTION
Workaround for
- #1318 