### PR TITLE
Remove use of `lazy_attribute` for CMR methods for f.d. module morphisms, fix `is_conetwork_matrix` with col/row keys

### DIFF
--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -18,7 +18,6 @@
         "ntests": 105
     },
     "sage.algebras.finite_dimensional_algebras.finite_dimensional_algebra_morphism": {
-        "failed": true,
         "ntests": 59
     },
     "sage.algebras.finite_gca": {
@@ -2028,7 +2027,6 @@
         "ntests": 8
     },
     "sage.modules.fp_graded.free_morphism": {
-        "failed": true,
         "ntests": 47
     },
     "sage.modules.fp_graded.steenrod.module": {
@@ -2129,7 +2127,6 @@
         "ntests": 160
     },
     "sage.modules.with_basis.morphism": {
-        "failed": true,
         "ntests": 353
     },
     "sage.modules.with_basis.subquotient": {

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -1128,9 +1128,16 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: result, certificate
                 (True,
                  (Digraph on 10 vertices,
-                  {0: (8, 7), 1: (1, 29), 2: (34, 2), 3: (41, 7)},
-                  {'a': (8, 22), 'b': (22, 29), 'c': (34, 0), 'd': (41, 2), 'e': (8, 7),
-                   'f': (7, 8), 'g': (0, 0), 'h': (7, 8), 'i': (36, 37)}))
+                  {'a': (8, 7),
+                   'b': (1, 29),
+                   'c': (34, 2),
+                   'd': (41, 7),
+                   'e': (7, 3),
+                   'f': (22, 0),
+                   'g': (3, 0),
+                   'h': (3, 1),
+                   'i': (2, 1)},
+                  {0: (8, 22), 1: (22, 29), 2: (34, 0), 3: (41, 2)}))
             """
             try:
                 matrix = self._matrix_cmr()

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -916,8 +916,7 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             MS = MatrixSpace(self.base_ring(), M.nrows(), M.ncols(), sparse=True)
             return Matrix_cmr_chr_sparse(MS, M)
 
-        @lazy_attribute
-        def is_unimodular(self):
+        def is_unimodular(self, **kwds):
             r"""
             Return whether ``self`` is a unimodular morphism.
 
@@ -944,12 +943,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return matrix.is_unimodular
+                return matrix.is_unimodular(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def is_strongly_unimodular(self):
+        def is_strongly_unimodular(self, **kwds):
             r"""
             Return whether ``self`` is a strongly unimodular morphism.
 
@@ -978,12 +976,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return matrix.is_strongly_unimodular
+                return matrix.is_strongly_unimodular(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def equimodulus(self):
+        def equimodulus(self, **kwds):
             r"""
             Return the integer `k` such that ``self`` is equimodular with determinant gcd `k`.
 
@@ -995,12 +992,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return matrix.equimodulus
+                return matrix.equimodulus(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def strong_equimodulus(self):
+        def strong_equimodulus(self, **kwds):
             r"""
             Return the integer `k` such that ``self`` is strongly equimodular with determinant gcd `k`.
 
@@ -1012,12 +1008,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return matrix.strong_equimodulus
+                return matrix.strong_equimodulus(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def is_k_equimodular(self):
+        def is_k_equimodular(self, k, **kwds):
             r"""
             Return whether ``self`` is an equimodular morphism with determinant gcd `k`.
 
@@ -1046,12 +1041,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return matrix.is_k_equimodular
+                return matrix.is_k_equimodular(k, **kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def is_strongly_k_equimodular(self):
+        def is_strongly_k_equimodular(self, k, **kwds):
             r"""
             Return whether ``self`` is a strongly equimodular morphism with determinant gcd `k`.
 
@@ -1086,9 +1080,9 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return matrix.is_strongly_k_equimodular
+                return matrix.is_strongly_k_equimodular(k, **kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
         def _wrapped_method_with_certificate(self, matrix_method):
 
@@ -1104,8 +1098,7 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                                      **kwds)
             return wrapper
 
-        @lazy_attribute
-        def is_conetwork_matrix(self):
+        def is_conetwork_matrix(self, **kwds):
             r"""
             Return whether the matrix of ``self`` is a conetwork matrix.
 
@@ -1144,12 +1137,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return self._wrapped_method_with_certificate(matrix.is_conetwork_matrix)
+                return self._wrapped_method_with_certificate(matrix.is_conetwork_matrix)(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def is_network_matrix(self):
+        def is_network_matrix(self, **kwds):
             r"""
             Return whether the matrix of ``self`` is a network matrix.
 
@@ -1190,12 +1182,11 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return self._wrapped_method_with_certificate(matrix.is_network_matrix)
+                return self._wrapped_method_with_certificate(matrix.is_network_matrix)(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
-        @lazy_attribute
-        def is_totally_unimodular(self):
+        def is_totally_unimodular(self, **kwds):
             r"""
             Return whether the matrix of ``self`` is totally unimodular.
 
@@ -1226,9 +1217,9 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (ImportError, TypeError):
                 matrix = self.matrix()
             try:
-                return self._wrapped_method_with_certificate(matrix.is_totally_unimodular)
+                return self._wrapped_method_with_certificate(matrix.is_totally_unimodular)(**kwds)
             except AttributeError:
-                return NotImplemented
+                raise NotImplementedError
 
     class Homsets(HomsetsCategory):
 

--- a/src/sage/matrix/matrix_cmr_sparse.pyx
+++ b/src/sage/matrix/matrix_cmr_sparse.pyx
@@ -5155,8 +5155,8 @@ cdef class Matrix_cmr_chr_sparse(Matrix_cmr_sparse):
 
         if <bint> result:
             sage_digraph = _sage_digraph(digraph, arcs_reversed)
-            sage_forest_arcs = _sage_arcs(digraph, forest_arcs, arcs_reversed, self.ncols(), row_keys)
-            sage_coforest_arcs = _sage_arcs(digraph, coforest_arcs, arcs_reversed, self.nrows(), column_keys)
+            sage_forest_arcs = _sage_arcs(digraph, forest_arcs, arcs_reversed, self.ncols(), column_keys)
+            sage_coforest_arcs = _sage_arcs(digraph, coforest_arcs, arcs_reversed, self.nrows(), row_keys)
             return True, (sage_digraph, sage_forest_arcs, sage_coforest_arcs)
 
         return False, NotImplemented  # submatrix TBD


### PR DESCRIPTION
The use of `lazy_attribute` was causing pickling errors in unrelated classes