### PR TITLE
Fix installation with `pip` without `--no-build-isolation` (after #1395)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,9 @@ Full Installation from Source as passagemath
     (passagemath-venv) $ export SAGE_CONF_TARGETS="build-local gmpy2 memory_allocator"
     ```
 
-    If you wish to build all Python dependencies from source as well (instead of
-    taking them from binary wheels on PyPI), replace the last command by:
+    If you wish to build all Python dependencies from source as well,
+    using the pinned and patched versions defined by the Sage distribution,
+    instead of taking them from binary wheels on PyPI, replace the last command by:
 
     ```bash session
     (passagemath-venv) $ export SAGE_CONF_TARGETS="build"

--- a/pkgs/sagemath-benzene/pyproject.toml.m4
+++ b/pkgs/sagemath-benzene/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-brial/pyproject.toml.m4
+++ b/pkgs/sagemath-brial/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-buckygen/pyproject.toml.m4
+++ b/pkgs/sagemath-buckygen/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-cddlib/pyproject.toml.m4
+++ b/pkgs/sagemath-cddlib/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-cliquer/pyproject.toml.m4
+++ b/pkgs/sagemath-cliquer/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-combinat/pyproject.toml.m4
+++ b/pkgs/sagemath-combinat/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_pkgconfig
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-coxeter3/pyproject.toml.m4
+++ b/pkgs/sagemath-coxeter3/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_objects

--- a/pkgs/sagemath-eclib/pyproject.toml.m4
+++ b/pkgs/sagemath-eclib/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-fricas/pyproject.toml.m4
+++ b/pkgs/sagemath-fricas/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-frobby/pyproject.toml.m4
+++ b/pkgs/sagemath-frobby/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-gfan/pyproject.toml.m4
+++ b/pkgs/sagemath-gfan/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-giac/pyproject.toml.m4
+++ b/pkgs/sagemath-giac/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_categories

--- a/pkgs/sagemath-glpk/pyproject.toml.m4
+++ b/pkgs/sagemath-glpk/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-glucose/pyproject.toml.m4
+++ b/pkgs/sagemath-glucose/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-homfly/pyproject.toml.m4
+++ b/pkgs/sagemath-homfly/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_objects

--- a/pkgs/sagemath-kenzo/pyproject.toml.m4
+++ b/pkgs/sagemath-kenzo/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-kissat/pyproject.toml.m4
+++ b/pkgs/sagemath-kissat/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-latte-4ti2/pyproject.toml.m4
+++ b/pkgs/sagemath-latte-4ti2/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-lcalc/pyproject.toml.m4
+++ b/pkgs/sagemath-lcalc/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-libbraiding/pyproject.toml.m4
+++ b/pkgs/sagemath-libbraiding/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-linbox/pyproject.toml.m4
+++ b/pkgs/sagemath-linbox/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_categories

--- a/pkgs/sagemath-lrslib/pyproject.toml.m4
+++ b/pkgs/sagemath-lrslib/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-macaulay2/pyproject.toml.m4
+++ b/pkgs/sagemath-macaulay2/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-mcqd/pyproject.toml.m4
+++ b/pkgs/sagemath-mcqd/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-meataxe/pyproject.toml.m4
+++ b/pkgs/sagemath-meataxe/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_modules

--- a/pkgs/sagemath-modules/pyproject.toml.m4
+++ b/pkgs/sagemath-modules/pyproject.toml.m4
@@ -6,6 +6,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # but it is not part of the install-requires.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_jinja2
     SPKG_INSTALL_REQUIRES_pkgconfig

--- a/pkgs/sagemath-msolve/pyproject.toml.m4
+++ b/pkgs/sagemath-msolve/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-nauty/pyproject.toml.m4
+++ b/pkgs/sagemath-nauty/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-ntl/pyproject.toml.m4
+++ b/pkgs/sagemath-ntl/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_categories

--- a/pkgs/sagemath-objects/pyproject.toml.m4
+++ b/pkgs/sagemath-objects/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-palp/pyproject.toml.m4
+++ b/pkgs/sagemath-palp/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-pari/pyproject.toml.m4
+++ b/pkgs/sagemath-pari/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_categories

--- a/pkgs/sagemath-planarity/pyproject.toml.m4
+++ b/pkgs/sagemath-planarity/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-plantri/pyproject.toml.m4
+++ b/pkgs/sagemath-plantri/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-plot/pyproject.toml.m4
+++ b/pkgs/sagemath-plot/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_pkgconfig
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-qepcad/pyproject.toml.m4
+++ b/pkgs/sagemath-qepcad/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-rankwidth/pyproject.toml.m4
+++ b/pkgs/sagemath-rankwidth/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-rubiks/pyproject.toml.m4
+++ b/pkgs/sagemath-rubiks/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-singular/pyproject.toml.m4
+++ b/pkgs/sagemath-singular/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_categories

--- a/pkgs/sagemath-sirocco/pyproject.toml.m4
+++ b/pkgs/sagemath-sirocco/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_modules

--- a/pkgs/sagemath-sympow/pyproject.toml.m4
+++ b/pkgs/sagemath-sympow/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_categories
     SPKG_INSTALL_REQUIRES_sagemath_environment

--- a/pkgs/sagemath-tachyon/pyproject.toml.m4
+++ b/pkgs/sagemath-tachyon/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_sagemath_objects

--- a/pkgs/sagemath-tdlib/pyproject.toml.m4
+++ b/pkgs/sagemath-tdlib/pyproject.toml.m4
@@ -3,6 +3,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 # Minimum requirements for the build system to execute.
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython

--- a/pkgs/sagemath-topcom/pyproject.toml.m4
+++ b/pkgs/sagemath-topcom/pyproject.toml.m4
@@ -4,6 +4,7 @@ include(`sage_spkg_versions_toml.m4')dnl' -*- conf-toml -*-
 requires = [
     SPKG_INSTALL_REQUIRES_setuptools
     SPKG_INSTALL_REQUIRES_pkgconfig
+    SPKG_INSTALL_REQUIRES_sage_conf
     SPKG_INSTALL_REQUIRES_sage_setup
     SPKG_INSTALL_REQUIRES_sagemath_environment
     SPKG_INSTALL_REQUIRES_cython


### PR DESCRIPTION
In #1395, we removed the recommendation to use `--no-build-isolation` for installing sagemath-standard.

To make this work, we add a dependency on sage-conf for all packages that use `spkgs` or `required_modules` in their `setup.py`.

@GMS103 
