### PR TITLE
`sage -gap`: Go through `sage.interfaces.gap.gap_cmd`

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -639,7 +639,8 @@ if [ "$1" = '-gap' -o "$1" = '--gap' ]; then
     shift
     # Use "-A" to avoid warnings about missing packages. The gap
     # interface and libgap within sage both already do this.
-    exec gap -A "$@"
+    set -x
+    eval exec $(python3 -c 'from sage.interfaces.gap import gap_cmd; print(gap_cmd)') "$@"
 fi
 
 if [ "$1" = '-gap3' -o "$1" = '--gap3' ]; then

--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -260,9 +260,6 @@ fi
 if [ -n "$SAGE_WHEELS_PATH" ]; then
     export PATH="$SAGE_WHEELS_PATH:$PATH"
 fi
-if [ -n "$SAGE_GAP_PATH" ]; then
-    export PATH="$SAGE_GAP_PATH:$PATH"
-fi
 if [ -d "$SAGE_ROOT" ]; then
     if [ -d "$SAGE_ROOT"/tools ]; then
         export PATH="$SAGE_ROOT/tools:$PATH"

--- a/src/bin/sage-venv-config
+++ b/src/bin/sage-venv-config
@@ -32,15 +32,6 @@ else:
     SAGE_WHEELS_PATH = ':'.join(_os.path.join(p, 'bin') for p in sage_wheels.__path__)
 
 
-try:
-    import gap
-except ImportError:
-    pass
-else:
-    import os as _os
-    SAGE_GAP_PATH = ':'.join(_os.path.join(p, 'bin') for p in gap.__path__)
-
-
 def _main():
     from argparse import ArgumentParser
     from sys import exit, stdout

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -211,6 +211,7 @@ import os
 import pexpect
 import time
 import platform
+import shlex
 import string
 import warnings
 
@@ -230,7 +231,7 @@ if SAGE_GAP_COMMAND is None:
     # Passing -A allows us to use a minimal GAP installation without
     # producing errors at start-up. The files sage.g and sage.gaprc are
     # used to load any additional packages that may be available.
-    gap_cmd = f'{gap_executable} -A -l "{GAP_ROOT_PATHS}"'
+    gap_cmd = f'{shlex.quote(gap_executable)} -A -l {shlex.quote(GAP_ROOT_PATHS)}'
     if SAGE_GAP_MEMORY is not None:
         gap_cmd += " -s " + SAGE_GAP_MEMORY + " -o " + SAGE_GAP_MEMORY
 else:


### PR DESCRIPTION
... which already handles the GAP_ROOT_PATH correctly.

Revert #1415, which did not work as intended.