### PR TITLE
build/pkgs/sage_conf/spkg-src: Restore version from 10.6.1

### DIFF
--- a/build/pkgs/sage_conf/spkg-src
+++ b/build/pkgs/sage_conf/spkg-src
@@ -1,1 +1,22 @@
-../sagemath_objects/spkg-src
+#!/usr/bin/env bash
+#
+# Script to prepare an sdist tarball for sage_conf
+# This script is not used during build.
+#
+# HOW TO MAKE THE TARBALL:
+# ./sage --sh build/pkgs/sage_conf/spkg-src
+
+if [ -z "$SAGE_ROOT" ] ; then
+    echo >&2 "Error - SAGE_ROOT undefined ... exiting"
+    echo >&2 "Maybe run 'sage -sh'?"
+    exit 1
+fi
+
+# Exit on failure
+set -e
+
+cd pkgs/sage-conf_pypi
+# Get rid of old *.egg-info/SOURCES.txt
+rm -Rf *.egg-info
+
+python3 -m build --sdist --no-isolation --skip-dependency-check --outdir "$SAGE_DISTFILES"


### PR DESCRIPTION
... to use pkgs/sage-conf_pypi.

The sage-conf sdists on PyPI were broken since 10.6.2, now yanked.
