### PR TITLE
Elementary divisors: Use `canonical_associate`

### DIFF
--- a/pkgs/sagemath-graphs/known-test-failures--modules--pari.json
+++ b/pkgs/sagemath-graphs/known-test-failures--modules--pari.json
@@ -1,6 +1,5 @@
 {
     "sage.algebras.clifford_algebra": {
-        "failed": true,
         "ntests": 618
     },
     "sage.algebras.clifford_algebra_element": {
@@ -1461,6 +1460,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.ecl": {
+        "ntests": 4
+    },
     "sage.features.eclib": {
         "ntests": 4
     },
@@ -1917,7 +1919,6 @@
         "ntests": 165
     },
     "sage.graphs.strongly_regular_db": {
-        "failed": true,
         "ntests": 312
     },
     "sage.graphs.traversals": {
@@ -1936,7 +1937,6 @@
         "ntests": 43
     },
     "sage.groups.abelian_gps.abelian_group": {
-        "failed": true,
         "ntests": 241
     },
     "sage.groups.abelian_gps.abelian_group_element": {
@@ -2427,7 +2427,7 @@
         "ntests": 67
     },
     "sage.misc.latex": {
-        "ntests": 244
+        "ntests": 240
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -3164,6 +3164,9 @@
     "sage.rings.function_field.jacobian_hess": {
         "ntests": 1
     },
+    "sage.rings.function_field.jacobian_khuri_makdisi": {
+        "ntests": 2
+    },
     "sage.rings.function_field.maps": {
         "ntests": 59
     },
@@ -3205,7 +3208,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1165
+        "ntests": 1163
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -3422,7 +3425,7 @@
         "ntests": 251
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 172
+        "ntests": 177
     },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 243
@@ -3480,9 +3483,6 @@
     },
     "sage.rings.polynomial.q_integer_valued_polynomials": {
         "ntests": 207
-    },
-    "sage.rings.polynomial.symmetric_ideal": {
-        "ntests": 36
     },
     "sage.rings.polynomial.symmetric_reduction": {
         "ntests": 9
@@ -4093,7 +4093,6 @@
         "ntests": 47
     },
     "sage.topology.simplicial_complex_morphism": {
-        "failed": true,
         "ntests": 224
     },
     "sage.topology.simplicial_set": {

--- a/pkgs/sagemath-graphs/known-test-failures--modules.json
+++ b/pkgs/sagemath-graphs/known-test-failures--modules.json
@@ -922,7 +922,6 @@
         "ntests": 274
     },
     "sage.combinat.designs.latin_squares": {
-        "failed": true,
         "ntests": 37
     },
     "sage.combinat.designs.orthogonal_arrays_build_recursive": {
@@ -1375,6 +1374,9 @@
         "ntests": 4
     },
     "sage.features.dvipng": {
+        "ntests": 4
+    },
+    "sage.features.ecl": {
         "ntests": 4
     },
     "sage.features.eclib": {
@@ -1851,7 +1853,6 @@
         "ntests": 43
     },
     "sage.groups.abelian_gps.abelian_group": {
-        "failed": true,
         "ntests": 241
     },
     "sage.groups.abelian_gps.abelian_group_element": {
@@ -2065,7 +2066,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2052
+        "ntests": 2046
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -2295,7 +2296,7 @@
         "ntests": 67
     },
     "sage.misc.latex": {
-        "ntests": 244
+        "ntests": 240
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -2915,6 +2916,9 @@
     "sage.rings.function_field.jacobian_hess": {
         "ntests": 1
     },
+    "sage.rings.function_field.jacobian_khuri_makdisi": {
+        "ntests": 2
+    },
     "sage.rings.function_field.maps": {
         "ntests": 55
     },
@@ -2952,7 +2956,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1101
+        "ntests": 1099
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -3082,7 +3086,7 @@
         "ntests": 251
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 168
+        "ntests": 173
     },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 56
@@ -3138,9 +3142,6 @@
     },
     "sage.rings.polynomial.skew_polynomial_ring": {
         "ntests": 20
-    },
-    "sage.rings.polynomial.symmetric_ideal": {
-        "ntests": 36
     },
     "sage.rings.polynomial.symmetric_reduction": {
         "ntests": 9
@@ -3676,7 +3677,6 @@
         "ntests": 47
     },
     "sage.topology.simplicial_complex_morphism": {
-        "failed": true,
         "ntests": 224
     },
     "sage.topology.simplicial_set": {

--- a/pkgs/sagemath-graphs/known-test-failures.json
+++ b/pkgs/sagemath-graphs/known-test-failures.json
@@ -742,7 +742,7 @@
         "ntests": 274
     },
     "sage.combinat.designs.latin_squares": {
-        "ntests": 12
+        "ntests": 13
     },
     "sage.combinat.designs.orthogonal_arrays_build_recursive": {
         "ntests": 20
@@ -997,6 +997,9 @@
         "ntests": 4
     },
     "sage.features.dvipng": {
+        "ntests": 4
+    },
+    "sage.features.ecl": {
         "ntests": 4
     },
     "sage.features.eclib": {
@@ -1610,7 +1613,7 @@
     },
     "sage.misc.latex": {
         "failed": true,
-        "ntests": 221
+        "ntests": 220
     },
     "sage.misc.latex_macros": {
         "ntests": 11
@@ -1992,6 +1995,9 @@
     "sage.rings.function_field.jacobian_hess": {
         "ntests": 1
     },
+    "sage.rings.function_field.jacobian_khuri_makdisi": {
+        "ntests": 2
+    },
     "sage.rings.function_field.maps": {
         "ntests": 55
     },
@@ -2027,7 +2033,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1085
+        "ntests": 1083
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -2138,7 +2144,7 @@
         "ntests": 245
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 163
+        "ntests": 168
     },
     "sage.rings.polynomial.polydict": {
         "ntests": 396
@@ -2168,9 +2174,6 @@
     },
     "sage.rings.polynomial.polynomial_singular_interface": {
         "ntests": 42
-    },
-    "sage.rings.polynomial.symmetric_ideal": {
-        "ntests": 36
     },
     "sage.rings.polynomial.symmetric_reduction": {
         "ntests": 9

--- a/pkgs/sagemath-modules/known-test-failures.json
+++ b/pkgs/sagemath-modules/known-test-failures.json
@@ -293,9 +293,6 @@
     "sage.categories.examples.finite_dimensional_algebras_with_basis": {
         "ntests": 17
     },
-    "sage.categories.examples.finite_dimensional_lie_algebras_with_basis": {
-        "ntests": 1
-    },
     "sage.categories.examples.finite_enumerated_sets": {
         "ntests": 29
     },
@@ -553,7 +550,7 @@
         "ntests": 4
     },
     "sage.categories.lie_algebras": {
-        "ntests": 112
+        "ntests": 96
     },
     "sage.categories.lie_algebras_with_basis": {
         "ntests": 19
@@ -1189,12 +1186,15 @@
         "ntests": 3
     },
     "sage.features.databases": {
-        "ntests": 36
+        "ntests": 40
     },
     "sage.features.dot2tex": {
         "ntests": 4
     },
     "sage.features.dvipng": {
+        "ntests": 4
+    },
+    "sage.features.ecl": {
         "ntests": 4
     },
     "sage.features.eclib": {
@@ -1433,7 +1433,6 @@
         "ntests": 80
     },
     "sage.groups.abelian_gps.abelian_group": {
-        "failed": true,
         "ntests": 241
     },
     "sage.groups.abelian_gps.abelian_group_element": {
@@ -1617,7 +1616,7 @@
     },
     "sage.matrix.matrix2": {
         "failed": true,
-        "ntests": 2039
+        "ntests": 2033
     },
     "sage.matrix.matrix_cdv": {
         "ntests": 5
@@ -2466,6 +2465,9 @@
     "sage.rings.function_field.jacobian_hess": {
         "ntests": 1
     },
+    "sage.rings.function_field.jacobian_khuri_makdisi": {
+        "ntests": 2
+    },
     "sage.rings.function_field.maps": {
         "ntests": 55
     },
@@ -2503,7 +2505,7 @@
     },
     "sage.rings.integer": {
         "failed": true,
-        "ntests": 1101
+        "ntests": 1099
     },
     "sage.rings.integer_fake.pxd": {
         "ntests": 1
@@ -2633,7 +2635,7 @@
         "ntests": 251
     },
     "sage.rings.polynomial.multi_polynomial_sequence": {
-        "ntests": 168
+        "ntests": 173
     },
     "sage.rings.polynomial.ore_function_element": {
         "ntests": 56
@@ -2689,9 +2691,6 @@
     },
     "sage.rings.polynomial.skew_polynomial_ring": {
         "ntests": 20
-    },
-    "sage.rings.polynomial.symmetric_ideal": {
-        "ntests": 36
     },
     "sage.rings.polynomial.symmetric_reduction": {
         "ntests": 9

--- a/pkgs/sagemath-plot/known-test-failures.json
+++ b/pkgs/sagemath-plot/known-test-failures.json
@@ -1018,6 +1018,9 @@
     "sage.features.dvipng": {
         "ntests": 4
     },
+    "sage.features.ecl": {
+        "ntests": 3
+    },
     "sage.features.eclib": {
         "ntests": 3
     },
@@ -1249,7 +1252,6 @@
         "ntests": 79
     },
     "sage.groups.abelian_gps.abelian_group": {
-        "failed": true,
         "ntests": 216
     },
     "sage.groups.abelian_gps.abelian_group_element": {
@@ -1629,8 +1631,7 @@
         "ntests": 63
     },
     "sage.misc.latex": {
-        "failed": true,
-        "ntests": 223
+        "ntests": 220
     },
     "sage.misc.latex_macros": {
         "ntests": 11

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -16614,7 +16614,11 @@ cdef class Matrix(Matrix1):
         """
         d = self.smith_form(transformation=False)
         r = min(self.nrows(), self.ncols())
-        return [d[i, i] for i in range(r)]
+        ed = [d[i, i] for i in range(r)]
+        try:
+            return [x.canonical_associate()[0] for x in ed]
+        except (AttributeError, TypeError):
+            return ed
 
     def smith_form(self, transformation=True, integral=None, exact=True):
         r"""

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -459,8 +459,8 @@ def has_latex_attr(x) -> bool:
     Types inherit the ``_latex_`` method of the class to which they refer,
     but calling it is broken::
 
-        sage: # needs sage.modules
-        sage: T = type(identity_matrix(3)); T                                           # needs sage.libs.flint
+        sage: # needs sage.libs.flint sage.modules
+        sage: T = type(identity_matrix(3)); T
         <class 'sage.matrix.matrix_integer_dense.Matrix_integer_dense'>
         sage: hasattr(T, '_latex_')
         True


### PR DESCRIPTION
When we don't use the specialized matrix implementation for integers, the computed Smith form is not necessarily normalized in the way expected by code using the elementary divisors.

We fix it using the new `canonical_associate` methods.