### PR TITLE
tox.ini (homebrew): Work around preinstalled "cmake", formula/cask confusion on GH Actions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -779,6 +779,8 @@ commands =
     #
     # https://docs.brew.sh/Installation
     homebrew:      bash -c 'if [ ! -x {env:HOMEBREW}/bin/brew ]; then git clone --depth 1 https://github.com/Homebrew/brew {env:HOMEBREW}; fi'
+    # work around 'cmake was installed from the local/pinned tap' on GH Actions
+    homebrew-{usrlocal,opthomebrew}: bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) {env:HOMEBREW}/bin/brew uninstall cmake || : ;; esac'
     homebrew:      bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list {env:SAGE_PACKAGE_LIST_ARGS}) {env:ALL_EXTRA_SAGE_PACKAGES}); {env:HOMEBREW}/bin/brew install --force --formula $PACKAGES; {env:HOMEBREW}/bin/brew upgrade --formula $PACKAGES;; esac'
     #
     # local-macports

--- a/tox.ini
+++ b/tox.ini
@@ -779,7 +779,7 @@ commands =
     #
     # https://docs.brew.sh/Installation
     homebrew:      bash -c 'if [ ! -x {env:HOMEBREW}/bin/brew ]; then git clone --depth 1 https://github.com/Homebrew/brew {env:HOMEBREW}; fi'
-    homebrew:      bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list {env:SAGE_PACKAGE_LIST_ARGS}) {env:ALL_EXTRA_SAGE_PACKAGES}); {env:HOMEBREW}/bin/brew install $PACKAGES; {env:HOMEBREW}/bin/brew upgrade $PACKAGES;; esac'
+    homebrew:      bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list {env:SAGE_PACKAGE_LIST_ARGS}) {env:ALL_EXTRA_SAGE_PACKAGES}); {env:HOMEBREW}/bin/brew install --formula $PACKAGES; {env:HOMEBREW}/bin/brew upgrade --formula $PACKAGES;; esac'
     #
     # local-macports
     #

--- a/tox.ini
+++ b/tox.ini
@@ -779,7 +779,7 @@ commands =
     #
     # https://docs.brew.sh/Installation
     homebrew:      bash -c 'if [ ! -x {env:HOMEBREW}/bin/brew ]; then git clone --depth 1 https://github.com/Homebrew/brew {env:HOMEBREW}; fi'
-    homebrew:      bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list {env:SAGE_PACKAGE_LIST_ARGS}) {env:ALL_EXTRA_SAGE_PACKAGES}); {env:HOMEBREW}/bin/brew install --formula $PACKAGES; {env:HOMEBREW}/bin/brew upgrade --formula $PACKAGES;; esac'
+    homebrew:      bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list {env:SAGE_PACKAGE_LIST_ARGS}) {env:ALL_EXTRA_SAGE_PACKAGES}); {env:HOMEBREW}/bin/brew install --force --formula $PACKAGES; {env:HOMEBREW}/bin/brew upgrade --formula $PACKAGES;; esac'
     #
     # local-macports
     #


### PR DESCRIPTION
seen in Normaliz CI
```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.

To install this version, you must first uninstall the existing formula:
  brew uninstall cmake
Then you can install the desired version:
  brew install cmake
Warning: Treating cmake as a cask. For the formula, use local/pinned/cmake or specify the `--formula` flag. To silence this message, use the `--cask` flag.
```
https://github.com/passagemath/upstream-Normaliz/actions/runs/17504619687/job/49725453391#step:10:65

@w-bruns