### PR TITLE
.github/workflows/dist.yml: Do not upload sdists to PyPI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1053,8 +1053,7 @@ jobs:
          "ubuntu-24.04-arm-musllinux-*-wheels",
          "macos-13-*-wheels",
          "macos-14-*-wheels",
-         "noarch-wheels",
-         "dist"]
+         "noarch-wheels"]
     secrets: inherit
 
   tox:


### PR DESCRIPTION
Currently, we always have to run the PyPI upload several times after deleting old versions to make room for new ones.

We defer the upload of sdists to this manual step so that the time window with latest versions having no wheels is greatly reduced.