### PR TITLE
pkgs/sagemath-gap/tox.ini: Make sure ::error:: works in all situations

### DIFF
--- a/pkgs/sagemath-gap/tox.ini
+++ b/pkgs/sagemath-gap/tox.ini
@@ -90,7 +90,7 @@ commands =
     notest,!notest:                       eval TEST=\$\{TEST_COMMAND_$package-\$TEST_COMMAND\}; \
     notest,!notest:                       if ! sage -gap --nointeract -c "$TEST(\"$package\");" 2>&1 | tee "{env_log_dir}/$package.log"; then status=1; fi; \
     notest,!notest:                       echo "::endgroup::"; \
-    notest,!notest:                       if ! grep -q "^ *${SHARP}I  No errors detected while testing" "{env_log_dir}/$package.log"; then status=1; echo "::error title=Error testing GAP package $package::"$(grep "^ *${SHARP}I  " "{env_log_dir}/$package.log"); fi; \
+    notest,!notest:                       if ! grep -q "^ *${SHARP}I  No errors detected while testing" "{env_log_dir}/$package.log"; then status=1; echo "::error title=Error testing GAP package $package::"$(grep "^ *${SHARP}I " "{env_log_dir}/$package.log" || grep "^ *Error, " "{env_log_dir}/$package.log" || echo "Unknown failure"); fi; \
     notest,!notest:                    done; exit $status'
 
     # broken: AtlasRep


### PR DESCRIPTION
The failure in `wpe` does not show an "Error" annotation in GH Actions
```
  testing: 
  Error, Cannot read file 
```
https://github.com/passagemath/passagemath/actions/runs/17886625369/job/50874985630#step:9:35495