### PR TITLE
build/pkgs/{ppl,pplpy}: Use std=c++14

### DIFF
--- a/build/pkgs/ppl/spkg-install.in
+++ b/build/pkgs/ppl/spkg-install.in
@@ -1,6 +1,8 @@
 # Make sure that we prefer Sage's gmp library over system-wide gmp installs
 export CXXFLAGS="$CXXFLAGS -I$SAGE_LOCAL/include"
 
+export CXXFLAGS="$CXXFLAGS -std=c++14"
+
 cd src
 
 cp "$SAGE_ROOT"/config/config.* .

--- a/build/pkgs/pplpy/spkg-install.in
+++ b/build/pkgs/pplpy/spkg-install.in
@@ -1,1 +1,3 @@
+export CXXFLAGS="$CXXFLAGS -std=c++14"
+
 cd src && sdh_pip_install .


### PR DESCRIPTION
To fix this:
```
[spkg-install] arm64-apple-darwin20.0.0-clang++ -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0 -isystem /Users/averyli/conda/include -D_FORTIFY_SOURCE=2 -isystem /Users/averyli/conda/include -Ippl -I/Users/averyli/sage/passagemath/local/var/lib/sage/venv-python3.12/lib/python3.12/site-packages/gmpy2 -I/Users/averyli/sage/passagemath/local/var/lib/sage/venv-python3.12/include -I/Users/averyli/conda/envs/passagemath-venv-2/include/python3.12 -c ppl/linear_algebra.cpp -o build/temp.macosx-11.0-arm64-cpython-312/ppl/linear_algebra.o
[spkg-install] In file included from ppl/linear_algebra.cpp:1168:
[spkg-install] /Users/averyli/conda/include/ppl.hh:101797:33: error: no member named 'mem_fun_ref' in namespace 'std'; did you mean 'widen_fun_ref'?
[spkg-install]  101797 |   pairwise_apply_assign(y, std::mem_fun_ref(&D::meet_assign));
[spkg-install]         |                            ~~~~~^
[spkg-install] /Users/averyli/conda/include/ppl.hh:96540:1: note: 'widen_fun_ref' declared here
[spkg-install]  96540 | widen_fun_ref(void (PSET::* wm)(const PSET&, unsigned*)) {
[spkg-install]        | ^
[spkg-install] /Users/averyli/conda/include/ppl.hh:103755:57: error: no member named 'mem_fun_ref' in namespace 'std'; did you mean 'widen_fun_ref'?
[spkg-install]  103755 |                           Det_PSET::lift_op_assign(std::mem_fun_ref(&PSET::intersection_assign)));
[spkg-install]         |                                                    ~~~~~^
[spkg-install] /Users/averyli/conda/include/ppl.hh:96540:1: note: 'widen_fun_ref' declared here
[spkg-install]  96540 | widen_fun_ref(void (PSET::* wm)(const PSET&, unsigned*)) {
[spkg-install]        | ^
[spkg-install] /Users/averyli/conda/include/ppl.hh:103763:57: error: no member named 'mem_fun_ref' in namespace 'std'; did you mean 'widen_fun_ref'?
[spkg-install]  103763 |                           Det_PSET::lift_op_assign(std::mem_fun_ref(&PSET::time_elapse_assign)));
[spkg-install]         |                                                    ~~~~~^
[spkg-install] /Users/averyli/conda/include/ppl.hh:96540:1: note: 'widen_fun_ref' declared here
[spkg-install]  96540 | widen_fun_ref(void (PSET::* wm)(const PSET&, unsigned*)) {
[spkg-install]        | ^
[spkg-install] 3 errors generated.
[spkg-install] error: command '/Users/averyli/conda/bin/arm64-apple-darwin20.0.0-clang++' failed with exit code 1
```
