### PR TITLE
build/pkgs/pari/spkg-check.in: Use OMP_NUM_THREADS=1

### DIFF
--- a/build/pkgs/pari/spkg-check.in
+++ b/build/pkgs/pari/spkg-check.in
@@ -6,6 +6,9 @@ export CFLAGS=$CFLAGS_O3
 
 cd src
 
+# Try avoiding pthread deadlocks - https://github.com/passagemath/passagemath/issues/1684
+export OMP_NUM_THREADS=1
+
 $MAKE test-all
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Workaround for:
- https://github.com/passagemath/passagemath/issues/1684