### PR TITLE
When `configure --with-sage-venv=none` is used, do not override `PYTHONPATH` during build

### DIFF
--- a/build/make/install
+++ b/build/make/install
@@ -25,7 +25,15 @@ if [ -z "${SAGE_ORIG_PATH_SET}" ]; then
 fi
 export PATH="$SAGE_ROOT/build/bin:$SAGE_SRC/bin:$SAGE_LOCAL/bin:$PATH"
 
-export PYTHONPATH="$SAGE_LOCAL"
+. "$SAGE_ROOT/build/bin/sage-build-env-config"
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to read sage-build-env-config.  Did you run configure?"
+    exit 1
+fi
+
+if [ "$SAGE_VENV_FLAGS" != "DISABLED" ]; then
+    export PYTHONPATH="$SAGE_LOCAL"
+fi
 
 sage_num_threads_array=$(sage-build-num-threads 2>/dev/null || echo 1 2 1)
 sage_num_threads_array="${sage_num_threads_array% *}" # strip third item


### PR DESCRIPTION
This is a follow-up after
- #1707

... to have the PYTHONPATH reflecting the build environment take effect while building the wheelhouse.