### PR TITLE
OrderElement_quadratic: override `canonical_associate`

### DIFF
--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2953,6 +2953,24 @@ cdef class OrderElement_quadratic(NumberFieldElement_quadratic):
             const = const - scale * alpha
             return const.denominator().lcm(scale.denominator())
 
+    def canonical_associate(self):
+        """
+        Return a canonical associate.
+
+        Only implemented here because order elements inherit from field elements,
+        but the canonical associate implemented there does not apply here.
+
+        EXAMPLES::
+
+            sage: x = polygen(ZZ, 'x')
+            sage: K = NumberField(x^2 - 27, 'a')
+            sage: OK = K.ring_of_integers()
+            sage: (OK.1).canonical_associate()
+            NotImplemented
+        """
+        return NotImplemented
+
+
 cdef class Z_to_quadratic_field_element(Morphism):
     """
     Morphism that coerces from integers to elements of a quadratic number


### PR DESCRIPTION
This fixes a bug in `canonical_associate`, introduced in sagemath/sage#40019 @nbruin @mantepse @vbraun, for quadratic number field orders. https://github.com/passagemath/passagemath/pull/1767#issuecomment-3487531312
```
sage: x = polygen(ZZ, 'x')
sage: OE.<w> = EquationOrder(x^2 - x + 2)
sage: parent(w)
Maximal Order generated by w in Number Field in w with defining polynomial x^2 - x + 2
sage: w.canonical_associate()
(1, w)
sage: parent(w) in Fields()
False
sage: w.is_unit()
False
```

The solution, as discussed in #1767 @cxzhong, is to override the `canonical_associate` method inherited from `FieldElement`, as is already done in `OrderElement_absolute` in another file.
