### PR TITLE
Fix mpmath to Sage conversion in _eigenvectors_left_mpmath

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -7477,10 +7477,12 @@ cdef class Matrix(Matrix1):
         from mpmath import mp
         eigenvalues, eigenvectors = mp.eig(self._mpmath_(), left=True, right=False)
         from sage.rings.complex_mpfr import ComplexField
+        from sage.libs.mpmath.utils import mpmath_to_sage
         C = ComplexField(self.base_ring().precision())
+        prec = self.base_ring().precision()
         from sage.modules.free_module_element import vector
         return [
-                (C(e), [vector(C, V)], 1)
+                (mpmath_to_sage(e, prec), [vector(C, [mpmath_to_sage(x, prec) for x in V])], 1)
                 for e, V in zip(eigenvalues, eigenvectors.tolist())
                 ]
 


### PR DESCRIPTION
Use mpmath_to_sage utility from sage.libs.mpmath.utils to convert mpmath eigenvalues and eigenvector components to Sage objects instead of relying on non-existent _mpfr_() and _complex_mpfr_field_() methods.


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


