### PR TITLE
src/sage/repl/display/formatter.py: Remove import of unicode_to_str

### DIFF
--- a/src/sage/repl/display/formatter.py
+++ b/src/sage/repl/display/formatter.py
@@ -63,7 +63,6 @@ This other facility uses a simple
 from io import StringIO
 
 from IPython.core.formatters import DisplayFormatter, PlainTextFormatter
-from IPython.utils.py3compat import unicode_to_str
 from IPython.core.display import DisplayObject
 
 from ipywidgets import Widget
@@ -312,7 +311,7 @@ class SagePlainTextFormatter(PlainTextFormatter):
             print('---- calling ipython formatter ----')
         stream = StringIO()
         printer = SagePrettyPrinter(
-            stream, self.max_width, unicode_to_str(self.newline))
+            stream, self.max_width, self.newline)
         printer.pretty(obj)
         printer.flush()
         return stream.getvalue()


### PR DESCRIPTION
As suggested by @culler in https://groups.google.com/g/sage-devel/c/APNEPF7xUgM/m/FyN2VyZHAgAJ

Incompatibility was also reported in https://groups.google.com/g/sage-support/c/dwii8GG5_3A/m/sWfNGMGzBgAJ

Broken in IPython 9.7 via
- https://github.com/ipython/ipython/pull/15033 @Carreau 
- see https://github.com/sagemath/sage/issues/41140 @jlportner
