### PR TITLE
README.md, ci-wheels.yml: No more wheelhouse for Python 3.14

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -185,9 +185,9 @@ jobs:
               pip download -v --only-binary :all: --no-deps -d $WHEELHOUSE pas$pkg
           fi
           # Use passagemath-conf wheelhouse for missing wheels of third-party projects
-          case "${{ matrix.os }}--${{ matrix.python-version }}" in
-              *--3.14*) export SAGE_CONF_TARGETS="cysignals gmpy2";;
-          esac
+          ## case "${{ matrix.os }}--${{ matrix.python-version }}" in
+          ##     *--3.14*) export SAGE_CONF_TARGETS="cysignals fpylll pplpy primecountpy";;
+          ## esac
           if [ -n "$SAGE_CONF_TARGETS" ]; then
               case "${{ matrix.os }}" in
                   ubuntu*) sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -124,20 +124,6 @@ $ source ~/passagemath-venv/bin/activate
 repeat the last command whenever you open a new terminal session in which you wish to
 use passagemath.)
 
-For Python 3.14,
-[some third-party packages are still missing wheels](https://github.com/passagemath/passagemath/issues/347).
-Build these wheels from source using [![PyPI: passagemath-conf](https://img.shields.io/pypi/v/passagemath-conf.svg?label=passagemath-conf)](https://pypi.python.org/pypi/passagemath-conf)
-
-```bash session
-(passagemath-venv) $ export SAGE_CONF_TARGETS="cysignals gmpy2"
-(passagemath-venv) $ export SAGE_CONF_CONFIGURE_ARGS="--disable-gcc-version-check"
-(passagemath-venv) $ pip cache remove passagemath_conf
-(passagemath-venv) $ pip install --force-reinstall -v passagemath-conf
-(passagemath-venv) $ rehash
-(passagemath-venv) $ export PIP_FIND_LINKS=$(sage-config SAGE_SPKG_WHEELS)
-(passagemath-venv) $ export PIP_PREFER_BINARY=1
-```
-
 Then install the meta-package [![PyPI: passagemath-standard](https://img.shields.io/pypi/v/passagemath-standard.svg?label=passagemath-standard)](https://pypi.python.org/pypi/passagemath-standard)
 
 ```bash session


### PR DESCRIPTION
- https://github.com/passagemath/passagemath/issues/347

As gmpy2 2.3.0a2 now has 3.14 wheels