### PR TITLE
README.md, ci-wheels.yml: Update wheelhouse packages needed for Python 3.14

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -186,7 +186,7 @@ jobs:
           fi
           # Use passagemath-conf wheelhouse for missing wheels of third-party projects
           case "${{ matrix.os }}--${{ matrix.python-version }}" in
-              *--3.14*) export SAGE_CONF_TARGETS="cysignals fpylll pplpy primecountpy";;
+              *--3.14*) export SAGE_CONF_TARGETS="cysignals gmpy2";;
           esac
           if [ -n "$SAGE_CONF_TARGETS" ]; then
               case "${{ matrix.os }}" in

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For Python 3.14,
 Build these wheels from source using [![PyPI: passagemath-conf](https://img.shields.io/pypi/v/passagemath-conf.svg?label=passagemath-conf)](https://pypi.python.org/pypi/passagemath-conf)
 
 ```bash session
-(passagemath-venv) $ export SAGE_CONF_TARGETS="cysignals fpylll pplpy primecountpy"
+(passagemath-venv) $ export SAGE_CONF_TARGETS="cysignals gmpy2"
 (passagemath-venv) $ export SAGE_CONF_CONFIGURE_ARGS="--disable-gcc-version-check"
 (passagemath-venv) $ pip cache remove passagemath_conf
 (passagemath-venv) $ pip install --force-reinstall -v passagemath-conf


### PR DESCRIPTION
- #347

Thanks to @malb uploading fpylll 3.14 wheels; the remaining bottleneck is now gmpy2 @skirpichev 