### PR TITLE
sage_setup.autogen: Do not generate an `__init__.py` file

### DIFF
--- a/src/sage_setup/autogen/interpreters/internal/__init__.py
+++ b/src/sage_setup/autogen/interpreters/internal/__init__.py
@@ -271,6 +271,3 @@ def rebuild(dirname, force=False, interpreters=None, distribution=None):
         if distribution is not None:
             f.write(f"# sage_setup: distribution = {distribution}\n")
         f.write("# " + AUTOGEN_WARN)
-
-    with open(os.path.join(dirname, '__init__.py'), 'w') as f:
-        f.write("# " + AUTOGEN_WARN)


### PR DESCRIPTION
Reported in https://github.com/msys2/MINGW-packages/issues/24738#issuecomment-3567457375 by @striezel 