### PR TITLE
ci-wheels.yml: Tighten glob pattern for constraints

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -175,7 +175,7 @@ jobs:
                        *$pkg_underscore-*.whl) ;;
                        *musllinux*)            ;;
                        *_i686*)                ;;
-                       *-cp$python_version_no_dot-*|*-cp$python_version_abi3-abi3-*|*-none-any*|passagemath_conf-*) echo "${whl%%-*} @ file://$WHEELHOUSE/$whl";;
+                       *-cp$python_version_no_dot-cp$python_version_no_dot-*|*-cp$python_version_abi3-abi3-*|*-none-any*|passagemath_conf-*) echo "${whl%%-*} @ file://$WHEELHOUSE/$whl";;
                    esac;
                done) | tee constraints.txt
               export PIP_CONSTRAINT=${GITHUB_WORKSPACE}/constraints.txt


### PR DESCRIPTION
Fixes testing wheels for 3.14, avoiding duplicate constraints like this
```
passagemath_pari @ file:///home/runner/work/passagemath/passagemath/wheelhouse/passagemath_pari-10.6.38-cp314-cp314-manylinux_2_28_x86_64.whl
passagemath_pari @ file:///home/runner/work/passagemath/passagemath/wheelhouse/passagemath_pari-10.6.38-cp314-cp314t-manylinux_2_28_x86_64.whl
```
https://github.com/passagemath/passagemath/actions/runs/19689356920/job/56401759236#step:9:197