### PR TITLE
src/sage/doctest [Windows]: Do not use `multiprocessing.set_start_method('fork')`

### DIFF
--- a/src/sage/doctest/external.py
+++ b/src/sage/doctest/external.py
@@ -32,14 +32,16 @@ AUTHORS:
 # ****************************************************************************
 
 import multiprocessing
-import platform
+import sys
 
 # With OS X, Python 3.8 defaults to use 'spawn' instead of 'fork' in
 # multiprocessing, and Sage doctesting doesn't work with 'spawn'. See
 # trac #27754.
 # With Python 3.14, the default changed to 'forkserver' on Linux as well.
 # Sage doctesting requires 'fork' method.
-multiprocessing.set_start_method('fork', force=True)
+if sys.platform != 'win32':
+    multiprocessing.set_start_method('fork', force=True)
+
 Array = multiprocessing.Array
 
 # Functions in this module whose name is of the form 'has_xxx' tests if the

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -54,7 +54,6 @@ import hashlib
 import linecache
 import multiprocessing
 import os
-import platform
 import re
 import sys
 import tempfile
@@ -92,7 +91,8 @@ if typing.TYPE_CHECKING:
 # trac #27754.
 # With Python 3.14, the default changed to 'forkserver' on Linux as well.
 # Sage doctesting requires 'fork' method.
-multiprocessing.set_start_method('fork', force=True)
+if sys.platform != 'win32':
+    multiprocessing.set_start_method('fork', force=True)
 
 
 def _sorted_dict_pprinter_factory(start, end):


### PR DESCRIPTION
- Fixes #1824 
- Regression was introduced in https://github.com/passagemath/passagemath/pull/1689 @cxzhong 
