### PR TITLE
`build/pkgs/nauty` [Windows]: Fix installation

### DIFF
--- a/build/pkgs/nauty/spkg-install.in
+++ b/build/pkgs/nauty/spkg-install.in
@@ -17,8 +17,11 @@ addedgeg addptg amtog ancestorg assembleg biplabg catg complg converseg copyg
 countg countneg cubhamg deledgeg delptg dimacs2g directg dreadnaut dretodot
 dretog edgetransg genbg genbgL geng gengL genposetg genquarticg genrang
 genspecialg gentourng gentreeg genktreeg hamheuristic labelg linegraphg listg
-multig nbrhoodg newedgeg pickg planarg productg ranlabg ransubg shortg showg
+multig nbrhoodg newedgeg pickg planarg productg ranlabg ransubg showg
 subdivideg twohamg underlyingg uniqg vcolg watercluster2 NRswitchg"
+if [ -z "$MSYSTEM" ]; then
+    PROGRAMS="$PROGRAMS shortg"
+fi
 sdh_install $PROGRAMS "$SAGE_LOCAL/bin"
 
 sdh_install nauty.h "$SAGE_LOCAL/include/nauty"

--- a/pkgs/sagemath-nauty/repair_wheel.py
+++ b/pkgs/sagemath-nauty/repair_wheel.py
@@ -18,7 +18,7 @@ wheel = Path(sys.argv[1])
 # SAGE_LOCAL/bin/* --> sage_wheels/bin/*
 # list of files from build/pkgs/nauty/spkg-install.in
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/{{addedgeg,addptg,amtog,ancestorg,assembleg,biplabg,catg,complg,converseg,copyg,countg,countneg,cubhamg,deledgeg,delptg,dimacs2g,directg,dreadnaut,dretodot,dretog,edgetransg,genbg,genbgL,geng,gengL,genposetg,genquarticg,genrang,genspecialg,gentourng,gentreeg,genktreeg,hamheuristic,labelg,linegraphg,listg,multig,nbrhoodg,newedgeg,pickg,planarg,productg,ranlabg,ransubg,shortg,showg,subdivideg,twohamg,underlyingg,uniqg,vcolg,watercluster2,NRswitchg}}) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/{{addedgeg,addptg,amtog,ancestorg,assembleg,biplabg,catg,complg,converseg,copyg,countg,countneg,cubhamg,deledgeg,delptg,dimacs2g,directg,dreadnaut,dretodot,dretog,edgetransg,genbg,genbgL,geng,gengL,genposetg,genquarticg,genrang,genspecialg,gentourng,gentreeg,genktreeg,hamheuristic,labelg,linegraphg,listg,multig,nbrhoodg,newedgeg,pickg,planarg,productg,ranlabg,ransubg,{"shortg," if sys.platform != "win32" else ""}showg,subdivideg,twohamg,underlyingg,uniqg,vcolg,watercluster2,NRswitchg}}) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:


### PR DESCRIPTION
Skipping `shortg`.

Split out from https://github.com/passagemath/passagemath/pull/1089

