### PR TITLE
build/pkgs/fflas_ffpack: Retry autotuning until it succeeds

### DIFF
--- a/build/pkgs/fflas_ffpack/spkg-install.in
+++ b/build/pkgs/fflas_ffpack/spkg-install.in
@@ -36,10 +36,8 @@ sdh_configure --with-default="$SAGE_LOCAL" --with-blas-libs="$LINBOX_BLAS" \
               --enable-precompilation $FFLAS_FFPACK_CONFIGURE
 sdh_make
 
-$MAKE autotune
-if [ $? -ne 0 ]; then
-    echo >&2 "Error tuning fflas-ffpack"
-    exit 1
-fi
+while ! $MAKE autotune; do
+    echo >&2 "Error tuning fflas-ffpack, retrying"
+done
 
 sdh_make_install


### PR DESCRIPTION
We sporadically see:
```
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] terminate called after throwing an instance of 'FFPACK::CharpolyFailed'
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] make[4]: *** [Makefile:977: autotune] Error 134
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] make[3]: *** [Makefile:1013: autotune] Error 2
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] Error tuning fflas-ffpack
```
as reported in
- https://github.com/linbox-team/fflas-ffpack/issues/387

Here we work around it by retrying autotuning until it succeeds.
