### PR TITLE
build/pkgs/fflas_ffpack/spkg-install.in: Quoting fix

### DIFF
--- a/build/pkgs/fflas_ffpack/spkg-install.in
+++ b/build/pkgs/fflas_ffpack/spkg-install.in
@@ -6,7 +6,7 @@ else
     LINBOX_BLAS="$(pkg-config --libs blas cblas)"
     BLAS_CFLAGS="$(pkg-config --cflags blas cblas)"
     if [ "$BLAS_CFLAGS" != "" ]; then
-        LINBOX_BLAS_CFLAGS="--with-blas-cflags=$BLAS_CFLAGS"
+        LINBOX_BLAS_CFLAGS="--with-blas-cflags=\"$BLAS_CFLAGS\""
     else
         LINBOX_BLAS_CFLAGS=""
     fi
@@ -31,7 +31,7 @@ fi
 
 # We disable openmp because of build failures, see
 # https://github.com/sagemath/sage/issues/17635#comment:67
-sdh_configure --with-default="$SAGE_LOCAL" --with-blas-libs="$LINBOX_BLAS" \
+eval sdh_configure "--with-default=\"$SAGE_LOCAL\"" "--with-blas-libs=\"$LINBOX_BLAS\"" \
               $LINBOX_BLAS_CFLAGS --disable-static \
               --enable-precompilation $FFLAS_FFPACK_CONFIGURE
 sdh_make


### PR DESCRIPTION
Fix for:
```
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] Using --with-blas-libs='-lopenblas' '--with-blas-cflags=-I/usr/include/openblas -fopenmp'
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] *************************************************
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] Configuring fflas_ffpack-2.5.0+sage-2024-05-18b
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] configure: error: unrecognized option: `-fopenmp'
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] Try `./configure --help' for more information
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] configure: error: unrecognized option: `-fopenmp'
  [fflas_ffpack-2.5.0+sage-2024-05-18b]   [spkg-install] Try `./configure --help' for more information
```
https://github.com/passagemath/passagemath/actions/runs/20110152353/job/57705152293?pr=1825
