### PR TITLE
`FiniteDimensionalModulesWithBasis.MorphismMethods.matrix`: Add options `row_order`, `column_order`

### DIFF
--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -706,14 +706,19 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                   a b c
                 v[1 0 0]
                 w[0 1 0]
+                sage: print(M._repr_matrix(row_order='wv', column_order='cb'))
+                  c b
+                w[0 1]
+                v[0 0]
             """
-            matrix = self.matrix()
+            matrix, _, _, _, row_order, column_order = self._matrix_side_bases_orders(
+                row_order=row_order, column_order=column_order)
 
             from sage.matrix.constructor import options
 
             if matrix.nrows() <= options.max_rows() and matrix.ncols() <= options.max_cols():
-                return matrix.str(top_border=self.domain().basis().keys(),
-                                  left_border=self.codomain().basis().keys())
+                return matrix.str(top_border=column_order,
+                                  left_border=row_order)
 
             return repr(matrix)
 
@@ -735,15 +740,20 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                     a b c
                   v[1 0 0]
                   w[0 1 0]
+                sage: print(M._ascii_art_matrix(row_order='wv', column_order='cb'))
+                  c b
+                w[0 1]
+                v[0 0]
             """
-            matrix = self.matrix()
+            matrix, _, _, _, row_order, column_order = self._matrix_side_bases_orders(
+                row_order=row_order, column_order=column_order)
 
             from sage.matrix.constructor import options
 
             if matrix.nrows() <= options.max_rows() and matrix.ncols() <= options.max_cols():
                 return matrix.str(character_art=True,
-                                  top_border=self.domain().basis().keys(),
-                                  left_border=self.codomain().basis().keys())
+                                  top_border=column_order,
+                                  left_border=row_order)
 
             from sage.typeset.ascii_art import AsciiArt
 
@@ -767,15 +777,20 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                     a b c
                   v⎛1 0 0⎞
                   w⎝0 1 0⎠
+                sage: print(M._unicode_art_matrix(row_order='wv', column_order='cb'))
+                  c b
+                w⎛0 1⎞
+                v⎝0 0⎠
             """
-            matrix = self.matrix()
+            matrix, _, _, _, row_order, column_order = self._matrix_side_bases_orders(
+                row_order=row_order, column_order=column_order)
 
             from sage.matrix.constructor import options
 
             if matrix.nrows() <= options.max_rows() and matrix.ncols() <= options.max_cols():
                 return matrix.str(unicode=True, character_art=True,
-                                  top_border=self.domain().basis().keys(),
-                                  left_border=self.codomain().basis().keys())
+                                  top_border=column_order,
+                                  left_border=row_order)
 
             from sage.typeset.unicode_art import UnicodeArt
 


### PR DESCRIPTION
Follow-up after #1880, which provided a new method `_matrix_side_bases_orders()`.

Here we use it to extend the user-facing method `matrix()` with options `row_order`, `column_order`. This can also be used for zooming in to a submatrix.
```
                sage: M = matrix(ZZ, [[1, 2, 3], [4, 5, 6]],
                ....:            column_keys=['a', 'b', 'c'],
                ....:            row_keys=['v', 'w']); M
                Generic morphism:
                From: Free module generated by {'a', 'b', 'c'} over Integer Ring
                To:   Free module generated by {'v', 'w'} over Integer Ring
                sage: M.matrix()
                [1 2 3]
                [4 5 6]
                sage: M.matrix(row_order='wv', column_order='cb')
                [6 5]
                [3 2]
```

Likewise, we extend the methods `_unicode_art_matrix()`, `_ascii_art_matrix()`, `_repr_matrix()`.

FYI @discopt @xuluze @tscrim