### PR TITLE
remove `unset TERM` when initializing non-interactive sage by @unprintable123, backported

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -597,7 +597,6 @@ fi
 if [ "$1" = '-c' ]; then
     shift
     sage_setup
-    unset TERM  # See Issue #12263
     exec sage-eval "$@"
 fi
 
@@ -1148,7 +1147,6 @@ if [ $# -ge 1 ]; then
         exit 1
     fi
     sage_setup
-    unset TERM  # See Issue #12263
     # sage-run rejects all command line options as the first argument.
     exec sage-run "$@"
 fi


### PR DESCRIPTION
Backport of:
- https://github.com/sagemath/sage/pull/40495 by @unprintable123