### PR TITLE
sage.doctest.sources (printpath): Handle ValueError from relpath in Windows

### DIFF
--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -660,12 +660,13 @@ class FileDocTestSource(DocTestSource):
         """
         if self.options.abspath:
             return os.path.abspath(self.path)
-        else:
+        try:
             relpath = os.path.relpath(self.path)
-            if relpath.startswith(".." + os.path.sep):
-                return self.path
-            else:
-                return relpath
+        except ValueError:
+            return self.path
+        if relpath.startswith(".." + os.path.sep):
+            return self.path
+        return relpath
 
     @lazy_attribute
     def basename(self):


### PR DESCRIPTION
https://github.com/msys2/MINGW-packages/issues/24738#issuecomment-3659100003