### PR TITLE
src/sage/rings/polynomial/polynomial_template.pxi: Remove unused method `get_cparent`

### DIFF
--- a/src/sage/rings/polynomial/polynomial_template.pxi
+++ b/src/sage/rings/polynomial/polynomial_template.pxi
@@ -181,9 +181,6 @@ cdef class Polynomial_template(Polynomial):
             x = parent.base_ring()(x)
             self.__class__.__init__(self, parent, x, check=check, is_gen=is_gen, construct=construct)
 
-    def get_cparent(self):
-        return <long> self._cparent
-
     def __reduce__(self):
         """
         EXAMPLES::


### PR DESCRIPTION
- Fixes #1862 @striezel 
