### PR TITLE
`build/pkgs/sagemath*/spkg-check` [Windows]: Fix `file://` URL in `PIP_FIND_LINKS`

### DIFF
--- a/build/pkgs/sagemath_objects/spkg-check
+++ b/build/pkgs/sagemath_objects/spkg-check
@@ -16,6 +16,10 @@ for lib in "$SAGE_SRC/bin/sage-src-env-config" "$SAGE_SRC/bin/sage-env-config" "
 done
 
 export PIP_NO_INDEX=true
+if [ -n "$MSYSTEM" ]; then
+    # Convert from paths /d/a/... to D:/a/... before prepending file://
+    export SAGE_SPKG_WHEELS=$(cygpath -m $SAGE_SPKG_WHEELS)
+fi
 export PIP_FIND_LINKS="file://$SAGE_SPKG_WHEELS"
 
 unset tox_args


### PR DESCRIPTION
To fix:
```
  [sagemath_cmr-10.6.42]   [spkg-check] WARNING: Location 'file:///d/a/passagemath/passagemath/sage-local/var/lib/sage/venv-python3.12/var/lib/sage/wheels' is ignored: it is neither a file nor a directory.
```
