### PR TITLE
`ci-mingw.yml` (standard-sitepackages): Use `--without-system-typing_extensions`

### DIFF
--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -132,6 +132,7 @@ jobs:
       logs_artifact_suffix: "-standard-sitepackages"
       extra_configure_args: >-
         --enable-system-site-packages
+        --without-system-typing_extensions
       extra_sage_packages: >-
         bliss
         bzip2


### PR DESCRIPTION
This dependency of passagemath-objects is reported as missing during tox tests, for unknown reasons.

Workaround.