### PR TITLE
Disable build isolation when `--enable-system-site-packages` is used

### DIFF
--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -268,7 +268,7 @@ sdh_build_wheel() {
         sdh_die "Error building a wheel for $PKG_NAME"
     else
         case $build_isolation_option in
-            *--no-isolation*)
+            *--no-isolation*--skip-dependency-check*)
                 sdh_die "Error building a wheel for $PKG_NAME"
                 ;;
             *)


### PR DESCRIPTION
We use `--enable-system-site-packages` in ci-mingw.

FYI @orlitzky upstream candidate 