### PR TITLE
ci-mingw.yml: Build and test passagemath-singular

### DIFF
--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -38,6 +38,7 @@ jobs:
         sagemath_planarity
         sagemath_plot
         sagemath_rankwidth
+        sagemath_singular
         sagemath_tdlib
       targets_optional: >-
         sagemath_bliss-check
@@ -57,6 +58,7 @@ jobs:
         sagemath_planarity-check
         sagemath_plot-check
         sagemath_rankwidth-check
+        sagemath_singular-check
         sagemath_tdlib-check
 
   mingw-standard:
@@ -105,6 +107,7 @@ jobs:
         sagemath_planarity
         sagemath_plot
         sagemath_rankwidth
+        sagemath_singular
         sagemath_tdlib
       targets_optional: >-
         sagemath_bliss-check
@@ -124,6 +127,7 @@ jobs:
         sagemath_planarity-check
         sagemath_plot-check
         sagemath_rankwidth-check
+        sagemath_singular-check
         sagemath_tdlib-check
 
   mingw-standard-sitepackages:
@@ -195,6 +199,7 @@ jobs:
         sagemath_planarity
         sagemath_plot
         sagemath_rankwidth
+        sagemath_singular
         sagemath_tdlib
       targets_optional: >-
         sagemath_bliss-check
@@ -214,4 +219,5 @@ jobs:
         sagemath_planarity-check
         sagemath_plot-check
         sagemath_rankwidth-check
+        sagemath_singular-check
         sagemath_tdlib-check

--- a/build/pkgs/singular/spkg-install.in
+++ b/build/pkgs/singular/spkg-install.in
@@ -11,6 +11,10 @@ if [ "x$SAGE_DEBUG" = "xyes" ]; then
     SINGULAR_CONFIGURE="$SINGULAR_CONFIGURE --enable-debug --disable-optimizationflags"
 fi
 
+if [ -n "$MSYSTEM" ]; then
+    SINGULAR_CONFIGURE="$SINGULAR_CONFIGURE --disable-omalloc"
+fi
+
 # Patch out excessive use of -rpath
 # https://github.com/passagemath/passagemath/issues/1633
 sed -i.bak 's/-Wl,-rpath,[^ ]* //g' **/configure


### PR DESCRIPTION
Using `--disable-omalloc` because of: 

```
=== configuring in omalloc (/d/a/passagemath/passagemath/sage-local/var/tmp/sage/build/singular-4.4.1p4/src/omalloc)
2025-12-30T21:58:37.7396287Z   [singular-4.4.1p4]   [spkg-install] 
2025-12-30T21:58:37.7468951Z   [singular-4.4.1p4]   [spkg-install] checking size of long... 4
2025-12-30T21:58:37.7469187Z   [singular-4.4.1p4]   [spkg-install] checking size of void*... 8
2025-12-30T21:58:37.7469416Z   [singular-4.4.1p4]   [spkg-install] checking size of double... 8
2025-12-30T21:58:37.7469840Z   [singular-4.4.1p4]   [spkg-install] checking size of size_t... 8
2025-12-30T21:58:37.7470182Z   [singular-4.4.1p4]   [spkg-install] configure: error: need equal sizes for long and void*
2025-12-30T21:58:37.7470508Z   [singular-4.4.1p4]   [spkg-install] configure: error: ./configure failed for omalloc
```
(Discussed in https://www.singular.uni-kl.de/forum/viewtopic.php%3Ff=10&t=2946&start=0&view=print.html (2021).)