### PR TITLE
`build/make/install`: Use `--no-print-directory` for `make _clean-broken-gcc`

### DIFF
--- a/build/make/install
+++ b/build/make/install
@@ -52,7 +52,7 @@ fi
 # Make the special target _clean-broken-gcc before trying to build any other
 # packages.  This is necessary if configure detected a broken GCC installed
 # in Sage; Issue #25011
-$MAKE _clean-broken-gcc
+$MAKE --no-print-directory _clean-broken-gcc
 
 # If "make" doesn't understand the -q option (although we require
 # GNU make, which supports it), it should exit with a non-zero status


### PR DESCRIPTION
This gets rid of a lot of this:
```
make[1]: Entering directory '/d/a/passagemath/passagemath/build/make'
make[1]: Leaving directory '/d/a/passagemath/passagemath/build/make'
```
