### PR TITLE
Makefile: Invoke 'make --stop' silently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ SAGE_ROOT_LOGS = logs
 # such as: make V=0 build "V=1 normaliz pynormaliz"
 %::
 	@if [ -x relocate-once.py ]; then ./relocate-once.py; fi
-	$(MAKE) build/make/Makefile --stop
+	@$(MAKE) --no-print-directory build/make/Makefile --stop
 	+build/bin/sage-logger \
 		"cd build/make && ./install $@" logs/install.log
 


### PR DESCRIPTION
Avoiding many
```
make -j6 build/make/Makefile --stop
make[1]: Entering directory '/d/a/passagemath/passagemath'
make[1]: 'build/make/Makefile' is up to date.
make[1]: Leaving directory '/d/a/passagemath/passagemath'
```