### PR TITLE
src/sage/env.py (cython_aliases) [Windows]: Use SOABI to distinguish native Windows and MSYS2

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -494,7 +494,7 @@ def cython_aliases(required_modules=None, optional_modules=None):
         var = lib.upper().replace("-", "") + "_"
         if lib == 'cblas':
             lib = get_cblas_pc_module_name()
-        if system == 'Windows' and not os.environ.get('MSYSTEM'):
+        if system == 'Windows' and not sysconfig.get_config_var("SOABI"):  # Windows but not MSYS2/mingw32
             aliases[var + "CFLAGS"] = aliases[var + "INCDIR"] = aliases[var + "LIBDIR"] = aliases[var + "LIBEXTRA"] = []
             aliases[var + "LIBRARIES"] = lib
             continue


### PR DESCRIPTION
To fix a regression in Windows wheel building:
```
  Exception while cythonizing source files: OSError("pkg-config probably not installed: FileNotFoundError(2, 'The system cannot find the file specified', None, 2, None)")
  ************************************************************************
  Traceback (most recent call last):
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\pkgconfig\pkgconfig.py", line 91, in _wrapper
      return func(*args, **kwargs)
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\pkgconfig\pkgconfig.py", line 125, in exists
      return call(cmd) == 0
    File "C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.10.11\tools\lib\subprocess.py", line 345, in call
      with Popen(*popenargs, **kwargs) as p:
    File "C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.10.11\tools\lib\subprocess.py", line 971, in __init__
      self._execute_child(args, executable, preexec_fn, close_fds,
    File "C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.10.11\tools\lib\subprocess.py", line 1456, in _execute_child
      hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
  FileNotFoundError: [WinError 2] The system cannot find the file specified
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-lpxcqymr\cp310-win_amd64\build\venv\lib\site-packages\pyproject_hooks\_in_process\_in_process.py", line 389, in <module>
      main()
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-lpxcqymr\cp310-win_amd64\build\venv\lib\site-packages\pyproject_hooks\_in_process\_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-lpxcqymr\cp310-win_amd64\build\venv\lib\site-packages\pyproject_hooks\_in_process\_in_process.py", line 280, in build_wheel
      return _build_backend().build_wheel(
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\setuptools\build_meta.py", line 432, in build_wheel
      return _build(['bdist_wheel'])
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\setuptools\build_meta.py", line 423, in _build
      return self._build_with_temp_dir(
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\setuptools\build_meta.py", line 404, in _build_with_temp_dir
      self.run_setup()
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\setuptools\build_meta.py", line 317, in run_setup
      exec(code, locals())
    File "<string>", line 10, in <module>
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\sage_setup\__init__.py", line 175, in sage_setup
      aliases=cython_aliases(),
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\sage\env.py", line 504, in cython_aliases
      pc = pkgconfig.parse('zlib')
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\pkgconfig\pkgconfig.py", line 248, in parse
      _raise_if_not_exists(package)
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\pkgconfig\pkgconfig.py", line 102, in _raise_if_not_exists
      if not exists(package):
    File "C:\Users\runneradmin\AppData\Local\Temp\build-env-8kb9d20p\lib\site-packages\pkgconfig\pkgconfig.py", line 93, in _wrapper
      raise EnvironmentError("pkg-config probably not installed: %r" % e)
  OSError: pkg-config probably not installed: FileNotFoundError(2, 'The system cannot find the file specified', None, 2, None)
```
https://github.com/passagemath/passagemath/actions/runs/20610127798/job/59193580576#step:17:437