### PR TITLE
Build Windows wheels for passagemath-libbraiding

### DIFF
--- a/.github/workflows/dist-wheels-windows.yml
+++ b/.github/workflows/dist-wheels-windows.yml
@@ -433,6 +433,20 @@ jobs:
         with:
           package-dir: unpacked/passagemath_combinat
 
+      - name: sagemath-sirocco
+        id:   sagemath-sirocco
+        if:   (success() || failure()) && steps.unpack.outcome == 'success'
+        uses: pypa/cibuildwheel@v3.3.0
+        with:
+          package-dir: unpacked/passagemath_sirocco
+
+      - name: sagemath-libbraiding
+        id:   sagemath-libbraiding
+        if:   (success() || failure()) && steps.unpack.outcome == 'success'
+        uses: pypa/cibuildwheel@v3.3.0
+        with:
+          package-dir: unpacked/passagemath_libbraiding
+
         ####### sagemath-modules and what depends on it
 
       - name: sagemath-modules

--- a/build/pkgs/_cibuildwheel_local_windows/dependencies
+++ b/build/pkgs/_cibuildwheel_local_windows/dependencies
@@ -1,1 +1,1 @@
-boost_cropped gmp glpk gsl mpc mpfr cmr rw cddlib graphs planarity cliquer libhomfly symmetrica m4ri m4rie libgd
+boost_cropped gmp glpk gsl mpc mpfr cmr rw cddlib graphs planarity cliquer libhomfly symmetrica m4ri m4rie libgd sirocco libbraiding


### PR DESCRIPTION
MSYS2 succeeds in packaging sirocco and libbraiding. 

Here we catch up with the Windows wheel build. https://github.com/msys2/MINGW-packages/issues/24738

Incidentally we tighten the declared dependencies of passagemath-libbraiding, FYI @striezel.

FYI @miguelmarco 