### PR TITLE
mingw.yml: Use `--without-system-zlib`

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -216,7 +216,7 @@ jobs:
               mkdir -p logs/pkgs
               touch logs/pkgs/config.log
               ln -s logs/pkgs/config.log config.log
-              ./configure --enable-build-as-root --prefix=$PREFIX --with-sage-venv --with-system-python3=force --disable-python-distutils-check ${{ inputs.extra_configure_args }}
+              ./configure --enable-build-as-root --prefix=$PREFIX --with-sage-venv --with-system-python3=force --disable-python-distutils-check --without-system-zlib ${{ inputs.extra_configure_args }}
           fi
           export TARGETS_PRE="${{ inputs.targets_pre }}" TARGETS="${{ inputs.targets }}" TARGETS_OPTIONAL="${{ inputs.targets_optional }}"
           export VIRTUALENV_SYSTEM_SITE_PACKAGES=1


### PR DESCRIPTION
This is to work around:
```
  [pillow-12.1.0]   [spkg-install] RequiredDependencyException: 
  [pillow-12.1.0]   [spkg-install] 
  [pillow-12.1.0]   [spkg-install] The headers or library files could not be found for zlib,
  [pillow-12.1.0]   [spkg-install] a required dependency when compiling Pillow from source.
  [pillow-12.1.0]   [spkg-install] 
  [pillow-12.1.0]   [spkg-install] Please see the install instructions at:
  [pillow-12.1.0]   [spkg-install]    https://pillow.readthedocs.io/en/latest/installation/basic-installation.html
```