### PR TITLE
src/sage/schemes/elliptic_curves/padics.py: Fix up after #1879, #1887

### DIFF
--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -41,7 +41,8 @@ from sage.rings.rational_field import RationalField
 lazy_import('sage.rings.padics.factory', ['Qp', 'Zp'])
 lazy_import('sage.schemes.hyperelliptic_curves.hypellfrob', 'hypellfrob')
 lazy_import('sage.schemes.hyperelliptic_curves.monsky_washnitzer',
-            ['adjusted_prec', 'matrix_of_frobenius'])
+            ['adjusted_prec', 'matrix_of_frobenius'],
+            as_=['mw_adjusted_prec', 'mw_matrix_of_frobenius'])
 
 from . import padic_lseries as plseries
 
@@ -1703,18 +1704,18 @@ def matrix_of_frobenius(self, p, prec=20, check=False, check_hypotheses=True, al
         # Need to increase precision a little to compensate for precision
         # losses during the computation. (See monsky_washnitzer.py
         # for more details.)
-        adj_prec = adjusted_prec(p, prec)
+        adjusted_prec = mw_adjusted_prec(p, prec)
 
         if check:
             trace = None
         else:
             trace = self.ap(p)
 
-        base_ring = Integers(p**adj_prec)
+        base_ring = Integers(p**adjusted_prec)
 
         R, x = PolynomialRing(base_ring, 'x').objgen()
         Q = x**3 + base_ring(X.a4()) * x + base_ring(X.a6())
-        frob_p = matrix_of_frobenius(Q, p, adj_prec, trace)
+        frob_p = mw_matrix_of_frobenius(Q, p, adjusted_prec, trace)
 
     else:   # algorithm == "sqrtp"
         p_to_prec = p**prec


### PR DESCRIPTION
Name clashes introduced in #1879, #1887 caused these errors:
```
      File "/sage/local/var/lib/sage/venv-python3.13.9/lib/python3.13/site-packages/sage/schemes/elliptic_curves/padics.py", line 73, in __check_padic_hypotheses
        if self.conductor() % p == 0 or self.ap(p) % p == 0:
           ^^^^^^^^^^^^^^
      File "sage/structure/element.pyx", line 495, in sage.structure.element.Element.__getattr__
        return self.getattr_from_category(name)
      File "sage/structure/element.pyx", line 508, in sage.structure.element.Element.getattr_from_category
        return getattr_from_other_class(self, cls, name)
      File "sage/cpython/getattr.pyx", line 363, in sage.cpython.getattr.getattr_from_other_class
        raise AttributeError(dummy_error_message)
    AttributeError: 'sage.rings.polynomial.polynomial_zmod_flint.Polynomial_zmod_flint' object has no attribute '__dict__'
```