### PR TITLE
ci-downstream-mingw.yml: Use Python 3.13

### DIFF
--- a/.github/workflows/ci-downstream-mingw.yml
+++ b/.github/workflows/ci-downstream-mingw.yml
@@ -78,7 +78,7 @@ jobs:
       - name: tox
         run: |
           set -x
-          python_version=3.12
+          python_version=3.13
           python_version_no_dot=${python_version/./}
           pkg=${{ matrix.distribution }}
           cd pkgs/$pkg


### PR DESCRIPTION
MSYS2 switched to Python 3.13 - https://github.com/msys2/MINGW-packages/issues/24738#issuecomment-3733840856