### PR TITLE
tox.ini (archlinux): Set DOCKER_DEFAULT_PLATFORM=linux/amd64

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -374,6 +374,7 @@ setenv =
     archlinux:      SYSTEM=arch
     archlinux:      BASE_IMAGE=archlinux
     archlinux:                                 IGNORE_MISSING_SYSTEM_PACKAGES=yes
+    archlinux:        DOCKER_DEFAULT_PLATFORM=linux/amd64
     #
     # https://hub.docker.com/r/vbatts/slackware
     #


### PR DESCRIPTION
Enabling testing of archlinux on ARM macOS hosts

h/t @antonio-rojas https://github.com/passagemath/passagemath/pull/1966#issuecomment-3736531731