### PR TITLE
build/pkgs/{polymake,perl_cpan_polymake_prereq}: Remove File::Slurp

### DIFF
--- a/build/pkgs/perl_cpan_polymake_prereq/distros/alpine.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/alpine.txt
@@ -1,6 +1,5 @@
 perl-term-readkey
 perl-dev
-perl-file-slurp
 perl-json
 perl-xml-writer
 perl-xml-libxslt

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/cpan.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/cpan.txt
@@ -1,7 +1,6 @@
 XML::Writer
 XML::LibXML
 XML::LibXSLT
-File::Slurp
 JSON
 SVG
 Term::ReadKey

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/debian.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/debian.txt
@@ -2,7 +2,6 @@ libxml-libxslt-perl
 libxml-writer-perl
 libxml2-dev
 libperl-dev
-libfile-slurp-perl
 libjson-perl
 libsvg-perl
 libterm-readkey-perl

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/fedora.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/fedora.txt
@@ -1,5 +1,4 @@
 perl-ExtUtils-Embed
-perl-File-Slurp
 perl-JSON
 perl-Term-ReadLine-Gnu
 perl-TermReadKey

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/freebsd.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/freebsd.txt
@@ -1,7 +1,6 @@
 textproc/p5-XML-Writer
 textproc/p5-XML-LibXML
 textproc/p5-XML-LibXSLT
-devel/p5-File-Slurp
 converters/p5-JSON
 textproc/p5-SVG
 devel/p5-Term-ReadKey

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/gentoo.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/gentoo.txt
@@ -1,7 +1,6 @@
 XML-Writer
 XML-LibXML
 XML-LibXSLT
-File-Slurp
 dev-perl/Term-ReadLine-Gnu
 dev-perl/TermReadKey
 JSON

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/nix.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/nix.txt
@@ -1,4 +1,3 @@
-perlPackages.FileSlurp
 perlPackages.XMLWriter
 perlPackages.XMLLibXML
 perlPackages.XMLLibXSLT

--- a/build/pkgs/perl_cpan_polymake_prereq/distros/void.txt
+++ b/build/pkgs/perl_cpan_polymake_prereq/distros/void.txt
@@ -1,4 +1,3 @@
-perl-File-Slurp
 perl-JSON
 perl-SVG
 perl-Term-ReadKey

--- a/build/pkgs/polymake/SPKG.rst
+++ b/build/pkgs/polymake/SPKG.rst
@@ -26,8 +26,7 @@ Dependencies
 
 Polymake needs a working installation of Perl, including its shared
 library and some modules (``XML::Writer XML::LibXML XML::LibXSLT
-Term::ReadLine::Gnu JSON SVG``). The Polymake interface in Sage
-additionally needs ``File::Slurp``.
+Term::ReadLine::Gnu JSON SVG``).
 
 These are not provided by a Sage package. The dummy package
 ``perl_cpan_polymake_prereq`` will signal an error at build time if the
@@ -47,7 +46,7 @@ home directory or ``/usr/local``) is using CPAN. This is also the way to
 install the modules on macOS. For this, if you don't have root access,
 you will need the ``local::lib`` Perl module installed::
 
-   cpan -i XML::Writer XML::LibXML XML::LibXSLT File::Slurp Term::ReadLine::Gnu JSON SVG
+   cpan -i XML::Writer XML::LibXML XML::LibXSLT Term::ReadLine::Gnu JSON SVG
 
 Before installing the ``polymake`` package, refer to the SPKG pages for the following packages to ensure a more featureful Polymake installation:
 


### PR DESCRIPTION
It is no longer used - ever since we removed the polymake pexpect interface.