### PR TITLE
src/sage/rings/polynomial/multi_polynomial_sequence.py: Use lazy_import

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -165,12 +165,12 @@ Classes
 from sage.misc.persist import register_unpickle_override
 from sage.misc.cachefunc import cached_method
 from sage.misc.converting_dict import KeyConvertingDict
+from sage.misc.lazy_import import lazy_import
 from sage.rings.finite_rings.finite_field_base import FiniteField
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 from sage.rings.infinity import Infinity
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal, NCPolynomialIdeal
 from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_base
-from sage.rings.polynomial.plural import NCPolynomialRing_plural
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRing_sparse
 from sage.rings.quotient_ring import QuotientRing_nc
@@ -185,6 +185,8 @@ except ImportError:
     def singular_gb_standard_options(func):
         return func
     libsingular_gb_standard_options = singular_gb_standard_options
+
+lazy_import("sage.rings.polynomial.plural", "NCPolynomialRing_plural")
 
 
 def is_PolynomialSequence(F):


### PR DESCRIPTION
... for sage.rings.polynomial.plural

This fixes a modularization regression @trevorkarn 
```
File "sage/categories/pushout.py", line 1702, in sage.categories.pushout.LaurentPolynomialFunctor
Failed example:
    f = P.hom([x + 2*y, 3*x - y],P)
Exception raised:
    Traceback (most recent call last):
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-categories/.tox/py311-norequirements/lib/python3.11/site-packages/sage/doctest/forker.py", line 742, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-categories/.tox/py311-norequirements/lib/python3.11/site-packages/sage/doctest/forker.py", line 1166, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.categories.pushout.LaurentPolynomialFunctor[7]>", line 1, in <module>
        f = P.hom([x + Integer(2)*y, Integer(3)*x - y],P)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "sage/structure/parent_gens.pyx", line 299, in sage.structure.parent_gens.ParentWithGens.hom
        return parent.Parent.hom(self, im_gens, codomain, base_map=base_map, category=category, check=check)
      File "sage/structure/parent.pyx", line 1436, in sage.structure.parent.Parent.hom
        return self.Hom(codomain, **Hom_kwds)(im_gens, **kwds)
      File "sage/structure/parent.pyx", line 902, in sage.structure.parent.Parent.__call__
        return mor._call_with_args(x, args, kwds)
      File "sage/structure/coerce_maps.pyx", line 121, in sage.structure.coerce_maps.DefaultConvertMap_unique._call_with_args
        raise
      File "sage/structure/coerce_maps.pyx", line 111, in sage.structure.coerce_maps.DefaultConvertMap_unique._call_with_args
        return C._element_constructor(x, **kwds)
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-categories/.tox/py311-norequirements/lib/python3.11/site-packages/sage/rings/homset.py", line 175, in _element_constructor_
        return morphism.RingHomomorphism_im_gens(self, x, base_map=base_map, check=check)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "sage/rings/morphism.pyx", line 1838, in sage.rings.morphism.RingHomomorphism_im_gens.__init__
        im_gens = sage.structure.all.Sequence(im_gens, parent.codomain(),
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-categories/.tox/py311-norequirements/lib/python3.11/site-packages/sage/structure/sequence.py", line 298, in Sequence
        return PolynomialSequence(x, universe, immutable=immutable, cr=cr, cr_str=cr_str)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "sage/misc/lazy_import.pyx", line 425, in sage.misc.lazy_import.LazyImport.__call__
        return self.get_object()(*args, **kwds)
      File "sage/misc/lazy_import.pyx", line 243, in sage.misc.lazy_import.LazyImport.get_object
        return self._get_object()
      File "sage/misc/lazy_import.pyx", line 284, in sage.misc.lazy_import.LazyImport._get_object
        raise
      File "sage/misc/lazy_import.pyx", line 278, in sage.misc.lazy_import.LazyImport._get_object
        self._object = getattr(__import__(self._module, {}, {}, [self._name]), self._name)
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-categories/.tox/py311-norequirements/lib/python3.11/site-packages/sage/rings/polynomial/multi_polynomial_sequence.py", line 173, in <module>
        from sage.rings.polynomial.plural import NCPolynomialRing_plural
    ModuleNotFoundError: No module named 'sage.rings.polynomial.plural'
```
https://github.com/passagemath/passagemath/actions/runs/21326881500/job/61385663069#step:9:3923