### PR TITLE
ci-downstream-mingw.yml: use Python 3.14

### DIFF
--- a/.github/workflows/ci-downstream-mingw.yml
+++ b/.github/workflows/ci-downstream-mingw.yml
@@ -81,7 +81,7 @@ jobs:
       - name: tox
         run: |
           set -x
-          python_version=3.13
+          python_version=3.14
           python_version_no_dot=${python_version/./}
           pkg=${{ matrix.distribution }}
           cd pkgs/$pkg


### PR DESCRIPTION
MSYS2 switched to Python 3.14 - https://github.com/msys2/MINGW-packages/issues/24738#issuecomment-3812789725

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


**Edit:** There's also a pull request with the same changes targeting the main branch: https://github.com/passagemath/passagemath/pull/2051

