### PR TITLE
`src/bin/sage-env` [MinGW]: Use `CFLAGS` etc. instead of `CPATH`, `LIBRARY_PATH`

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -288,10 +288,11 @@ fi
 
 if [ -n "$SAGE_LOCAL" ]; then
   if [ -n "$MSYSTEM" ]; then
-      export CFLAGS="-I$SAGE_LOCAL/include $CFLAGS"
-      export CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
-      export CXXFLAGS="-I$SAGE_LOCAL/include $CXXFLAGS"
-      export LDFLAGS="-L$SAGE_LOCAL/lib $LDFLAGS"
+      SAGE_LOCAL_m=$(cygpath -m $SAGE_LOCAL)
+      export CFLAGS="-I${SAGE_LOCAL_m}/include $CFLAGS"
+      export CPPFLAGS="-I${SAGE_LOCAL_m}/include $CPPFLAGS"
+      export CXXFLAGS="-I${SAGE_LOCAL_m}/include $CXXFLAGS"
+      export LDFLAGS="-L${SAGE_LOCAL_m}/lib $LDFLAGS"
   else
     # Compile-time path for libraries.  This is the equivalent of
     # adding the gcc option -L $SAGE_LOCAL/lib.


### PR DESCRIPTION
For #2024
