### PR TITLE
src/sage/interfaces/interface.py: Restore specific import order

### DIFF
--- a/src/sage/interfaces/interface.py
+++ b/src/sage/interfaces/interface.py
@@ -43,12 +43,15 @@ AUTHORS:
 
 import operator
 
-from sage.misc.fast_methods import WithEqualityById
-from sage.misc.instancedoc import instancedoc
 from sage.structure.element import Element, parent
 from sage.structure.parent_base import ParentWithBase
 from sage.structure.richcmp import rich_to_bool
 from sage.structure.sage_object import SageObject
+
+# Above needs to be imported first to break import cycles
+
+from sage.misc.fast_methods import WithEqualityById
+from sage.misc.instancedoc import instancedoc
 
 
 class AsciiArtString(str):


### PR DESCRIPTION
This makes `sage.interfaces.gap` importable by itself again.