### PR TITLE
build/pkgs/libgd/spkg-install.in [Windows]: autoreconf

### DIFF
--- a/build/pkgs/libgd/spkg-install.in
+++ b/build/pkgs/libgd/spkg-install.in
@@ -3,6 +3,11 @@ cd src
 export CFLAGS="-g $CFLAGS"
 
 cp "$SAGE_ROOT"/config/config.* config/
+
+if [ -n "$MSYSTEM" ]; then
+    autoreconf -fi
+fi
+
 # We explicitly disable X, fontconfig, and support of various formats/libraries.
 # We only need png.
 # see https://github.com/libgd/libgd/blob/master/configure.ac


### PR DESCRIPTION
This is to fix
```
  [libgd-2.3.3]   [spkg-install] /usr/bin/bash ../libtool  --tag=CC   --mode=link gcc  -g -g -O2 -fvisibility=hidden -Wall -version-info 3:11:0 -no-undefined  -o libgd.la -rpath /c/a/passagemath/passagemath/sage-local/lib gd.lo gd_avif.lo gd_bmp.lo gd_color.lo gd_color_map.lo gd_color_match.lo gd_crop.lo gd_filename.lo gd_filter.lo gd_gd.lo gd_gd2.lo gd_gif_in.lo gd_gif_out.lo gd_heif.lo gd_interpolation.lo gd_io.lo gd_io_dp.lo gd_io_file.lo gd_io_ss.lo gd_jpeg.lo gd_matrix.lo gd_nnquant.lo gd_png.lo gd_rotate.lo gd_security.lo gd_ss.lo gd_tga.lo gd_tiff.lo gd_topal.lo gd_transform.lo gd_version.lo gd_wbmp.lo gd_webp.lo gd_xbm.lo gdcache.lo gdfontg.lo gdfontl.lo gdfontmb.lo gdfonts.lo gdfontt.lo gdft.lo gdfx.lo gdhelpers.lo gdkanji.lo gdtables.lo gdxpm.lo wbmp.lo -liconv -L/c/a/passagemath/passagemath/sage-local/lib -LC:/a/passagemath/passagemath/sage-local/lib -lz  -LC:/a/passagemath/passagemath/sage-local/lib -lpng16
  [libgd-2.3.3]   [spkg-install] 
  [libgd-2.3.3]   [spkg-install] *** Warning: linker path does not have real file for library -lz.
  [libgd-2.3.3]   [spkg-install] *** I have the capability to make that library automatically link in when
  [libgd-2.3.3]   [spkg-install] *** you link to this library.  But I can only do this if you have a
  [libgd-2.3.3]   [spkg-install] *** shared version of the library, which you do not appear to have
  [libgd-2.3.3]   [spkg-install] *** because I did check the linker path looking for a file starting
  [libgd-2.3.3]   [spkg-install] *** with libz and none of the candidates passed a file format test
  [libgd-2.3.3]   [spkg-install] *** using a file magic. Last file checked: C:/a/_temp/msys64/clangarm64/lib/libz.dll.a
  [libgd-2.3.3]   [spkg-install] *** The inter-library dependencies that have been dropped here will be
  [libgd-2.3.3]   [spkg-install] *** automatically added whenever a program is linked with this library
  [libgd-2.3.3]   [spkg-install] *** or is declared to -dlopen it.
  [libgd-2.3.3]   [spkg-install] 
  [libgd-2.3.3]   [spkg-install] *** Since this library must not contain undefined symbols,
  [libgd-2.3.3]   [spkg-install] *** because either the platform does not support them or
  [libgd-2.3.3]   [spkg-install] *** it was explicitly requested with -no-undefined,
  [libgd-2.3.3]   [spkg-install] *** libtool will only create a static version of it.
```

as previously seen for libpng