### PR TITLE
`build/pkgs/dot2tex`: Pin pyparsing <3.3

### DIFF
--- a/build/pkgs/dot2tex/version_requirements.txt
+++ b/build/pkgs/dot2tex/version_requirements.txt
@@ -1,1 +1,2 @@
 dot2tex >=2.11.3
+pyparsing <3.3


### PR DESCRIPTION
To avoid deprecation warnings