### PR TITLE
Doctests: Undo renames after doctests

### DIFF
--- a/src/sage/categories/homset.py
+++ b/src/sage/categories/homset.py
@@ -623,16 +623,17 @@ class Homset(Set_generic):
             sage: H
             Set of Morphisms from X to Y in Category of monoids
             sage: TestSuite(H).run()
-
-            sage: H = MyHomset(X, Y, category=1, base = ZZ)
+            sage: H = MyHomset(X, Y, category=1, base=ZZ)
             Traceback (most recent call last):
             ...
             TypeError: category (=1) must be a category
-
-            sage: H = MyHomset(X, Y, category=1, base = ZZ, check = False)
+            sage: H = MyHomset(X, Y, category=1, base=ZZ, check=False)
             Traceback (most recent call last):
             ...
             AttributeError: 'sage.rings.integer.Integer' object has no attribute 'Homsets'...
+            sage: X.rename()
+            sage: Y.rename()
+
             sage: P.<t> = ZZ[]
             sage: f = P.hom([1/2*t])
             sage: f.parent().domain()

--- a/src/sage/categories/modules.py
+++ b/src/sage/categories/modules.py
@@ -985,4 +985,6 @@ class Modules(Category_module):
                     F # G
                     sage: T.tensor_factors()
                     (F, G)
+                    sage: F.rename()
+                    sage: G.rename()
                 """

--- a/src/sage/modules/module.pyx
+++ b/src/sage/modules/module.pyx
@@ -113,6 +113,7 @@ cdef class Module(Parent):
         sage: M.rename('toto')
         sage: h == M.__hash__()
         True
+        sage: M.rename()
     """
     def __init__(self, base, category=None, names=None):
         """

--- a/src/sage/monoids/automatic_semigroup.py
+++ b/src/sage/monoids/automatic_semigroup.py
@@ -414,6 +414,7 @@ class AutomaticSemigroup(UniqueRepresentation, Parent):
             sage: AutomaticSemigroup(Family({1: S5((1,2))}),                            # needs sage.groups
             ....:                    category=Groups().Finite().Subobjects())
             A subgroup of (S5) with 1 generators
+            sage: S5.rename()
         """
         categories = [Groups(), Monoids(), Semigroups()]
         for category in categories:
@@ -520,6 +521,7 @@ class AutomaticSemigroup(UniqueRepresentation, Parent):
 
             sage: len(M._retract.cache.keys())                                          # needs sage.groups
             24
+            sage: S5.rename()
         """
         element = self._retract(ambient_element)
         if check:
@@ -831,6 +833,7 @@ class AutomaticSemigroup(UniqueRepresentation, Parent):
             19
             sage: M.cardinality()
             24
+            sage: W.rename()
         """
         if self._constructed:
             return

--- a/src/sage/sets/set.py
+++ b/src/sage/sets/set.py
@@ -555,6 +555,7 @@ class Set_object(Set_generic, Set_base, Set_boolean_operators, Set_add_sub_opera
             sage: X.rename('{ integers }')
             sage: X
             { integers }
+            sage: X.rename()
         """
         return "Set of elements of " + repr(self.__object)
 


### PR DESCRIPTION
On Windows, we currently use the single-process doctester. So we need to make sure that changes such as renames of cached global objects are undone at the end of the doctests that do that.