### PR TITLE
build/pkgs/jupyterlite_sphinx: New

### DIFF
--- a/build/pkgs/jupyterlite_sphinx/SPKG.rst
+++ b/build/pkgs/jupyterlite_sphinx/SPKG.rst
@@ -1,0 +1,17 @@
+jupyterlite_sphinx: Sphinx extension for deploying JupyterLite
+==============================================================
+
+Description
+-----------
+
+Sphinx extension for deploying JupyterLite
+
+License
+-------
+
+BSD 3-Clause License
+
+Upstream Contact
+----------------
+
+https://pypi.org/project/jupyterlite-sphinx/

--- a/build/pkgs/jupyterlite_sphinx/dependencies
+++ b/build/pkgs/jupyterlite_sphinx/dependencies
@@ -1,0 +1,1 @@
+docutils jupyter_server jupyterlab_server nbformat sphinx jupyter_core

--- a/build/pkgs/jupyterlite_sphinx/requirements.txt
+++ b/build/pkgs/jupyterlite_sphinx/requirements.txt
@@ -1,0 +1,1 @@
+jupyterlite-sphinx

--- a/build/pkgs/jupyterlite_sphinx/type
+++ b/build/pkgs/jupyterlite_sphinx/type
@@ -1,0 +1,1 @@
+standard

--- a/configure.ac
+++ b/configure.ac
@@ -466,7 +466,7 @@ AC_ARG_ENABLE([cvxopt],
 AC_ARG_ENABLE([notebook],
   AS_HELP_STRING([--disable-notebook],
                  [disable build of the Jupyter notebook and related packages]), [
-    for pkg in notebook nbconvert beautifulsoup4 sagenb_export nbformat nbclient terminado send2trash prometheus_client mistune pandocfilters bleach defusedxml jsonschema jupyter_jsmol argon2_cffi argon2_cffi_bindings webencodings tinycss2 ipympl soupsieve fastjsonschema anyio arrow async_lru fqdn isoduration json5 jsonpointer jsonschema_specifications jupyter_events jupyter_lsp jupyter_server jupyter_server_terminals jupyterlab jupyterlab_server jupyterlab_pygments jupyterlab_mathjax2 jupyter_sphinx notebook_shim overrides python_json_logger pyyaml referencing rfc3339_validator rfc3986_validator rpds_py sniffio types_python_dateutil uri_template webcolors websocket_client httpx httpcore h11; do
+    for pkg in notebook nbconvert beautifulsoup4 sagenb_export nbformat nbclient terminado send2trash prometheus_client mistune pandocfilters bleach defusedxml jsonschema jupyter_jsmol argon2_cffi argon2_cffi_bindings webencodings tinycss2 ipympl soupsieve fastjsonschema anyio arrow async_lru fqdn isoduration json5 jsonpointer jsonschema_specifications jupyter_events jupyter_lsp jupyter_server jupyter_server_terminals jupyterlab jupyterlab_server jupyterlab_pygments jupyterlab_mathjax2 jupyter_sphinx jupyterlite_sphinx notebook_shim overrides python_json_logger pyyaml referencing rfc3339_validator rfc3986_validator rpds_py sniffio types_python_dateutil uri_template webcolors websocket_client httpx httpcore h11; do
       AS_VAR_SET([SAGE_ENABLE_$pkg], [$enableval])
     done
   ])

--- a/pkgs/sagemath-doc-html/pyproject.toml.m4
+++ b/pkgs/sagemath-doc-html/pyproject.toml.m4
@@ -9,6 +9,7 @@ requires = [
     SPKG_INSTALL_REQUIRES_sphinx_inline_tabs
     SPKG_INSTALL_REQUIRES_furo
     SPKG_INSTALL_REQUIRES_jupyter_sphinx
+    SPKG_INSTALL_REQUIRES_jupyterlite_sphinx
     SPKG_INSTALL_REQUIRES_sagelib
     SPKG_INSTALL_REQUIRES_sagemath_cliquer
     SPKG_INSTALL_REQUIRES_sagemath_cmr

--- a/pkgs/sagemath-doc-pdf/pyproject.toml.m4
+++ b/pkgs/sagemath-doc-pdf/pyproject.toml.m4
@@ -9,6 +9,7 @@ requires = [
     SPKG_INSTALL_REQUIRES_sphinx_inline_tabs
     SPKG_INSTALL_REQUIRES_furo
     SPKG_INSTALL_REQUIRES_jupyter_sphinx
+    SPKG_INSTALL_REQUIRES_jupyterlite_sphinx
     SPKG_INSTALL_REQUIRES_sagelib
 ]
 build-backend = 'mesonpy'

--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -60,6 +60,8 @@ extensions = [
 if JupyterSphinx().is_present():
     extensions.append('jupyter_sphinx')
 
+extensions.append('jupyterlite_sphinx')
+
 jupyter_execute_default_kernel = 'sagemath'
 
 if SAGE_LIVE_DOC == 'yes':
@@ -113,6 +115,40 @@ if SAGE_LIVE_DOC == 'yes':
             'lineNumbers': True,
         }
     })
+
+
+# -- Options for jupyterlite-sphinx ------------------------------------------
+# from https://github.com/jupyterlite/sphinx-demo/blob/main/xeus-kernel-example/docs/source/conf.py
+
+# A list of glob patterns relative to the source directory that match file
+#  and directories to include as a part of the embedded JupyterLite site.
+jupyterlite_contents = ["custom_contents/*"]
+
+# Set this to False to unsilence the verbose output of the JupyterLite build
+# process. This is useful for debugging.
+jupyterlite_silence = False
+
+# Strip out the JupyterLite contents from the output HTML files
+strip_tagged_cells = True
+
+# The global_enable_try_examples configuration option inserts the directives
+# to all "Examples" processed by numpydoc or sphinx.ext.napoleon.
+global_enable_try_examples = True
+
+# The global_button_text configuration option sets the button text for all
+# buttons, and can be overridden in individual TryExamples buttons as well.
+try_examples_global_button_text = "Try it online"
+
+# Considering the experimental nature of the TryExamples feature, this option
+# allows setting a warning message to be displayed as a cell at the top of
+# all interactive examples. This message can be written in Markdown.
+try_examples_global_warning_text = (
+    "This interactive example is experimental. Please report any issues "
+    "you may find to the JupyterLite team via "
+    "[the issue tracker](https://github.com/jupyterlite/sphinx-demo/issues/new). "
+    "Thank you!"
+)
+
 
 # This code is executed before each ".. PLOT::" directive in the Sphinx
 # documentation. It defines a 'sphinx_plot' function that displays a Sage object


### PR DESCRIPTION
We add another tab to the code examples in the documentation, for serverless (in-browser) execution using JupyterLite and the WebAssembly builds of passagemath deployed in the prefix.dev emscripten-forge channels.

- http://passagemath.org/passagemath-jupyterlite-demo/
- https://github.com/jupyterlite/jupyterlite-sphinx
- https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html#pre-installed-packages
- https://github.com/jupyterlite/sphinx-demo/blob/main/xeus-kernel-example/docs/source/conf.py

FYI @kwankyu 

Deployment in other projects:
- https://github.com/scientific-python/specs/pull/388 by @agriyakhetarpal
- https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/19, https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/19
- pywt: https://github.com/PyWavelets/pywt/issues/706, https://github.com/PyWavelets/pywt/pull/728
- https://github.com/scikit-learn-contrib/fastcan/issues/161
- https://github.com/numpy/numpy/pull/26745, https://github.com/numpy/numpy/issues/25969