### PR TITLE
`sage.misc.stopgap`, `sage.typeset`: Do not fail when `DOCTEST_MODE` cannot be imported

### DIFF
--- a/src/sage/misc/stopgap.pyx
+++ b/src/sage/misc/stopgap.pyx
@@ -15,9 +15,14 @@ Stopgaps
 
 import warnings
 
+cdef bint ENABLED = True
 
-from sage.doctest import DOCTEST_MODE
-cdef bint ENABLED = not DOCTEST_MODE
+try:
+    from sage.doctest import DOCTEST_MODE
+except ImportError:
+    pass
+else:
+    ENABLED = not DOCTEST_MODE
 
 
 def set_state(bint mode):

--- a/src/sage/typeset/character_art.py
+++ b/src/sage/typeset/character_art.py
@@ -218,9 +218,13 @@ class CharacterArt(SageObject):
             sage: empty_ascii_art._isatty()
             False
         """
-        from sage.doctest import DOCTEST_MODE
-        if DOCTEST_MODE:
-            return False
+        try:
+            from sage.doctest import DOCTEST_MODE
+        except ImportError:
+            pass
+        else:
+            if DOCTEST_MODE:
+                return False
         try:
             return sys.stdout.isatty()
         except Exception:


### PR DESCRIPTION
This makes it work when passagemath-repl is not installed.