### PR TITLE
.github/workflows/ci-mingw.yml: Add passagemath-symbolics

### DIFF
--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -45,6 +45,7 @@ jobs:
         sagemath_polyhedra
         sagemath_rankwidth
         sagemath_sirocco
+        sagemath_symbolics
         sagemath_tdlib
       targets_optional: >-
         sagemath_bliss-check
@@ -130,6 +131,7 @@ jobs:
         sagemath_polyhedra
         sagemath_rankwidth
         sagemath_sirocco
+        sagemath_symbolics
         sagemath_tdlib
       targets_optional: >-
         sagemath_bliss-check
@@ -240,6 +242,7 @@ jobs:
         sagemath_polyhedra
         sagemath_rankwidth
         sagemath_sirocco
+        sagemath_symbolics
         sagemath_tdlib
       targets_optional: >-
         sagemath_bliss-check

--- a/build/pkgs/singular/dependencies
+++ b/build/pkgs/singular/dependencies
@@ -1,4 +1,4 @@
-$(MP_LIBRARY) ntl flint readline mpfr cddlib
+$(MP_LIBRARY) ntl flint readline mpfr cddlib | meson
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/singular/spkg-install.in
+++ b/build/pkgs/singular/spkg-install.in
@@ -56,9 +56,19 @@ build_singular()
     fi
 }
 
-
-# Actually run all the functions defined above
-for i in config build_singular; do
-    echo "############### Singular stage $i ###############"
-    cd "$SRC" && $i
-done
+if [ -n "$MSYSTEM" ]; then
+    # Only build factory on MinGW
+    for a in "$SAGE_ROOT"/subprojects/packagefiles/singular/*.patch; do
+        patch -p1 < "$a"
+    done
+    (cd "$SAGE_ROOT"/subprojects/packagefiles/singular && tar cf - .) | tar xf -
+    meson setup build --prefix="$SAGE_LOCAL"
+    meson compile -C build
+    meson install -C build
+else
+    # Full build of Singular
+    for i in config build_singular; do
+        echo "############### Singular stage $i ###############"
+        cd "$SRC" && $i
+    done
+fi

--- a/subprojects/packagefiles/singular/include_config.patch
+++ b/subprojects/packagefiles/singular/include_config.patch
@@ -2,12 +2,14 @@ diff --git a/factory/variable.h b/factory/variable.h
 index 11739d4..bfbb168 100644
 --- a/factory/variable.h
 +++ b/factory/variable.h
-@@ -8,7 +8,7 @@
+@@ -8,7 +8,9 @@
  #ifndef INCL_VARIABLE_H
  #define INCL_VARIABLE_H
  
 -// #include "config.h"
 +#include "config.h"
++
++#include <cstring>
  
  #ifndef NOSTREAMIO
  # ifdef HAVE_IOSTREAM


### PR DESCRIPTION
On MinGW, we replace the Singular dependency by a `libfactory`-only build using the meson build system in `subprojects/` by @tobiasdiez.