### PR TITLE
src/sage/categories/homset.py: Undo renames of unique representation objects in doctests

### DIFF
--- a/src/sage/categories/homset.py
+++ b/src/sage/categories/homset.py
@@ -1284,6 +1284,8 @@ class HomsetWithBase(Homset):
             sage: H.base()
             Integer Ring
             sage: TestSuite(H).run()
+            sage: X.rename()
+            sage: Y.rename()
         """
         if base is None:
             base = X.base_ring()


### PR DESCRIPTION
- Fixes #2226
