### PR TITLE
src/sage/categories: Undo more renames of unique representation objects in doctests

### DIFF
--- a/src/sage/categories/cartesian_product.py
+++ b/src/sage/categories/cartesian_product.py
@@ -63,6 +63,7 @@ class CartesianProductFunctor(CovariantFunctorialConstruction, MultivariateConst
         ('abcdabcd', 1, 1/4)
         sage: C.category()
         Category of Cartesian products of monoids
+        sage: M.rename()
 
         sage: Monoids().CartesianProducts()
         Category of Cartesian products of monoids

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3877,6 +3877,7 @@ class EquivariantSubobjectConstructionFunctor(ConstructionFunctor):
             sage: I.construction()
             (EquivariantSubobjectConstructionFunctor,
             Representation of S3 indexed by {1, 2, 3} over Integer Ring)
+            sage: M.rename()
         """
         from sage.categories.sets_cat import Sets
         super().__init__(Sets(), Sets())


### PR DESCRIPTION
- Fixes #2226
