### PR TITLE
Fix NameError in Partitions.cardinality() when passagemath-flint is absent

### DIFF
--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7172,6 +7172,11 @@ class Partitions_n(Partitions):
             ....:     if Partitions(n).cardinality() != Partitions(n).cardinality(algorithm='pari')])
             0
 
+        For small `n`, the result is computed by enumeration even without FLINT::
+
+            sage: Partitions(5).cardinality()
+            7
+
         For negative inputs, the result is zero (the algorithm is ignored)::
 
             sage: Partitions(-5).cardinality()
@@ -7185,6 +7190,11 @@ class Partitions_n(Partitions):
             return ZZ.zero()
 
         if algorithm == 'flint':
+            if cached_number_of_partitions is None:
+                if self.n <= 10:
+                    return self._cardinality_from_iterator()
+                from sage.features.sagemath import sage__libs__flint
+                sage__libs__flint().require()
             return cached_number_of_partitions(self.n)
 
         elif algorithm == 'gap':
@@ -7265,6 +7275,9 @@ class Partitions_n(Partitions):
         - Florent Hivert (2009-11-23)
         """
         n = self.n
+        if cached_number_of_partitions is None:
+            from sage.features.sagemath import sage__libs__flint
+            sage__libs__flint().require()
         res = []  # A dictionary of multiplicities could be faster.
         while n > 0:
             # Choose a pair d,j = 1,2..., with d*j <= n with probability
@@ -9911,6 +9924,9 @@ def number_of_partitions(n, algorithm='default'):
         algorithm = 'flint'
 
     if algorithm == 'flint':
+        if cached_number_of_partitions is None:
+            from sage.features.sagemath import sage__libs__flint
+            sage__libs__flint().require()
         return cached_number_of_partitions(n)
 
     raise ValueError("unknown algorithm '%s'" % algorithm)
@@ -10059,7 +10075,7 @@ try:
     from sage.libs.flint.arith_sage import number_of_partitions as flint_number_of_partitions
     cached_number_of_partitions = cached_function(flint_number_of_partitions)
 except ImportError:
-    pass
+    cached_number_of_partitions = None
 
 # October 2012: fixing outdated pickles which use classes being deprecated
 from sage.misc.persist import register_unpickle_override


### PR DESCRIPTION
Fixes #2243.

**Root cause**

`partition.py` imports `flint_number_of_partitions` at module level inside a `try/except ImportError: pass` block. On ImportError, `cached_number_of_partitions` is never bound. Three callers use it unconditionally:

- `Partitions.cardinality()` (default `algorithm='flint'`)
- `Partitions.random_element_uniform()`
- `number_of_partitions()`

All three raise `NameError: name 'cached_number_of_partitions' is not defined` in any modular install without `passagemath-flint`.

**Fix**

Following the approach suggested by @mkoeppe in #2243:

- `except ImportError: pass` → `except ImportError: cached_number_of_partitions = None`
- `cardinality(algorithm='flint')`: for `n ≤ 10`, falls back to `_cardinality_from_iterator()`; for larger `n`, raises `FeatureNotPresentError` via `sage__libs__flint().require()`
- `random_element_uniform()` and `number_of_partitions()`: raise `FeatureNotPresentError` unconditionally when flint is absent (no enumeration fallback is meaningful for these)

The threshold `n ≤ 10` covers the typical doctest range while keeping enumeration fast (≤ 42 partitions). Happy to adjust if a higher value is preferable.

**Verified** in an environment with `passagemath-combinat` but without `passagemath-flint`:

```python
>>> Partitions(5).cardinality()
7                                     # via _cardinality_from_iterator()

>>> Partitions(100).cardinality()
FeatureNotPresentError: sage.libs.flint is not available.
Failed to import `sage.libs.flint.flint_sage`: No module named 'sage.libs.flint'
```