### PR TITLE
Fix .inverse_image() returning the zero element on the wrong curve by @yyyyx4, backported

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -634,6 +634,11 @@ class EllipticCurveHom(Morphism):
             sage: f.inverse_image(f.codomain().zero())
             (0 : 1 : 0)
 
+        Make sure the inverse image of zero is returned on the correct curve (:issue:`41529`)::
+
+            sage: f.inverse_image(0).curve() is f.domain()
+            True
+
         You can give a tuple as input::
 
             sage: f.inverse_image((0, 2))  # random
@@ -667,7 +672,7 @@ class EllipticCurveHom(Morphism):
             if all:
                 return self.kernel_points()
             else:
-                return Q
+                return self.domain().zero()
         if all:
             try:
                 P = self.inverse_image(Q)


### PR DESCRIPTION
Backport of
- https://github.com/sagemath/sage/pull/41529 by @yyyyx4