### PR TITLE
Fix pickling regression introduced by lazy_import in calculus_method.py

### DIFF
--- a/src/sage/manifolds/calculus_method.py
+++ b/src/sage/manifolds/calculus_method.py
@@ -27,11 +27,8 @@ from sage.manifolds.utilities import (
     simplify_chain_real_sympy,
 )
 from sage.misc.latex import latex
-from sage.misc.lazy_import import lazy_import
 from sage.structure.sage_object import SageObject
 from sage.symbolic.ring import SR
-
-lazy_import('sympy', 'latex', as_='sympy_latex')
 
 
 # Conversion functions
@@ -200,6 +197,7 @@ class CalculusMethod(SageObject):
             self._simplify_dict['SR'] = simplify_chain_generic
         # The default simplifying functions are saved:
         self._simplify_dict_default = self._simplify_dict.copy()
+        from sympy import latex as sympy_latex
         self._latex_dict = {'sympy': sympy_latex, 'SR': latex}
 
     def simplify(self, expression, method=None):


### PR DESCRIPTION
After #2282 replaced the module-level `try/except ImportError` with `lazy_import('sympy', 'latex', as_='sympy_latex')`, every `CalculusMethod` instance failed to pickle:

    TypeError: cannot pickle 'sage.misc.lazy_import.LazyImport' object
    when serializing dict item 'sympy'
    when serializing dict item '_latex_dict'
    when serializing sage.manifolds.calculus_method.CalculusMethod state

This cascaded to ~398 failures across the manifolds package — any object holding a `_calc_method` attribute.

**Root cause**: `lazy_import` stores a `LazyImport` descriptor in the module's `__dict__`. Reading that name inside a function uses `LOAD_GLOBAL`, a plain dict lookup that does *not* trigger the descriptor protocol. So `self._latex_dict = {'sympy': sympy_latex, 'SR': latex}` stored the unresolved `LazyImport` object in the instance dict. `LazyImport` objects are not picklable; the actual function (once resolved) would have been fine.

**Fix**: local `from sympy import latex as sympy_latex` inside `__init__`. The import is still deferred until first `CalculusMethod` instantiation, meeting the startup-time goal from #2282. The actual function object is stored in `_latex_dict`, which pickles correctly.

Reported by mkoeppe in https://github.com/passagemath/passagemath/pull/2282#issuecomment-4095302247.