### PR TITLE
docs, tox: document check_unbound_imports and add tox env

### DIFF
--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -443,6 +443,28 @@ Pyflakes
 `Pyflakes <https://github.com/PyCQA/pyflakes>`_ checks for common coding errors.
 
 
+.. _section-tools-check-unbound-imports:
+
+check_unbound_imports
+=====================
+
+:sage_root:`tools/check_unbound_imports.py` is an AST-based checker that
+detects a specific class of ``NameError`` bug: a name imported inside a
+``try`` block where the ``except ImportError`` does not bind the name, and
+the name is then used unconditionally outside the ``try``.  This pattern is
+a common source of silent failures in modular installs where optional
+packages may be absent.
+
+*Usage:*
+
+.. code-block:: console
+
+    $ python3 tools/check_unbound_imports.py <directory_or_file> [...]
+
+The script exits with status 1 if any issues are found, making it suitable
+for use in CI.  It requires only the Python standard library.
+
+
 .. _section-act:
 
 Act

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -258,6 +258,13 @@ description =
 deps = cython-lint
 commands = cython-lint --no-pycodestyle {posargs:{toxinidir}/sage/}
 
+[testenv:check-unbound-imports]
+description =
+    check for names that may be unbound after a failed try/except ImportError
+skip_install = true
+allowlist_externals = python3
+commands = python3 {toxinidir}/../tools/check_unbound_imports.py {posargs:{toxinidir}/sage/}
+
 [testenv:ruff]
 description =
     check against Python style conventions

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -262,8 +262,7 @@ commands = cython-lint --no-pycodestyle {posargs:{toxinidir}/sage/}
 description =
     check for names that may be unbound after a failed try/except ImportError
 skip_install = true
-allowlist_externals = python3
-commands = python3 {toxinidir}/../tools/check_unbound_imports.py {posargs:{toxinidir}/sage/}
+commands = {envpython} {toxinidir}/../tools/check_unbound_imports.py {posargs:{toxinidir}/sage/}
 
 [testenv:ruff]
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -1169,6 +1169,14 @@ envdir   = {[sage_src]envdir}
 commands = {[sage_src]commands}
 allowlist_externals = {[sage_src]allowlist_externals}
 
+[testenv:check-unbound-imports]
+description =
+    check for names that may be unbound after a failed try/except ImportError
+passenv  = {[sage_src]passenv}
+envdir   = {[sage_src]envdir}
+allowlist_externals = {[sage_src]allowlist_externals}
+commands = tox -c {toxinidir}/src/tox.ini -e {envname} -- {posargs:src/sage/}
+
 [testenv:ruff]
 description =
     check against Python style conventions


### PR DESCRIPTION
Part of #2283 (suggested by mkoeppe in a post-merge comment).

## Changes

**`src/doc/en/developer/tools.rst`**: new section documenting `tools/check_unbound_imports.py`, placed between Pyflakes and Act.

**`src/tox.ini`**: new `[testenv:check-unbound-imports]` environment. Not added to the default `envlist` — the tool currently finds existing hits in the tree that would need to be addressed first.
