### PR TITLE
polynomial_quotient_ring: add # needs sage.modules to string-conversion doctests

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -498,13 +498,14 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             sage: p.parent()
             Univariate Quotient Polynomial Ring in xbar over Rational Field
              with modulus x^4 + 2*x^2 + 1
-            sage: p.parent()('xbar')
+            sage: p.parent()('xbar')                                          # needs sage.modules
             xbar
 
         Note that the result of string conversion has the correct parent, even
         when the given string suggests an element of the cover ring or the base
         ring::
 
+            sage: # needs sage.modules
             sage: a = Q1('x'); a
             xbar
             sage: a.parent() is Q1
@@ -527,7 +528,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
         String conversion takes into account both the generators of the quotient
         ring and its base ring::
 
-            sage: Q3('x*ybar^2')
+            sage: Q3('x*ybar^2')                                              # needs sage.modules
             -x
         """
         if not isinstance(x, str):


### PR DESCRIPTION
Part of #2254.

`_element_constructor_` in `polynomial_quotient_ring.py` imports `GenDictWithBasering` from `sage.rings.polynomial.infinite_polynomial_ring` (in `sagemath-modules`) inline when the input is a string. The surrounding `try` block only catches `(TypeError, NameError)`, so a `ModuleNotFoundError` propagates when `sagemath-modules` is absent. This causes failures in CI jobs that install `sagemath-pari` (which depends on `sagemath-categories`, where this file lives) but not `sagemath-modules`.

Root cause: PR #2057 moved `infinite_polynomial_ring` to `sagemath-modules` and converted the top-level import to an inline one; PR #2069 added `# needs` guards elsewhere in this file but missed the string-conversion doctests in `_element_constructor_`.

Fix: add `# needs sage.modules` to the affected doctests.
