### PR TITLE
build/pkgs/{glpk,libgd,libhomfly}/spkg-install.in: Use `std=gnu17`

### DIFF
--- a/build/pkgs/glpk/spkg-install.in
+++ b/build/pkgs/glpk/spkg-install.in
@@ -24,9 +24,10 @@ fi
 #          are valid options.  So we *have to* add Sage's include and
 #          library directories to `CPPFLAGS` (done here) and `LDFLAGS`
 #          (already the default):
-CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
+export CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
 
-export CFLAGS LDFLAGS CPPFLAGS
+# Compilation errors with std=gnu23, https://github.com/passagemath/passagemath/issues/2308
+export CFLAGS="-std=gnu17 $CFLAGS"
 
 sdh_configure --with-gmp --disable-static
 sdh_make

--- a/build/pkgs/libgd/spkg-install.in
+++ b/build/pkgs/libgd/spkg-install.in
@@ -2,6 +2,9 @@ cd src
 
 export CFLAGS="-g $CFLAGS"
 
+# Compilation errors in libgd 2.3.3 with std=gnu23, https://github.com/passagemath/passagemath/issues/2307
+export CFLAGS="-std=gnu17 $CFLAGS"
+
 cp "$SAGE_ROOT"/config/config.* config/
 
 if [ -n "$MSYSTEM" ]; then

--- a/build/pkgs/libhomfly/spkg-install.in
+++ b/build/pkgs/libhomfly/spkg-install.in
@@ -1,5 +1,9 @@
 cd src
 cp "$SAGE_ROOT"/config/config.* build-aux/
+
+# Compilation errors with std=gnu23, https://github.com/passagemath/passagemath/issues/2306
+export CFLAGS="-std=gnu17 $CFLAGS"
+
 sdh_configure $LIBHOMFLY_CONFIGURE
 sdh_make
 sdh_make_install -j1


### PR DESCRIPTION
- Fixes #2306
- Fixes #2307 
- Fixes #2308 
- Fixes #2309
