### PR TITLE
build/pkgs/pari/spkg-check.in [macOS]: Attempt to mitigate nondeterministic hangs

### DIFF
--- a/build/pkgs/pari/spkg-check.in
+++ b/build/pkgs/pari/spkg-check.in
@@ -6,7 +6,13 @@ export CFLAGS=$CFLAGS_O3
 
 cd src
 
-$MAKE test-all
+if [ "$UNAME" = "Darwin" ]; then
+    # Attempt to mitigate nondeterministic hangs
+    # https://github.com/passagemath/passagemath/issues/1684
+    $MAKE -j1 test-all
+else
+    $MAKE test-all
+fi
 
 if [ $? -ne 0 ]; then
     echo "Error: PARI failed the self-tests when running '$MAKE test-all'"


### PR DESCRIPTION
by running the testsuite serially:
- https://github.com/passagemath/passagemath/issues/1684
