### PR TITLE
src/sage/libs/ecl.pyx: Use std=gnu17

### DIFF
--- a/src/sage/libs/ecl.pyx
+++ b/src/sage/libs/ecl.pyx
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-ecl
+# distutils: extra_compile_args = -std=gnu17
 """
 Library interface to Embeddable Common Lisp (ECL)
 """


### PR DESCRIPTION
- Fixes #2324