### PR TITLE
build/pkgs/gmp/spkg-install.in: Use `std=gnu17`

### DIFF
--- a/build/pkgs/gmp/spkg-install.in
+++ b/build/pkgs/gmp/spkg-install.in
@@ -23,6 +23,8 @@ case "$MSYSTEM" in
         ;;
 esac
 
+export CC="$CC -std=gnu17"
+
 user_cflags=$CFLAGS # Save them. 'sage-env' sets CC, but not CFLAGS.
 required_cflags=""  # Additional mandatory settings required by Sage, accumulated below.
 user_ldflags=$LDFLAGS # Save them.


### PR DESCRIPTION
- Fixes #2318 