### PR TITLE
build/pkgs/polymake/spkg-install.in: Use `-Wno-error=invalid-specialization`

### DIFF
--- a/build/pkgs/polymake/spkg-install.in
+++ b/build/pkgs/polymake/spkg-install.in
@@ -28,6 +28,9 @@ export CXXFLAGS="-I$(pwd)/include/core-wrappers -I$(pwd)/include/core $CXXFLAGS"
 # Disable (excessive) C++ debugging information - https://github.com/passagemath/passagemath/pull/1966#issuecomment-3751008687
 export CXXFLAGS="$CXXFLAGS -g0"
 
+# Fix build with clang 21: https://github.com/passagemath/passagemath/issues/2337
+export CXXFLAGS="$CXXFLAGS -Wno-error=invalid-specialization"
+
 # Patch out lib64 guesswork
 sed -i.bak 's/lib64/lib64-disabled/g' perllib/Polymake/ConfigureStandalone.pm
 


### PR DESCRIPTION
- for #2337