### PR TITLE
Add missing sage.libs.linbox doctest guards in modsym and geometry/cone

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -1328,7 +1328,7 @@ def classify_cone_2d(ray0, ray1, check=True):
     [CLS2011]_ ::
 
         sage: from sage.geometry.cone import normalize_rays
-        sage: for i in range(10):
+        sage: for i in range(10):                                    # needs sage.libs.linbox
         ....:     ray0 = random_vector(ZZ, 3)
         ....:     ray1 = random_vector(ZZ, 3)
         ....:     if ray0.is_zero() or ray1.is_zero(): continue

--- a/src/sage/modular/modsym/tests.py
+++ b/src/sage/modular/modsym/tests.py
@@ -231,7 +231,7 @@ class Test:
         EXAMPLES::
 
             sage: from sage.modular.modsym.tests import Test
-            sage: Test().random(1)
+            sage: Test().random(1)                                                # needs sage.libs.linbox
             test_random
             ...
         """


### PR DESCRIPTION
Two doctests were crashing `sagemath_schemes-check` CI jobs with `ModuleNotFoundError: No module named 'sage.matrix.matrix_cyclo_linbox'` (and `matrix_integer_linbox`). These environments don't install `linbox`, but the tests hit code paths that require it at runtime.

The root cause in both cases is an asymmetric dependency: the tests aren't inherently about `linbox`, but call into code that uses it opportunistically:

- `modsym/tests.py`: `Test().random()` exercises `decomposition()`, which calls `charpoly()` on cyclo-dense matrices — eventually importing `matrix_cyclo_linbox`.
- `geometry/cone.py`: the `classify_cone_2d` test loop calls `m.saturation()` on integer matrices, which can dispatch to `matrix_integer_linbox`.

Neither doctest had a `# needs sage.libs.linbox` guard. This PR adds them to the `sage:` line that initiates each code path.

These failures are visible in recent CI — e.g., [job 70482010564](https://github.com/passagemath/passagemath/actions/runs/24151401250/job/70482010564).

*Maintainer note: the same job shows a consistent failure in `src/sage/schemes/affine/affine_homset.py` line 414 — `numerical_points` returns 99 where the doctest expects 100, on every random seed. This looks like a permanent shift in numerical precision rather than occasional drift, and isn't currently captured in `known-test-failures.json`. The baseline hasn't been touched here — flagging in case it warrants a separate fix or baseline update.*