### PR TITLE
affine_homset: fix complex-tolerance comparison in numerical point filtering

### DIFF
--- a/src/sage/schemes/affine/affine_homset.py
+++ b/src/sage/schemes/affine/affine_homset.py
@@ -332,7 +332,7 @@ class SchemeHomset_points_affine(SchemeHomset_points):
                         if numerical:
                             if len(points[i]) == N:
                                 S = AS([points[i][R.gen(j)] for j in range(N)])
-                                if all(g(list(S)) < zero_tol for g in X.defining_polynomials()):
+                                if all(abs(g(list(S))) < zero_tol for g in X.defining_polynomials()):
                                     rat_points.append(S)
                         else:
                             if len(points[i]) == N and I.subs(points[i]) == I0:
@@ -501,7 +501,7 @@ class SchemeHomset_points_affine(SchemeHomset_points):
             for P in points:
                 if len(P) == N:
                     S = AA([P[R.gen(j)] for j in range(N)])
-                    if all(g(list(S)) < zero_tol for g in polys):
+                    if all(abs(g(list(S))) < zero_tol for g in polys):
                         rat_points.append(S)
 
         rat_points = sorted(rat_points)

--- a/src/sage/schemes/projective/projective_homset.py
+++ b/src/sage/schemes/projective/projective_homset.py
@@ -246,7 +246,7 @@ class SchemeHomset_points_projective_field(SchemeHomset_points):
                                 if len(points[i]) == N + 1:
                                     S = PS([points[i][R.gen(j)] for j in range(N + 1)])
                                     S.normalize_coordinates()
-                                    if all(g(list(S)) < zero_tol for g in X.defining_polynomials()):
+                                    if all(abs(g(list(S))) < zero_tol for g in X.defining_polynomials()):
                                         rat_points.add(S)
                             else:
                                 if len(points[i]) == N + 1 and I.subs(points[i]) == I0:
@@ -444,7 +444,7 @@ class SchemeHomset_points_projective_field(SchemeHomset_points):
                             if len(points[i]) == N + 1:
                                 S = PP([points[i][RF.gen(j)] for j in range(N + 1)])
                                 S.normalize_coordinates()
-                                if all(g(list(S)) < zero_tol for g in polys):
+                                if all(abs(g(list(S))) < zero_tol for g in polys):
                                     rat_points.add(S)
                         # remove duplicate element using tolerance
                         #since they are normalized we can just compare coefficients


### PR DESCRIPTION
Fixes #2355.

Both `numerical_points` and the numerical path of `points` filter candidate points with:

```python
if all(g(list(S)) < zero_tol for g in polys):
```

When `F=CDF` or `F=CC`, `g(list(S))` returns a complex number. Sage's `<` on a CDF element compares only the real part, not the magnitude. This produces false positives: a non-root with a large negative real residual (e.g. -0.5) satisfies `< zero_tol`, and so does a non-root with a tiny real part but large imaginary residual. Neither is close to zero. The correct check is the magnitude:

```python
if all(abs(g(list(S))) < zero_tol for g in polys):
```

Four occurrences changed: lines 335 and 504 in `affine_homset.py`, lines 249 and 447 in `projective_homset.py`.