### PR TITLE
plot: add _repr_svg_() for plain Python Jupyter kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,7 @@ src/*.egg-info/
 
 # Virtual environments
 /venv
+/.venv*
 src/.env
 src/.venv
 src/env/

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -1040,6 +1040,76 @@ class Graphics(WithEqualityById, SageObject):
         except Exception:
             return None
 
+    def _repr_svg_(self):
+        r"""
+        Return an SVG representation of this graphics object.
+
+        This allows ``Graphics`` objects to display as vector images in plain
+        Python Jupyter kernels (e.g. xeus-python in JupyterLite, Google Colab,
+        marimo) that do not use Sage's rich output system.
+
+        Unlike :meth:`_render_svg_`, rendering failures are suppressed and
+        ``None`` is returned, matching the IPython ``_repr_svg_`` protocol.
+
+        OUTPUT: string -- SVG image data, or ``None`` if rendering fails
+
+        EXAMPLES::
+
+            sage: G = line([(0, 0), (1, 1)])
+            sage: svg = G._repr_svg_()
+            sage: '<svg' in svg
+            True
+        """
+        try:
+            return self._render_svg_().decode('utf-8')
+        except Exception:
+            return None
+
+    def _render_svg_(self, **kwds):
+        r"""
+        Render this graphics object to SVG bytes.
+
+        Used by :meth:`_repr_svg_` (plain Python kernels). Raises on rendering
+        failure so that callers can surface errors.
+
+        Runtime keyword arguments (e.g. ``figsize``) overlay the instance's
+        saved options, matching the merge order of :meth:`save`.
+
+        OUTPUT: ``bytes`` -- SVG image data (UTF-8 encoded XML)
+
+        EXAMPLES::
+
+            sage: G = line([(0, 0), (1, 1)])
+            sage: svg = G._render_svg_()
+            sage: b'<svg' in svg
+            True
+        """
+        from io import BytesIO
+        from matplotlib import pyplot as plt, rcParams
+        from matplotlib.backends.backend_svg import FigureCanvasSVG
+        options = {}
+        options.update(self.SHOW_OPTIONS)
+        options.update(self._extra_kwds)
+        options.update(kwds)
+        options.pop('dpi', None)
+        options.pop('transparent', None)
+        options.pop('fig_tight', None)
+        rc_backup = (rcParams['ps.useafm'], rcParams['pdf.use14corefonts'],
+                     rcParams['text.usetex'])
+        figure = None
+        try:
+            figure = self.matplotlib(**options)
+            figure.set_canvas(FigureCanvasSVG(figure))
+            figure.tight_layout()
+            buf = BytesIO()
+            figure.savefig(buf, format='svg')
+            return buf.getvalue()
+        finally:
+            if figure is not None:
+                plt.close(figure)
+            (rcParams['ps.useafm'], rcParams['pdf.use14corefonts'],
+             rcParams['text.usetex']) = rc_backup
+
     def _render_png_(self, **kwds):
         r"""
         Render this graphics object to PNG bytes.
@@ -2279,8 +2349,11 @@ class Graphics(WithEqualityById, SageObject):
                 and dm.preferences.graphics != 'disable'):
             try:
                 if _running_in_notebook():
-                    from IPython.display import display, Image
-                    display(Image(self._render_png_(**kwds)))
+                    from IPython.display import display, SVG, Image
+                    try:
+                        display(SVG(self._render_svg_(**kwds).decode('utf-8')))
+                    except Exception:
+                        display(Image(self._render_png_(**kwds)))
                     return
             except Exception:
                 pass

--- a/src/sage/plot/multigraphics.py
+++ b/src/sage/plot/multigraphics.py
@@ -238,6 +238,70 @@ class MultiGraphics(WithEqualityById, SageObject):
         except Exception:
             return None
 
+    def _repr_svg_(self):
+        r"""
+        Return an SVG representation of this graphics array.
+
+        This allows ``MultiGraphics`` objects to display as vector images in
+        plain Python Jupyter kernels that do not use Sage's rich output system.
+
+        Unlike :meth:`_render_svg_`, rendering failures are suppressed and
+        ``None`` is returned, matching the IPython ``_repr_svg_`` protocol.
+
+        OUTPUT: string -- SVG image data, or ``None`` if rendering fails
+
+        EXAMPLES::
+
+            sage: G = graphics_array([line([(0,0),(1,1)]), circle((0,0),1)])
+            sage: svg = G._repr_svg_()
+            sage: '<svg' in svg
+            True
+        """
+        try:
+            return self._render_svg_().decode('utf-8')
+        except Exception:
+            return None
+
+    def _render_svg_(self, **kwds):
+        r"""
+        Render this graphics array to SVG bytes.
+
+        Used by :meth:`_repr_svg_` (plain Python kernels). Raises on rendering
+        failure so that callers can surface errors.
+
+        Runtime keyword arguments (e.g. ``figsize``) are passed through to
+        :meth:`matplotlib`.
+
+        OUTPUT: ``bytes`` -- SVG image data (UTF-8 encoded XML)
+
+        EXAMPLES::
+
+            sage: G = graphics_array([line([(0,0),(1,1)]), circle((0,0),1)])
+            sage: svg = G._render_svg_()
+            sage: b'<svg' in svg
+            True
+        """
+        from io import BytesIO
+        from matplotlib import pyplot as plt, rcParams
+        from matplotlib.backends.backend_svg import FigureCanvasSVG
+        figsize = kwds.pop('figsize', None)
+        rc_backup = (rcParams['ps.useafm'], rcParams['pdf.use14corefonts'],
+                     rcParams['text.usetex'])
+        figure = None
+        try:
+            figure = self.matplotlib(figsize=figsize)
+            figure.set_canvas(FigureCanvasSVG(figure))
+            if isinstance(self, GraphicsArray):
+                figure.tight_layout()
+            buf = BytesIO()
+            figure.savefig(buf, format='svg')
+            return buf.getvalue()
+        finally:
+            if figure is not None:
+                plt.close(figure)
+            (rcParams['ps.useafm'], rcParams['pdf.use14corefonts'],
+             rcParams['text.usetex']) = rc_backup
+
     def _render_png_(self, **kwds):
         r"""
         Render this graphics array to PNG bytes.
@@ -712,8 +776,11 @@ class MultiGraphics(WithEqualityById, SageObject):
                 and dm.preferences.graphics != 'disable'):
             try:
                 if _running_in_notebook():
-                    from IPython.display import display, Image
-                    display(Image(self._render_png_(**kwds)))
+                    from IPython.display import display, SVG, Image
+                    try:
+                        display(SVG(self._render_svg_(**kwds).decode('utf-8')))
+                    except Exception:
+                        display(Image(self._render_png_(**kwds)))
                     return
             except Exception:
                 pass


### PR DESCRIPTION
Follow-up to #2351 and #2236.

## What

`Graphics` and `MultiGraphics` now implement the IPython `_repr_svg_()` protocol, so 2D plots render as vector images in plain Python Jupyter kernels (xeus-python/JupyterLite, Google Colab, marimo) that bypass Sage's rich output system.

- `_repr_svg_()` — returns `str` (decoded UTF-8), matching the IPython protocol
- `_render_svg_()` — returns `bytes` via `FigureCanvasSVG`; raises on failure so callers can distinguish errors from unsupported cases
- `show()` fallback now tries SVG before PNG when `OutputImagePng` is absent from the display backend

No changes to `_rich_repr_()`, 3D objects, or the Sage kernel display path.

## Tests

Inline doctests added to all four new methods. Verified locally:

```
sage -t src/sage/plot/graphics.py   # 210 tests, 1 pre-existing tachyon failure
```

`multigraphics.py` tests run on CI (file-level `# sage.doctest: needs sage.symbolic` skips them locally without `passagemath-symbolics`).