### PR TITLE
plot: fix circular import in plain Python by pre-importing sage.structure.element

### DIFF
--- a/pkgs/sagemath-plot/tox.ini
+++ b/pkgs/sagemath-plot/tox.ini
@@ -67,6 +67,9 @@ allowlist_externals =
 commands =
     # Beware of the treacherous non-src layout. "./sage/" shadows the installed sage package.
     python -c 'import sys; "" in sys.path and sys.path.remove(""); import sage.all__sagemath_plot'
+    # Bare import smoke tests: catch circular import regressions (refs #1604)
+    python -c 'import sys; "" in sys.path and sys.path.remove(""); import sage.plot.line'
+    python -c 'import sys; "" in sys.path and sys.path.remove(""); import sage.plot.animate'
 
     !notest:        bash -c 'cd $(python -c "import sys; \"\" in sys.path and sys.path.remove(\"\"); from sage.env import SAGE_LIB; print(SAGE_LIB)") \
     !notest:                 && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_plot --baseline-stats-path={toxinidir}/known-test-failures.json $SAGE_DOCTEST_OPTIONS {posargs:--installed}'

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -131,6 +131,7 @@ import shlex
 import struct
 import zlib
 
+import sage.structure.element  # break Cython circular import (refs #1604)
 from sage.misc.fast_methods import WithEqualityById
 from sage.structure.sage_object import SageObject
 from sage.misc.temporary_file import tmp_dir, tmp_filename

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -40,6 +40,7 @@ from collections.abc import Iterable
 from math import isnan
 import sage.misc.verbose
 from sage.misc.temporary_file import tmp_filename
+import sage.structure.element  # break Cython circular import (refs #1604)
 from sage.misc.fast_methods import WithEqualityById
 from sage.structure.sage_object import SageObject
 from sage.misc.decorators import suboptions

--- a/src/sage/plot/multigraphics.py
+++ b/src/sage/plot/multigraphics.py
@@ -16,6 +16,7 @@ AUTHORS:
   ``GraphicsArray`` that was defined in the module :mod:`~sage.plot.graphics`.
 """
 import os
+import sage.structure.element  # break Cython circular import (refs #1604)
 from sage.misc.fast_methods import WithEqualityById
 from sage.structure.sage_object import SageObject
 from sage.misc.temporary_file import tmp_filename

--- a/src/sage/plot/primitive.py
+++ b/src/sage/plot/primitive.py
@@ -18,6 +18,7 @@ Plotting primitives
 #
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
+import sage.structure.element  # break Cython circular import (refs #1604)
 from sage.misc.fast_methods import WithEqualityById
 from sage.structure.sage_object import SageObject
 from sage.misc.verbose import verbose


### PR DESCRIPTION
Fixes #2367. Refs #1604.

## The bug

`from sage.plot.line import line` raises `ImportError: cannot import
name 'ConstantFunction'` in a fresh venv. The cycle: importing
`sage.misc.fast_methods` (Cython) triggers `constant_function.pyx`
init, which re-enters `sage.structure` before it finishes loading.

## The fix

Add `import sage.structure.element` before `from sage.misc.fast_methods
import WithEqualityById` in the four `sage.plot` modules that import
`fast_methods` directly: `primitive.py`, `graphics.py`,
`multigraphics.py`, `animate.py`.

## Tests

Verified manually in `.venv-plot` (Python 3.12, passagemath-plot 10.8.4):

```python
from sage.plot.line import line
from sage.plot.circle import circle
from sage.plot.multigraphics import GraphicsArray
from sage.plot.animate import animate
```

All four now work in a fresh Python session. An automated doctest is
not possible: the cycle only fires on first import in a bare session,
and the doctest runner pre-initializes via `sage.all__sagemath_plot`,
which masks the failure.