### PR TITLE
`build/pkgs/macaulay2`, `pkgs/sagemath-macaulay2/repair_wheel.py`: Build and ship share/doc/Macaulay2

### DIFF
--- a/build/pkgs/macaulay2/dependencies
+++ b/build/pkgs/macaulay2/dependencies
@@ -1,4 +1,4 @@
-4ti2 fflas_ffpack gettext gfortran boost_cropped cddlib libffi givaro glpk $(MP_LIBRARY) $(BLAS) liblzma mpc mpfi mpfr ncurses ntl readline singular libxml2 zlib lrslib normaliz topcom git gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve gdbm eigen gc jansson | cmake ninja_build pkgconf git $(PYTHON)
+4ti2 fflas_ffpack gettext gfortran boost_cropped cddlib libffi givaro glpk $(MP_LIBRARY) $(BLAS) liblzma mpc mpfi mpfr ncurses ntl readline singular libxml2 zlib lrslib normaliz topcom git gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve gdbm eigen gc jansson cohomcalg | cmake ninja_build pkgconf git $(PYTHON)
 
 # other needed packages according to https://github.com/Macaulay2/M2/blob/master/M2/INSTALL:
 # autoconf bison cohomcalg curl emacs flex install-info libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libgdbm-dev libgivaro-dev libglpk-dev libgtest-dev libmps-dev libtool lsb-release  npm openssh-server pinentry-curses time unzip xbase-clients yasm dpkg-dev libeigen3-dev libtool-bin coinor-csdp coinor-csdp-doc

--- a/build/pkgs/macaulay2/dependencies
+++ b/build/pkgs/macaulay2/dependencies
@@ -1,4 +1,4 @@
-4ti2 fflas_ffpack gettext gfortran boost_cropped cddlib libffi givaro glpk $(MP_LIBRARY) $(BLAS) liblzma mpc mpfi mpfr ncurses ntl readline singular libxml2 zlib lrslib normaliz topcom git gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve gdbm eigen gc jansson cohomcalg | cmake ninja_build pkgconf git $(PYTHON)
+4ti2 fflas_ffpack gettext gfortran boost_cropped cddlib libffi givaro glpk $(MP_LIBRARY) $(BLAS) liblzma mpc mpfi mpfr ncurses ntl readline singular libxml2 zlib lrslib normaliz topcom git gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve gdbm eigen gc jansson cohomcalg qepcad | cmake ninja_build pkgconf git $(PYTHON)
 
 # other needed packages according to https://github.com/Macaulay2/M2/blob/master/M2/INSTALL:
 # autoconf bison cohomcalg curl emacs flex install-info libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libgdbm-dev libgivaro-dev libglpk-dev libgtest-dev libmps-dev libtool lsb-release  npm openssh-server pinentry-curses time unzip xbase-clients yasm dpkg-dev libeigen3-dev libtool-bin coinor-csdp coinor-csdp-doc

--- a/build/pkgs/macaulay2/dependencies
+++ b/build/pkgs/macaulay2/dependencies
@@ -1,4 +1,4 @@
-4ti2 fflas_ffpack gettext gfortran boost_cropped cddlib libffi givaro glpk $(MP_LIBRARY) $(BLAS) liblzma mpc mpfi mpfr ncurses ntl readline singular libxml2 zlib lrslib normaliz topcom git gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve gdbm eigen gc jansson cohomcalg qepcad | cmake ninja_build pkgconf git $(PYTHON)
+4ti2 fflas_ffpack gettext gfortran boost_cropped cddlib libffi givaro glpk $(MP_LIBRARY) $(BLAS) liblzma mpc mpfi mpfr ncurses ntl readline singular libxml2 zlib lrslib normaliz topcom git gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve gdbm eigen gc jansson cohomcalg qepcad csdp | cmake ninja_build pkgconf git $(PYTHON)
 
 # other needed packages according to https://github.com/Macaulay2/M2/blob/master/M2/INSTALL:
 # autoconf bison cohomcalg curl emacs flex install-info libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libgdbm-dev libgivaro-dev libglpk-dev libgtest-dev libmps-dev libtool lsb-release  npm openssh-server pinentry-curses time unzip xbase-clients yasm dpkg-dev libeigen3-dev libtool-bin coinor-csdp coinor-csdp-doc

--- a/build/pkgs/macaulay2/patches/allow-older-gfan.patch
+++ b/build/pkgs/macaulay2/patches/allow-older-gfan.patch
@@ -1,0 +1,35 @@
+Description: Allow older gfan in older Ubuntu releases.
+ At least for now, we don't actually require gfan 0.8 for any features.
+ Backporting take some effort since we don't have libasl-dev in focal.
+Author: Doug Torrance <dtorrance@debian.org>
+Forwarded: not-needed
+Last-Update: 2026-06-06
+
+--- a/M2/configure.ac
++++ b/M2/configure.ac
+@@ -974,10 +974,10 @@
+ AC_MSG_CHECKING(whether the package gfan is installed)
+ if command -v gfan > /dev/null
+ then gfan_version=`gfan _version | head -2 | tail -1 | sed 's/gfan//'`
+-     AX_COMPARE_VERSION([$gfan_version], [ge], [0.8],
++     AX_COMPARE_VERSION([$gfan_version], [ge], [0.6],
+           [AC_MSG_RESULT([yes])
+            FILE_PREREQS="$FILE_PREREQS `command -v gfan`"],
+-          [AC_MSG_RESULT([yes, but < 0.8, will build])
++          [AC_MSG_RESULT([yes, but < 0.6, will build])
+            BUILD_gfan=yes])
+ else AC_MSG_RESULT([no, will build])
+      BUILD_gfan=yes
+--- a/M2/Macaulay2/packages/gfanInterface.m2
++++ b/M2/Macaulay2/packages/gfanInterface.m2
+@@ -1013,9 +1013,7 @@
+ 	if gfanProgram === null then
+ 	    gfanProgram = findProgram("gfan", "gfan --help",
+ 		Verbose => gfanVerbose,
+-		-- version 0.8 is required (the 0.6.2 series predates several
+-		-- features used here and is no longer supported upstream)
+-		MinimumVersion => ("0.8",
++		MinimumVersion => ("0.6",
+ 		    "gfan _version | head -2 | tail -1 | sed 's/gfan//'"));
+ 	tmpFile := gfanMakeTemporaryFile data;
+ 

--- a/build/pkgs/macaulay2/spkg-install.in
+++ b/build/pkgs/macaulay2/spkg-install.in
@@ -52,5 +52,5 @@ if [ -n "$SAGE_MACAULAY2_TARGETS" ]; then
    # "Note that this target must be built separately, before proceeding to M2-binary."
    cmake --build . --target $SAGE_MACAULAY2_TARGETS
 fi
-cmake --build . --target M2-core M2-emacs
+cmake --build . --target M2-core M2-emacs install-packages
 cmake --install .

--- a/build/pkgs/macaulay2/spkg-install.in
+++ b/build/pkgs/macaulay2/spkg-install.in
@@ -37,6 +37,8 @@ export Eigen3_DIR=$SAGE_LOCAL
 export Flint_DIR=$SAGE_LOCAL
 export Factory_DIR=$SAGE_LOCAL
 
+export qe=$SAGE_LOCAL
+
 # https://github.com/Macaulay2/M2/wiki/Building-M2-from-source-using-CMake
 # -DWITH_OMP=OFF makes OpenMP optional.
 cd M2/BUILD/build

--- a/pkgs/sagemath-macaulay2/repair_wheel.py
+++ b/pkgs/sagemath-macaulay2/repair_wheel.py
@@ -17,7 +17,7 @@ wheel = Path(sys.argv[1])
 
 # SAGE_LOCAL/bin/M2 --> sage_wheels/bin/M2 etc.
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,share/doc,lib,libexec}}/Macaulay2) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,share/doc,lib,libexec}}/Macaulay2) bin/cohomcalg | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:

--- a/pkgs/sagemath-macaulay2/repair_wheel.py
+++ b/pkgs/sagemath-macaulay2/repair_wheel.py
@@ -17,7 +17,7 @@ wheel = Path(sys.argv[1])
 
 # SAGE_LOCAL/bin/M2 --> sage_wheels/bin/M2 etc.
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,lib,libexec}}/Macaulay2) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,share/doc,lib,libexec}}/Macaulay2) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:


### PR DESCRIPTION
Missing so far, as reported in [#Q&amp;A: Get Macaulay2 > Installing M2: Python wheels @ 💬](https://macaulay2.zulipchat.com/#narrow/channel/351863-Q.26A.3A-Get-Macaulay2/topic/Installing.20M2.3A.20Python.20wheels/near/602892133) @d-torrance