### PR TITLE
tox.ini (docker-gentoo): Use IGNORE_MISSING_SYSTEM_PACKAGES=yes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -369,7 +369,7 @@ setenv =
     gentoo-python3.12: BASE_TAG=latest-py12
     gentoo-python3.13: BASE_TAG=latest-py13
     gentoo-python3.14: BASE_TAG=latest-py14
-    gentoo:                                    IGNORE_MISSING_SYSTEM_PACKAGES=no
+    gentoo:                                    IGNORE_MISSING_SYSTEM_PACKAGES=yes
     #
     # https://hub.docker.com/_/archlinux/
     # 2023-09: libgiac went missing, hence IGNORE_MISSING_SYSTEM_PACKAGES=yes


### PR DESCRIPTION
This addresses the mismatch between the cutting-edge gentoo package info that we seem to pick up from the gentoo enthusiasts in the upstream Sage project and the gentoo Docker images that we are using in CI.
- https://github.com/Normaliz/Normaliz/issues/449#issuecomment-4699195824 @w-bruns 