### PR TITLE
pkgs/sagemath-macaulay2/repair_wheel.py: Fix syntax

### DIFF
--- a/pkgs/sagemath-macaulay2/repair_wheel.py
+++ b/pkgs/sagemath-macaulay2/repair_wheel.py
@@ -17,7 +17,7 @@ wheel = Path(sys.argv[1])
 
 # SAGE_LOCAL/bin/M2 --> sage_wheels/bin/M2 etc.
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,share/doc,lib,libexec}}/Macaulay2 bin/{cohomcalg,csdp} ) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,share/doc,lib,libexec}}/Macaulay2 bin/{{cohomcalg,csdp}} ) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:


### PR DESCRIPTION
```
  + python3 /project/unpacked/passagemath_macaulay2/repair_wheel.py /tmp/cibuildwheel/built_wheel/passagemath_macaulay2-10.8.5rc4-cp311-cp311-linux_x86_64.whl
  Traceback (most recent call last):
    File "/project/unpacked/passagemath_macaulay2/repair_wheel.py", line 20, in <module>
      command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,share/doc,lib,libexec}}/Macaulay2 bin/{cohomcalg,csdp} ) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
                                                                                                                                                  ^^^^^^^^^
  NameError: name 'cohomcalg' is not defined
```
https://github.com/passagemath/passagemath/actions/runs/27522142556/job/81420030325#step:30:1140