### PR TITLE
build/pkgs/macaulay2/spkg-install.in: Use `IgnoreExampleErrors=true`

### DIFF
--- a/build/pkgs/macaulay2/spkg-install.in
+++ b/build/pkgs/macaulay2/spkg-install.in
@@ -49,6 +49,7 @@ sdh_cmake -GNinja -S../.. -B. \
       -DCMAKE_BUILD_RPATH="${SAGE_LOCAL}/lib" \
       -DCMAKE_INSTALL_RPATH="${SAGE_LOCAL}/lib" \
       -DWITH_OMP=OFF \
+      -DIgnoreExampleErrors=true \
       $BUILD_OPTIONS
 if [ -n "$SAGE_MACAULAY2_TARGETS" ]; then
    # "Note that this target must be built separately, before proceeding to M2-binary."


### PR DESCRIPTION
Workaround for 
- #2400 

[#Q&amp;A: Get Macaulay2 > Installing M2: Python wheels @ 💬](https://macaulay2.zulipchat.com/#narrow/channel/351863-Q.26A.3A-Get-Macaulay2/topic/Installing.20M2.3A.20Python.20wheels/near/603437155)