### PR TITLE
dist.yml (wheels): Use macos-26, macos-26-intel runners

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -118,8 +118,8 @@ jobs:
           ${{ fromJson(inputs.oss
                        || '["ubuntu-latest",
                             "ubuntu-24.04-arm",
-                            "macos-15-intel",
-                            "macos-14",
+                            "macos-26-intel",
+                            "macos-26",
                            ]') }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -209,8 +209,8 @@ jobs:
           case "${{ matrix.os }}" in
               ubuntu*-arm) tag="manylinux*_aarch64";;
               ubuntu*)  tag="manylinux*_x86_64";;
-              macos-15-intel) tag="macosx_*_x86_64";;
-              macos-14) tag="macosx_*_arm64";;
+              macos-*-intel) tag="macosx_*_x86_64";;
+              macos-*) tag="macosx_*_arm64";;
               windows*-arm) tag="win_arm64";;
               windows*) tag="win_amd64";;
           esac

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -365,10 +365,10 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             build: musllinux
-          - os: macos-15-intel
+          - os: macos-26-intel
             arch: x86_64
             build: macosx
-          - os: macos-14
+          - os: macos-26
             arch: arm64
             build: macosx
     env:
@@ -846,10 +846,10 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             build: musllinux
-          - os: macos-15-intel
+          - os: macos-26-intel
             arch: x86_64
             build: macosx
-          - os: macos-14
+          - os: macos-26
             arch: arm64
             build: macosx
     env:
@@ -1179,10 +1179,10 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
             build: musllinux
-          - os: macos-15-intel
+          - os: macos-26-intel
             arch: x86_64
             build: macosx
-          - os: macos-14
+          - os: macos-26
             arch: arm64
             build: macosx
     env:
@@ -1514,8 +1514,8 @@ jobs:
          "ubuntu-latest-musllinux-*-wheels",
          "ubuntu-24.04-arm-manylinux-*-wheels",
          "ubuntu-24.04-arm-musllinux-*-wheels",
-         "macos-15-intel-*-wheels",
-         "macos-14-*-wheels",
+         "macos-26-intel-macosx-*-wheels",
+         "macos-26-macosx-*-wheels",
          "noarch-wheels"]
     secrets: inherit
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -27,8 +27,8 @@ jobs:
                             "ubuntu-latest-musllinux-*-wheels",
                             "ubuntu-24.04-arm-manylinux-*-wheels",
                             "ubuntu-24.04-arm-musllinux-*-wheels",
-                            "macos-15-intel-*-wheels",
-                            "macos-14-*-wheels",
+                            "macos-26-intel-macosx-*-wheels",
+                            "macos-26-macosx-*-wheels",
                             "windows-*-wheels",
                             "noarch-wheels",
                             "dist"]') }}


### PR DESCRIPTION
Workaround for
- https://github.com/passagemath/passagemath/issues/2399#issuecomment-4711251218