### PR TITLE
build/pkgs/cohomcalg/spkg-install.in: Use -std=gnu++11 for C++ modules

### DIFF
--- a/build/pkgs/cohomcalg/spkg-install.in
+++ b/build/pkgs/cohomcalg/spkg-install.in
@@ -3,7 +3,7 @@ cd src
 sdh_make prefix="${SAGE_LOCAL}" \
          CPPFLAGS="${CPPFLAGS}" \
          CFLAGS="${CFLAGS}" \
-         CXXFLAGS="${CXXFLAGS}" \
+         CXXFLAGS="${CXXFLAGS} -std=gnu++11" \
          LDFLAGS="${LDFLAGS}" \
          CC="${CC}" \
          LD="${CXX}"


### PR DESCRIPTION
- Fixes https://github.com/passagemath/passagemath/issues/2399