### PR TITLE
pkgs/sagemath-macaulay2/repair_wheel.py: Ship normaliz executable

### DIFF
--- a/pkgs/sagemath-macaulay2/repair_wheel.py
+++ b/pkgs/sagemath-macaulay2/repair_wheel.py
@@ -17,7 +17,7 @@ wheel = Path(sys.argv[1])
 
 # SAGE_LOCAL/bin/M2 --> sage_wheels/bin/M2 etc.
 with InWheel(wheel, wheel):
-    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,lib,libexec}}/Macaulay2 bin/{{cohomcalg,csdp}} ) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
+    command = f'set -o pipefail; (cd {shlex.quote(SAGE_LOCAL)} && tar cf - --dereference bin/M2* {{share,lib,libexec}}/Macaulay2 bin/{{cohomcalg,csdp,normaliz}} ) | (mkdir -p sage_wheels && cd sage_wheels && tar xvf -)'
     print(f'Running {command}')
     sys.stdout.flush()
     if os.system(f"bash -c {shlex.quote(command)}") != 0:


### PR DESCRIPTION
"Core" tests already require a normaliz executable.

PyNormaliz does not ship it; so we ship it here.