### PR TITLE
build/pkgs/python3/spkg-configure.m4: Python 3.14 is no longer experimental

### DIFF
--- a/build/pkgs/python3/spkg-configure.m4
+++ b/build/pkgs/python3/spkg-configure.m4
@@ -1,7 +1,7 @@
 SAGE_SPKG_CONFIGURE([python3], [
    m4_pushdef([MIN_VERSION],               [3.11.0])
    m4_pushdef([MIN_NONDEPRECATED_VERSION], [3.11.0])
-   m4_pushdef([LT_STABLE_VERSION],         [3.14.0])
+   m4_pushdef([LT_STABLE_VERSION],         [3.15.0])
    m4_pushdef([LT_VERSION],                [3.15.0])
    AC_ARG_WITH([python],
                [AS_HELP_STRING([--with-python=PYTHON3],


### PR DESCRIPTION
... and has not been in a long while, but our `configure` script was still issuing warnings