### PR TITLE
pkgs/sagemath-macaulay2-doc: Only depend on macaulay2_docs, not macaulay2

### DIFF
--- a/build/pkgs/sagemath_macaulay2_doc/dependencies
+++ b/build/pkgs/sagemath_macaulay2_doc/dependencies
@@ -1,0 +1,1 @@
+macaulay2_docs

--- a/pkgs/sagemath-macaulay2-doc/pyproject.toml.m4
+++ b/pkgs/sagemath-macaulay2-doc/pyproject.toml.m4
@@ -38,7 +38,6 @@ build-requires = [
 ]
 
 host-requires = [
-  "pkg:generic/macaulay2",
   "pkg:generic/gmp",
   "pkg:generic/mpc",
   "pkg:generic/mpfr",


### PR DESCRIPTION
- Resolves #2411 (no longer needed)