### PR TITLE
README: Stop recommending `pip install --prefer-binary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Running passagemath in the cloud (Google Colab)
 
 Just create a [Google Colab](https://colab.google/) notebook and type:
 
-    %pip install --prefer-binary passagemath-standard
+    %pip install passagemath-standard
 
 Then import the top level:
 
@@ -156,7 +156,7 @@ use passagemath.)
 Then install the meta-package [![PyPI: passagemath-standard](https://img.shields.io/pypi/v/passagemath-standard.svg?label=passagemath-standard)](https://pypi.python.org/pypi/passagemath-standard)
 
 ```bash session
-(passagemath-venv) $ pip install -v --prefer-binary passagemath-standard
+(passagemath-venv) $ pip install -v passagemath-standard
 (passagemath-venv) $ rehash
 ```
 

--- a/pkgs/sagemath-benzene/README.rst
+++ b/pkgs/sagemath-benzene/README.rst
@@ -86,11 +86,11 @@ Examples
 
 Using the benzene program on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-benzene[test]" sage -sh -c benzene
+    $ pipx run --spec "passagemath-benzene[test]" sage -sh -c benzene
 
 Finding the installation location of the benzene program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-benzene[test]" ipython
+    $ pipx run --spec "passagemath-benzene[test]" ipython
 
     In [1]: from sage.features.graph_generators import Benzene
 
@@ -99,7 +99,7 @@ Finding the installation location of the benzene program::
 
 Using the Python interface::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-benzene[test]" ipython
+    $ pipx run --spec "passagemath-benzene[test]" ipython
 
     In [1]: from passagemath_benzene import *
 

--- a/pkgs/sagemath-buckygen/README.rst
+++ b/pkgs/sagemath-buckygen/README.rst
@@ -86,11 +86,11 @@ Examples
 
 Using the buckygen program on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-buckygen[test]" sage -sh -c buckygen
+    $ pipx run --spec "passagemath-buckygen[test]" sage -sh -c buckygen
 
 Finding the installation location of the buckygen program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-buckygen[test]" ipython
+    $ pipx run --spec "passagemath-buckygen[test]" ipython
 
     In [1]: from sage.features.graph_generators import Buckygen
 
@@ -99,7 +99,7 @@ Finding the installation location of the buckygen program::
 
 Using the Python interface::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-buckygen[test]" ipython
+    $ pipx run --spec "passagemath-buckygen[test]" ipython
 
     In [1]: from passagemath_buckygen import *
 

--- a/pkgs/sagemath-cliquer/README.rst
+++ b/pkgs/sagemath-cliquer/README.rst
@@ -86,7 +86,7 @@ Examples
 
 ::
 
-   $ pipx run --pip-args="--prefer-binary" --spec "passagemath-cliquer[test]" ipython
+   $ pipx run --spec "passagemath-cliquer[test]" ipython
 
    In [1]: from passagemath_cliquer import *
 

--- a/pkgs/sagemath-cmr/README.rst
+++ b/pkgs/sagemath-cmr/README.rst
@@ -92,7 +92,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-cmr[test]" ipython
+    $ pipx run --spec "passagemath-cmr[test]" ipython
 
     In [1]: from passagemath_cmr import *
 

--- a/pkgs/sagemath-combinat/README.rst
+++ b/pkgs/sagemath-combinat/README.rst
@@ -90,7 +90,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-combinat[test]" ipython
+    $ pipx run --spec "passagemath-combinat[test]" ipython
 
     In [1]: from passagemath_combinat import *
 

--- a/pkgs/sagemath-ecl/README.rst
+++ b/pkgs/sagemath-ecl/README.rst
@@ -90,7 +90,7 @@ Examples
 
 Starting ECL from the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-ecl[test]" sage --ecl
+    $ pipx run --spec "passagemath-ecl[test]" sage --ecl
 
     ECL (Embeddable Common-Lisp) 23.9.9 (git:UNKNOWN)
     Copyright (C) 1984 Taiichi Yuasa and Masami Hagiya
@@ -99,7 +99,7 @@ Starting ECL from the command line::
 
 Finding the installation location of ECL in Python::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-ecl[test]" ipython
+    $ pipx run --spec "passagemath-ecl[test]" ipython
 
     In [1]: from sage.features.ecl import Ecl
 
@@ -108,7 +108,7 @@ Finding the installation location of ECL in Python::
 
 Using the Cython interface to ECL::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-ecl[test]" sage
+    $ pipx run --spec "passagemath-ecl[test]" sage
 
     sage: from sage.libs.ecl import *
     sage: ecl_eval("(defun fibo (n) (cond ((= n 0) 0) ((= n 1) 1) (t (+ (fibo (- n 1)) (fibo (- n 2))))))")

--- a/pkgs/sagemath-eclib/README.rst
+++ b/pkgs/sagemath-eclib/README.rst
@@ -98,7 +98,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-eclib[test]" ipython
+    $ pipx run --spec "passagemath-eclib[test]" ipython
 
     In [1]: from passagemath_eclib import *
 
@@ -107,14 +107,14 @@ A quick way to try it out interactively::
 
 Finding the installation location of the mwrank program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-eclib" python
+    $ pipx run --spec "passagemath-eclib" python
     >>> from sage.features.eclib import Mwrank
     >>> Mwrank().absolute_filename()
     '.../bin/mwrank'
 
 Use with `sage.schemes.elliptic_curves <https://passagemath.org/docs/latest/html/en/reference/arithmetic_curves/index.html#elliptic-curves>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-eclib[test]" ipython
+    $ pipx run --spec "passagemath-eclib[test]" ipython
 
     In [1]: from passagemath_eclib import *
 

--- a/pkgs/sagemath-flint/README.rst
+++ b/pkgs/sagemath-flint/README.rst
@@ -87,7 +87,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-flint[test]" ipython
+    $ pipx run --spec "passagemath-flint[test]" ipython
     In [1]: from passagemath_flint import *
 
     In [2]: RealBallField(128).pi()

--- a/pkgs/sagemath-fricas/README.rst
+++ b/pkgs/sagemath-fricas/README.rst
@@ -90,11 +90,11 @@ Examples
 
 Starting FriCAS from the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-fricas[test]" sage --fricas
+    $ pipx run --spec "passagemath-fricas[test]" sage --fricas
 
 Finding the installation location of FriCAS in Python::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-fricas[test]" ipython
+    $ pipx run --spec "passagemath-fricas[test]" ipython
 
     In [1]: from sage.features.fricas import FriCAS
 
@@ -103,7 +103,7 @@ Finding the installation location of FriCAS in Python::
 
 Using the pexpect interface to FriCAS::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-fricas[test]" python
+    $ pipx run --spec "passagemath-fricas[test]" python
 
     >>> from passagemath_fricas import *
     >>> fricas('1+1')

--- a/pkgs/sagemath-frobby/README.rst
+++ b/pkgs/sagemath-frobby/README.rst
@@ -79,6 +79,6 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-frobby[test]" ipython
+    $ pipx run --spec "passagemath-frobby[test]" ipython
 
     In [1]: from passagemath_frobby import *

--- a/pkgs/sagemath-gap/README.rst
+++ b/pkgs/sagemath-gap/README.rst
@@ -138,7 +138,7 @@ Examples
 
 Running GAP from the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-gap" sage -gap
+    $ pipx run --spec "passagemath-gap" sage -gap
      ┌───────┐   GAP 4.14.0 of 2024-12-05
      │  GAP  │   https://www.gap-system.org
      └───────┘   Architecture: x86_64-apple-darwin22-default64-kv9
@@ -150,7 +150,7 @@ Running GAP from the command line::
 
 Using the library interface from Python::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-gap[test]" IPython
+    $ pipx run --spec "passagemath-gap[test]" IPython
 
     In [1]: from passagemath_modules import *
 

--- a/pkgs/sagemath-giac/README.rst
+++ b/pkgs/sagemath-giac/README.rst
@@ -101,7 +101,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-giac[test]" ipython
+    $ pipx run --spec "passagemath-giac[test]" ipython
 
     In [1]: from passagemath_giac import *
 
@@ -128,7 +128,7 @@ A quick way to try it out interactively::
 
 The last example again, using the Sage REPL::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-giac[test]" sage
+    $ pipx run --spec "passagemath-giac[test]" sage
     Warning: sage.all is not available; this is a limited REPL.
 
     sage: from passagemath_giac import *

--- a/pkgs/sagemath-glucose/README.rst
+++ b/pkgs/sagemath-glucose/README.rst
@@ -85,11 +85,11 @@ Examples
 
 Using glucose programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-glucose" sage -sh -c glucose
+    $ pipx run --spec "passagemath-glucose" sage -sh -c glucose
 
 Finding the installation location of a glucose program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-glucose[test]" ipython
+    $ pipx run --spec "passagemath-glucose[test]" ipython
 
     In [1]: from sage.features.sat import Glucose
 
@@ -98,7 +98,7 @@ Finding the installation location of a glucose program::
 
 Use with `sage.sat <https://passagemath.org/docs/latest/html/en/reference/sat/index.html>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-glucose[test]" ipython
+    $ pipx run --spec "passagemath-glucose[test]" ipython
 
     In [1]: from passagemath_glucose import *
 

--- a/pkgs/sagemath-graphs/README.rst
+++ b/pkgs/sagemath-graphs/README.rst
@@ -104,7 +104,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-graphs[test]" ipython
+    $ pipx run --spec "passagemath-graphs[test]" ipython
     In [1]: from passagemath_graphs import *
 
     In [6]: g = Graph([(1, 3), (3, 8), (5, 2)]); g
@@ -136,7 +136,7 @@ for network matrices, totally unimodular matrices and regular matroids, series-p
 ``pip install passagemath-graphs[igraph]`` additionally installs
 `igraph <https://python.igraph.org/en/stable/>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-graphs[igraph,test]" ipython
+    $ pipx run --spec "passagemath-graphs[igraph,test]" ipython
     In [1]: from passagemath_graphs import *
 
     In [2]: ## Example depending on igraph goes here
@@ -149,7 +149,7 @@ automorphism groups of graphs and digraphs.
 ``pip install passagemath-graphs[networkx]`` additionally installs
 `NetworkX <https://networkx.github.io>`__::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-graphs[networkx,test]" ipython
+    $ pipx run --spec "passagemath-graphs[networkx,test]" ipython
     In [1]: from passagemath_graphs import *
 
     In [2]: ## Example depending on networkx goes here
@@ -173,7 +173,7 @@ Features
 ``pip install passagemath-graphs[groups]`` additionally makes group-theoretic features
 available via `passagemath-gap <https://pypi.org/project/passagemath-gap/>`_, `passagemath-groups <https://pypi.org/project/passagemath-groups/>`_, and `passagemath-nauty <https://pypi.org/project/passagemath-nauty/>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-graphs[groups,test]" ipython
+    $ pipx run --spec "passagemath-graphs[groups,test]" ipython
     In [1]: from passagemath_graphs import *
 
     In [2]: g = Graph({
@@ -192,7 +192,7 @@ available via `passagemath-gap <https://pypi.org/project/passagemath-gap/>`_, `p
 ``pip install passagemath-graphs[mip]`` additionally makes the mixed-integer programming
 solver GLPK available via `passagemath-glpk <https://pypi.org/project/passagemath-glpk/>`_ and `passagemath-polyhedra <https://pypi.org/project/passagemath-polyhedra/>`_ (see there for other available solvers).::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-graphs[mip,test]" ipython
+    $ pipx run --spec "passagemath-graphs[mip,test]" ipython
     In [1]: from passagemath_graphs import *
 
     In [2]: ## Example depending on MIP goes here

--- a/pkgs/sagemath-homfly/README.rst
+++ b/pkgs/sagemath-homfly/README.rst
@@ -85,7 +85,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-homfly[test]" ipython
+    $ pipx run --spec "passagemath-homfly[test]" ipython
 
     In [1]: from sage.libs.homfly import homfly_polynomial_dict
 

--- a/pkgs/sagemath-kissat/README.rst
+++ b/pkgs/sagemath-kissat/README.rst
@@ -86,11 +86,11 @@ Examples
 
 Using kissat programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-kissat" sage -sh -c kissat
+    $ pipx run --spec "passagemath-kissat" sage -sh -c kissat
 
 Finding the installation location of the kissat program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-kissat[test]" ipython
+    $ pipx run --spec "passagemath-kissat[test]" ipython
 
     In [1]: from sage.features.sat import Kissat
 
@@ -99,7 +99,7 @@ Finding the installation location of the kissat program::
 
 Use with `sage.sat <https://passagemath.org/docs/latest/html/en/reference/sat/index.html>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-kissat[test]" ipython
+    $ pipx run --spec "passagemath-kissat[test]" ipython
 
     In [1]: from passagemath_kissat import *
 

--- a/pkgs/sagemath-latte-4ti2/README.rst
+++ b/pkgs/sagemath-latte-4ti2/README.rst
@@ -95,14 +95,14 @@ Examples
 
 Using LattE integrale and 4ti2 programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-latte-4ti2" sage -sh -c 'ppi 5'
+    $ pipx run --spec "passagemath-latte-4ti2" sage -sh -c 'ppi 5'
     ...
     ### This makes 47 PPI up to sign
     ### Writing data file ppi5.gra and matrix file ppi5.mat done.
 
 Finding the installation location of a LattE integrale or 4ti2 program in Python::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-latte-4ti2[test]" ipython
+    $ pipx run --spec "passagemath-latte-4ti2[test]" ipython
 
     In [1]: from sage.features.latte import Latte_count
 
@@ -116,7 +116,7 @@ Finding the installation location of a LattE integrale or 4ti2 program in Python
 
 Using the low-level Python interfaces::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-latte-4ti2[test]" ipython
+    $ pipx run --spec "passagemath-latte-4ti2[test]" ipython
 
     In [1]: from sage.interfaces.latte import count
 
@@ -127,7 +127,7 @@ Using the low-level Python interfaces::
 
 Use with sage.geometry.polyhedron::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-latte-4ti2[test]" ipython
+    $ pipx run --spec "passagemath-latte-4ti2[test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 

--- a/pkgs/sagemath-libbraiding/README.rst
+++ b/pkgs/sagemath-libbraiding/README.rst
@@ -87,7 +87,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-libbraiding[test]" ipython
+    $ pipx run --spec "passagemath-libbraiding[test]" ipython
 
     In [1]: from passagemath_libbraiding import *
 

--- a/pkgs/sagemath-libecm/README.rst
+++ b/pkgs/sagemath-libecm/README.rst
@@ -90,7 +90,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-libecm[test]" ipython
+    $ pipx run --spec "passagemath-libecm[test]" ipython
 
     In [1]: from sage.libs.libecm import ecmfactor
 

--- a/pkgs/sagemath-lrslib/README.rst
+++ b/pkgs/sagemath-lrslib/README.rst
@@ -87,12 +87,12 @@ Examples
 
 Using lrslib programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-lrslib" sage -sh -c lrs
+    $ pipx run --spec "passagemath-lrslib" sage -sh -c lrs
     *lrs:lrslib v.7.1 2021.6.2(64bit,lrslong.h,hybrid arithmetic)
 
 Finding the installation location of an lrslib program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-lrslib[test]" ipython
+    $ pipx run --spec "passagemath-lrslib[test]" ipython
 
     In [1]: from sage.features.lrs import LrsNash
 
@@ -101,7 +101,7 @@ Finding the installation location of an lrslib program::
 
 Use with `sage.game_theory <https://passagemath.org/docs/latest/html/en/reference/game_theory/index.html>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-lrslib[test]" ipython
+    $ pipx run --spec "passagemath-lrslib[test]" ipython
 
     In [1]: from passagemath_lrslib import *
 

--- a/pkgs/sagemath-macaulay2/README.rst
+++ b/pkgs/sagemath-macaulay2/README.rst
@@ -87,11 +87,11 @@ Examples
 
 Using Macaulay 2 on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-macaulay2" sage -sh -c 'M2'
+    $ pipx run --spec "passagemath-macaulay2" sage -sh -c 'M2'
 
 Finding the installation location of Macaulay 2::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-macaulay2[test]" ipython
+    $ pipx run --spec "passagemath-macaulay2[test]" ipython
 
     In [1]: from sage.features.macaulay2 import Macaulay2
 
@@ -100,7 +100,7 @@ Finding the installation location of Macaulay 2::
 
 Using the Python interface::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-macaulay2[test]" ipython
+    $ pipx run --spec "passagemath-macaulay2[test]" ipython
 
     In [1]: from passagemath_macaulay2 import *
 

--- a/pkgs/sagemath-maxima/README.rst
+++ b/pkgs/sagemath-maxima/README.rst
@@ -85,11 +85,11 @@ Examples
 
 Starting Maxima from the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-maxima" sage -maxima
+    $ pipx run --spec "passagemath-maxima" sage -maxima
 
 Using the pexpect interface to Maxima::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-maxima[test]" ipython
+    $ pipx run --spec "passagemath-maxima[test]" ipython
 
     In [1]: from sage.interfaces.maxima import maxima
 
@@ -101,7 +101,7 @@ Using the library interface to Maxima requires the additional package
 you can install it, for example, by using
 ``pip install "passagemath-maxima[symbolics]"``::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-maxima[symbolics,test]" ipython
+    $ pipx run --spec "passagemath-maxima[symbolics,test]" ipython
 
     In [1]: from sage.interfaces.maxima_lib import maxima_lib
 

--- a/pkgs/sagemath-modules/README.rst
+++ b/pkgs/sagemath-modules/README.rst
@@ -114,7 +114,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-modules[test]" ipython
+    $ pipx run --spec "passagemath-modules[test]" ipython
 
     In [1]: from passagemath_modules import *
 
@@ -148,7 +148,7 @@ Available as extras, from other distributions
 ``pip install "passagemath-modules[flint,fpylll,linbox]"``
  Lattice basis reduction (LLL, BKZ)::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-modules[flint,fpylll,linbox,test]" ipython
+    $ pipx run --spec "passagemath-modules[flint,fpylll,linbox,test]" ipython
 
     In [1]: from passagemath_modules import *
 

--- a/pkgs/sagemath-msolve/README.rst
+++ b/pkgs/sagemath-msolve/README.rst
@@ -78,7 +78,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-msolve[test]" ipython
+    $ pipx run --spec "passagemath-msolve[test]" ipython
 
     In [1]: from passagemath_msolve import *
 

--- a/pkgs/sagemath-nauty/README.rst
+++ b/pkgs/sagemath-nauty/README.rst
@@ -92,7 +92,7 @@ Examples
 
 Using the gtools on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-nauty" sage -sh -c 'geng 4'
+    $ pipx run --spec "passagemath-nauty" sage -sh -c 'geng 4'
     >A geng -d0D3 n=4 e=0-6
     C?
     CC
@@ -109,7 +109,7 @@ Using the gtools on the command line::
 
 Finding the installation location of a gtools program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-nauty[test]" ipython
+    $ pipx run --spec "passagemath-nauty[test]" ipython
 
     In [1]: from sage.features.nauty import NautyExecutable
 
@@ -118,7 +118,7 @@ Finding the installation location of a gtools program::
 
 Use with sage.graphs::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-nauty[test]" ipython
+    $ pipx run --spec "passagemath-nauty[test]" ipython
 
     In [1]: from passagemath_graphs import *
 

--- a/pkgs/sagemath-palp/README.rst
+++ b/pkgs/sagemath-palp/README.rst
@@ -87,14 +87,14 @@ Examples
 
 Using PALP programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-palp" sage -sh -c 'echo "14 2 3 4 5" | class.x -f -po zbin'
+    $ pipx run --spec "passagemath-palp" sage -sh -c 'echo "14 2 3 4 5" | class.x -f -po zbin'
     0kR-0 0MB 0kIP 0kNF-0k 5_13 v8r8 f10r10 10b6 0s 0u 0n
     14 2 3 4 5 R=152 +0sl hit=0 IP=276 NF=179 (0)
     Writing zbin: 152+0sl 0m+0s 644b  u36 done: 0s
 
 Finding the installation location of a PALP program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-palp[test]" ipython
+    $ pipx run --spec "passagemath-palp[test]" ipython
 
     In [1]: from sage.features.palp import PalpExecutable
 
@@ -103,7 +103,7 @@ Finding the installation location of a PALP program::
 
 Use with sage.geometry::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-palp[test]" ipython
+    $ pipx run --spec "passagemath-palp[test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 

--- a/pkgs/sagemath-pari/README.rst
+++ b/pkgs/sagemath-pari/README.rst
@@ -106,13 +106,13 @@ Examples
 
 Starting the GP calculator from the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-pari" sage -gp
+    $ pipx run --spec "passagemath-pari" sage -gp
     GP/PARI CALCULATOR Version 2.17.2 (released)
     ...
 
 Using the pexpect interface to the GP calculator::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-pari[test]" ipython
+    $ pipx run --spec "passagemath-pari[test]" ipython
 
     In [1]: from sage.interfaces.gp import gp
 
@@ -123,7 +123,7 @@ Using the pexpect interface to the GP calculator::
 
 Using the ``cypari2`` library interface::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-pari" python
+    $ pipx run --spec "passagemath-pari" python
 
     >>> import cypari2
     >>> pari = cypari2.Pari()

--- a/pkgs/sagemath-planarity/README.rst
+++ b/pkgs/sagemath-planarity/README.rst
@@ -89,7 +89,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-planarity[test]" ipython
+    $ pipx run --spec "passagemath-planarity[test]" ipython
 
     In [1]: from passagemath_planarity import *
 

--- a/pkgs/sagemath-plantri/README.rst
+++ b/pkgs/sagemath-plantri/README.rst
@@ -85,12 +85,12 @@ Examples
 
 Using plantri programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-plantri" sage -sh -c plantri
+    $ pipx run --spec "passagemath-plantri" sage -sh -c plantri
 
 
 Finding the installation location of a plantri program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-plantri[test]" ipython
+    $ pipx run --spec "passagemath-plantri[test]" ipython
 
     In [1]: from sage.features.graph_generators import Plantri
 
@@ -100,7 +100,7 @@ Finding the installation location of a plantri program::
 
 Using the Python interface::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-plantri[test]" ipython
+    $ pipx run --spec "passagemath-plantri[test]" ipython
 
     In [1]: from passagemath_plantri import *
 

--- a/pkgs/sagemath-plot/README.rst
+++ b/pkgs/sagemath-plot/README.rst
@@ -92,7 +92,7 @@ Examples
 
 ::
 
-   $ pipx run --pip-args="--prefer-binary" --spec "passagemath-plot[test]" ipython
+   $ pipx run --spec "passagemath-plot[test]" ipython
 
    In [1]: from passagemath_plot import *
 

--- a/pkgs/sagemath-polyhedra/README.rst
+++ b/pkgs/sagemath-polyhedra/README.rst
@@ -96,7 +96,7 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 
@@ -125,7 +125,7 @@ Additional features
 
  ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[graphs,test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[graphs,test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 
@@ -140,7 +140,7 @@ Additional features
 
  ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[graphs,groups,test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[graphs,groups,test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 
@@ -155,7 +155,7 @@ Additional features
 
  ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[graphs,toric,test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[graphs,toric,test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 
@@ -171,7 +171,7 @@ Additional features
 
  ::
 
-   $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[latte,test]" ipython
+   $ pipx run --spec "passagemath-polyhedra[latte,test]" ipython
 
    In [1]: from passagemath_polyhedra import *
 
@@ -198,7 +198,7 @@ Additional backends for polyhedral computations
 
  ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[normaliz,test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[normaliz,test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 
@@ -211,7 +211,7 @@ Additional backends for polyhedral computations
 
  ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[cddlib,test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[cddlib,test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 
@@ -224,7 +224,7 @@ Additional backends for polyhedral computations
 
  ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polyhedra[flint,lrslib,test]" ipython
+    $ pipx run --spec "passagemath-polyhedra[flint,lrslib,test]" ipython
 
     In [1]: from passagemath_polyhedra import *
 

--- a/pkgs/sagemath-polymake/README.rst
+++ b/pkgs/sagemath-polymake/README.rst
@@ -90,4 +90,4 @@ Examples
 
 Using polymake on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-polymake" sage -polymake
+    $ pipx run --spec "passagemath-polymake" sage -polymake

--- a/pkgs/sagemath-qepcad/README.rst
+++ b/pkgs/sagemath-qepcad/README.rst
@@ -79,7 +79,7 @@ Example
 
 ::
 
-    $ pipx run  --pip-args="--prefer-binary" --spec "passagemath-qepcad[test]" ipython
+    $ pipx run  --spec "passagemath-qepcad[test]" ipython
 
     In [1]: from passagemath_symbolics import *
 

--- a/pkgs/sagemath-rankwidth/README.rst
+++ b/pkgs/sagemath-rankwidth/README.rst
@@ -88,7 +88,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-rankwidth[test]" ipython
+    $ pipx run --spec "passagemath-rankwidth[test]" ipython
 
     In [1]: from passagemath_rankwidth import *
 

--- a/pkgs/sagemath-rubiks/README.rst
+++ b/pkgs/sagemath-rubiks/README.rst
@@ -106,12 +106,12 @@ Examples
 
 Using rubiks programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-rubiks" sage -sh -c cubex
+    $ pipx run --spec "passagemath-rubiks" sage -sh -c cubex
 
 
 Finding the installation location of a rubiks program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-rubiks[test]" ipython
+    $ pipx run --spec "passagemath-rubiks[test]" ipython
 
     In [1]: from sage.features.rubiks import cubex
 
@@ -120,7 +120,7 @@ Finding the installation location of a rubiks program::
 
 Using the Python interface::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-rubiks[test]" ipython
+    $ pipx run --spec "passagemath-rubiks[test]" ipython
 
     In [1]: from sage.interfaces.rubik import *
 
@@ -132,7 +132,7 @@ Using the Python interface::
 
 Using sage.groups.perm_gps::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-rubiks[test]" ipython
+    $ pipx run --spec "passagemath-rubiks[test]" ipython
 
     In [1]: from passagemath_rubiks import *
 

--- a/pkgs/sagemath-singular/README.rst
+++ b/pkgs/sagemath-singular/README.rst
@@ -98,7 +98,7 @@ Examples
 
 Using Singular on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-singular" sage -singular
+    $ pipx run --spec "passagemath-singular" sage -singular
                          SINGULAR                                 /
      A Computer Algebra System for Polynomial Computations       /   version 4.4.0
                                                                0<
@@ -108,7 +108,7 @@ Using Singular on the command line::
 
 Finding the installation location of the Singular executable::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-singular[test]" ipython
+    $ pipx run --spec "passagemath-singular[test]" ipython
 
     In [1]: from sage.features.singular import Singular
 
@@ -117,7 +117,7 @@ Finding the installation location of the Singular executable::
 
 Using the Cython interface to Singular::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-singular[test]" ipython
+    $ pipx run --spec "passagemath-singular[test]" ipython
 
     In [1]: from passagemath_singular import *
 

--- a/pkgs/sagemath-sirocco/README.rst
+++ b/pkgs/sagemath-sirocco/README.rst
@@ -86,7 +86,7 @@ Examples
 
 ::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-sirocco[test]" ipython
+    $ pipx run --spec "passagemath-sirocco[test]" ipython
 
     In [1]: from passagemath_sirocco import *
 

--- a/pkgs/sagemath-symbolics/README.rst
+++ b/pkgs/sagemath-symbolics/README.rst
@@ -96,7 +96,7 @@ Examples
 
 Using `SageManifolds <https://sagemanifolds.obspm.fr/>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-symbolics[test]" ipython
+    $ pipx run --spec "passagemath-symbolics[test]" ipython
 
     In [1]: from passagemath_symbolics import *
 

--- a/pkgs/sagemath-sympow/README.rst
+++ b/pkgs/sagemath-sympow/README.rst
@@ -85,12 +85,12 @@ Examples
 
 Using the sympow program on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-sympow" sage -sh -c sympow
+    $ pipx run --spec "passagemath-sympow" sage -sh -c sympow
 
 
 Finding the installation location of the sympow executable::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-sympow[test]" ipython
+    $ pipx run --spec "passagemath-sympow[test]" ipython
 
     In [1]: from sage.features.lrs import LrsNash
 

--- a/pkgs/sagemath-tachyon/README.rst
+++ b/pkgs/sagemath-tachyon/README.rst
@@ -79,6 +79,6 @@ Examples
 
 A quick way to try it out interactively::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-tachyon[test]" ipython
+    $ pipx run --spec "passagemath-tachyon[test]" ipython
 
     In [1]: from passagemath_tachyon import *

--- a/pkgs/sagemath-topcom/README.rst
+++ b/pkgs/sagemath-topcom/README.rst
@@ -89,7 +89,7 @@ Examples
 
 Using TOPCOM programs on the command line::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-topcom" sage -sh -c 'cube 4 | points2facets'
+    $ pipx run --spec "passagemath-topcom" sage -sh -c 'cube 4 | points2facets'
     Evaluating Commandline Options ...
     ... done.
     16,5:
@@ -106,7 +106,7 @@ Using TOPCOM programs on the command line::
 
 Finding the installation location of a TOPCOM program::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-topcom[test]" ipython
+    $ pipx run --spec "passagemath-topcom[test]" ipython
 
     In [1]: from sage.features.topcom import TOPCOMExecutable
 
@@ -115,7 +115,7 @@ Finding the installation location of a TOPCOM program::
 
 Using `sage.geometry.triangulation.point_configuration <https://passagemath.org/docs/latest/html/en/reference/discrete_geometry/sage/geometry/triangulation/point_configuration.html>`_::
 
-    $ pipx run --pip-args="--prefer-binary" --spec "passagemath-topcom[test]" ipython
+    $ pipx run --spec "passagemath-topcom[test]" ipython
 
     In [1]: from passagemath_topcom import *
 


### PR DESCRIPTION
It has no longer been necessary in quite a while because we push our sdists only after the wheels.

It played a part in the breakage in:
- https://github.com/PreTeXtBook/pretext-docker/issues/6