### PR TITLE
build/pkgs/msolve/distros: add mingw.txt

### DIFF
--- a/build/pkgs/msolve/distros/mingw.txt
+++ b/build/pkgs/msolve/distros/mingw.txt
@@ -1,0 +1,1 @@
+${MINGW_PACKAGE_PREFIX}-msolve


### PR DESCRIPTION
The msolve package has been added to MSYS2.
(See <https://github.com/msys2/MINGW-packages/pull/30306>.)

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

