### PR TITLE
build/pkgs/semigroups/spkg-install.in: Fix permissions of config aux files

### DIFF
--- a/build/pkgs/semigroups/spkg-install.in
+++ b/build/pkgs/semigroups/spkg-install.in
@@ -41,6 +41,10 @@ install_compiled_pkg()
 # Build and install
 
 cd src
+
+# shipped as 700 in semigroups-5.6.3
+chmod 755 config.*
+
 echo "Building GAP package semigroups"
 sdh_configure --with-gaproot="$GAP_ROOT"  --with-external-libsemigroups
 sdh_make


### PR DESCRIPTION
To fix:
```
tar: sage-local-manylinux_2_28_aarch64/lib/gap/pkg/semigroups/config.guess: Cannot open: Permission denied
tar: sage-local-manylinux_2_28_aarch64/lib/gap/pkg/semigroups/config.sub: Cannot open: Permission denied
```
https://github.com/passagemath/passagemath/actions/runs/29366727449/job/87203954709#step:16:18