### PR TITLE
Fix Graphics.show() in Jupyter kernels not based on ipykernel

### DIFF
--- a/src/sage/repl/ipython_extension.py
+++ b/src/sage/repl/ipython_extension.py
@@ -75,11 +75,30 @@ from sage.repl.load import load_wrap
 
 
 def _running_in_notebook():
-    try:
-        from ipykernel.zmqshell import ZMQInteractiveShell
-    except ImportError:
+    r"""
+    Return whether the current IPython shell is attached to a Jupyter kernel.
+
+    Kernel implementations set a ``kernel`` attribute on the shell before any
+    user code runs: ``ipykernel`` passes ``kernel=self`` when constructing
+    :class:`~ipykernel.zmqshell.ZMQInteractiveShell`, and xeus-python sets
+    ``kernel`` on its ``XPythonShell`` during interpreter initialization.
+    Checking this attribute instead of testing ``isinstance`` against
+    ``ZMQInteractiveShell`` also covers kernels that do not depend on
+    ``ipykernel``, such as xeus-python used by JupyterLite
+    (:passagemathissue:`2369`).
+
+    EXAMPLES:
+
+    The doctest environment is not attached to a Jupyter kernel::
+
+        sage: from sage.repl.ipython_extension import _running_in_notebook
+        sage: _running_in_notebook()
+        False
+    """
+    ip = get_ipython()
+    if ip is None:
         return False
-    return isinstance(get_ipython(), ZMQInteractiveShell)
+    return getattr(ip, 'kernel', None) is not None
 
 
 @magics_class


### PR DESCRIPTION
Fixes #2369.

From the issue, `_running_in_notebook()` returns False under JupyterLite's xeus-python kernel because ipykernel is not installed there, so the `IPython.display` fallback in `Graphics.show()` never runs.

This changes the check to look for the `kernel` attribute on the shell. ipykernel sets it when constructing `ZMQInteractiveShell` (`kernel=self` in ipkernel.py), and xeus-python sets it in `configure_impl()` in [xinterpreter.cpp](https://github.com/jupyter-xeus/xeus-python/blob/main/src/xinterpreter.cpp) before user code runs. Terminal shells and `SageTestShell` don't have it. Also adds a docstring and doctest for the function.

Tested with the native xeus-python kernel from conda-forge (passagemath-plot 10.8.6 installed, kernel driven via jupyter_client):

- before: `circle((0,0), 1).show()` returns with no `display_data` message (the bug)
- after: same code sends `display_data` with `image/svg+xml`
- a regular ipykernel kernel returns True with both the old and new check, so normal Jupyter is unchanged
- doctests for `sage.repl.ipython_extension` and `sage.plot.graphics` in a modular install: no new failures compared to unpatched

Not tested in an actual browser JupyterLite, only the native build of xeus-python.
