### PR TITLE
build/pkgs/{primecount,primesieve}: add mingw.txt

### DIFF
--- a/build/pkgs/primecount/distros/mingw.txt
+++ b/build/pkgs/primecount/distros/mingw.txt
@@ -1,0 +1,1 @@
+${MINGW_PACKAGE_PREFIX}-primecount

--- a/build/pkgs/primesieve/distros/mingw.txt
+++ b/build/pkgs/primesieve/distros/mingw.txt
@@ -1,0 +1,1 @@
+${MINGW_PACKAGE_PREFIX}-primesieve


### PR DESCRIPTION
primecount and primesieve have been added to the MSYS2 distribution
(<https://github.com/msys2/MINGW-packages/pull/30507>) and this pull
requests adds the corresponding information for those packages.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.