### PR TITLE
src/sage/all__sagemath_repl.py: Filter 'run_cell_async' deprecation warning

### DIFF
--- a/src/sage/all__sagemath_repl.py
+++ b/src/sage/all__sagemath_repl.py
@@ -110,6 +110,10 @@ warnings.filterwarnings('ignore', category=DeprecationWarning,
 warnings.filterwarnings('ignore', category=DeprecationWarning,
                         message=r"Parsing dates involving a day of month without a year.*")
 
+# seen in jupyterlite
+warnings.filterwarnings('ignore', category=DeprecationWarning,
+                        message=r"`run_cell_async` will not call `transform_cell` automatically.*")
+
 from sage.all__sagemath_objects import *
 from sage.all__sagemath_environment import *
 


### PR DESCRIPTION
Seen on jupyterlite:
```
/lib/python3.13/site-packages/xeus_python_shell/shell.py:44: DeprecationWarning: `run_cell_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.
  result = await coro
```
