### PR TITLE
Add Markov basis interface using 4ti2

### DIFF
--- a/pkgs/sagemath-modules/pyproject.toml.m4
+++ b/pkgs/sagemath-modules/pyproject.toml.m4
@@ -43,6 +43,7 @@ content-type = "text/x-rst"
 test    = ["passagemath-repl"]
 
 # extras by packages
+4ti2    = ["passagemath-latte-4ti2"]
 flint   = ["passagemath-flint"]
 fpylll  = [SPKG_INSTALL_REQUIRES_fpylll]
 gsl     = []  # No extra needed

--- a/src/sage/interfaces/four_ti_2.py
+++ b/src/sage/interfaces/four_ti_2.py
@@ -423,6 +423,81 @@ class FourTi2:
         self.call('graver', project, options=['-q'])
         return self.read_matrix(project+'.gra')
 
+    def markov(self, mat=None, lat=None, sign=None, weights=None,
+               weights_max=None, zsol=None, project=None, *,
+               precision=None, algorithm=None, generation=None,
+               truncation=None, minimal=None):
+        r"""
+        Run the 4ti2 program ``markov`` on the parameters.
+
+        See the
+        `4ti2 markov documentation <https://4ti2.github.io/markov.html>`_
+        for details on the input and computational options.
+
+        EXAMPLES::
+
+            sage: from sage.interfaces.four_ti_2 import four_ti_2
+            sage: A = matrix(ZZ, [[1, 1, 0, 0],
+            ....:                 [0, 0, 1, 1],
+            ....:                 [1, 0, 1, 0],
+            ....:                 [0, 1, 0, 1]])
+            sage: M = four_ti_2.markov(mat=A)  # optional - 4ti2
+            sage: M.dimensions()  # optional - 4ti2
+            (1, 4)
+            sage: A * M.transpose() == zero_matrix(ZZ, 4, 1)  # optional - 4ti2
+            True
+        """
+        if precision is not None:
+            precision = str(precision)
+            if precision == 'arb':
+                precision = 'arbitrary'
+            if precision not in ('32', '64', 'arbitrary'):
+                raise ValueError("precision must be 32, 64, or 'arbitrary'")
+
+        if algorithm not in (None, 'fifo', 'weighted', 'unbounded'):
+            raise ValueError("algorithm must be 'fifo', 'weighted', or "
+                             "'unbounded'")
+
+        if generation not in (None, 'hybrid', 'project-and-lift',
+                               'max-min', 'saturation'):
+            raise ValueError("generation must be 'hybrid', "
+                             "'project-and-lift', 'max-min', or "
+                             "'saturation'")
+
+        if truncation not in (None, 'ip', 'lp', 'weight', 'none'):
+            raise ValueError("truncation must be 'ip', 'lp', 'weight', "
+                             "or 'none'")
+
+        if minimal is not None and not isinstance(minimal, bool):
+            raise TypeError("minimal must be a boolean or None")
+
+        input_files = {
+            'mat': mat,
+            'lat': lat,
+            'sign': sign,
+            'weights': weights,
+            'weights.max': weights_max,
+            'zsol': zsol,
+            'project': project,
+        }
+        project = self._process_input(input_files)
+
+        options = ['-q']
+        if precision is not None:
+            options.append(f'--precision={precision}')
+        if algorithm is not None:
+            options.append(f'--algorithm={algorithm}')
+        if generation is not None:
+            options.append(f'--generation={generation}')
+        if truncation is not None:
+            options.append(f'--truncation={truncation}')
+        if minimal is not None:
+            state = 'yes' if minimal else 'no'
+            options.append(f'--minimal={state}')
+
+        self.call('markov', project, options=options)
+        return self.read_matrix(project+'.mar')
+
     def ppi(self, n):
         r"""
         Run the 4ti2 program ``ppi`` on the parameters.

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -5658,6 +5658,79 @@ cdef class Matrix(Matrix1):
             M = MatrixSpace(ring, self.nrows(), self.ncols())(A)
             return M.kernel()
 
+    def markov_basis(self, algorithm='4ti2', *, precision=None,
+                     completion=None, generation=None, minimal=True):
+        r"""
+        Return a Markov basis of this integer matrix using 4ti2.
+
+        For a matrix `A`, a Markov basis is a finite subset of
+        `\ker_{\ZZ}(A)` whose moves connect every nonnegative integer fiber
+        `\{x \in \ZZ_{\geq 0}^n : Ax=b\}`.  The rows of the returned matrix
+        are the Markov moves.
+
+        INPUT:
+
+        - ``algorithm`` -- (default: ``'4ti2'``) computational backend
+        - ``precision`` -- (optional) ``32``, ``64``, or ``'arbitrary'``
+        - ``completion`` -- (optional) completion procedure:
+          ``'fifo'``, ``'weighted'``, or ``'unbounded'``
+        - ``generation`` -- (optional) generation procedure:
+          ``'hybrid'``, ``'project-and-lift'``, ``'max-min'``, or
+          ``'saturation'``
+        - ``minimal`` -- boolean (default: ``True``); whether to compute a
+          minimal Markov basis
+
+        OUTPUT:
+
+        A matrix over `\ZZ` whose rows are Markov moves.  Their order and
+        signs are not canonical.
+
+        EXAMPLES::
+
+            sage: A = matrix(ZZ, [[1, 1, 0, 0],
+            ....:                 [0, 0, 1, 1],
+            ....:                 [1, 0, 1, 0],
+            ....:                 [0, 1, 0, 1]])
+            sage: M = A.markov_basis()  # optional - 4ti2
+            sage: M.dimensions()  # optional - 4ti2
+            (1, 4)
+            sage: A * M.transpose() == zero_matrix(ZZ, 4, 1)  # optional - 4ti2
+            True
+
+        Matrices whose entries are not integers are rejected::
+
+            sage: matrix(QQ, [[1/2, 1]]).markov_basis()
+            Traceback (most recent call last):
+            ...
+            TypeError: the matrix entries must be integers
+        """
+        if algorithm != '4ti2':
+            raise ValueError(f"unknown Markov basis algorithm: {algorithm!r}")
+
+        base_ring = self.base_ring()
+        if base_ring == ZZ:
+            integer_matrix = self
+        else:
+            try:
+                if (not base_ring.is_exact()
+                        or any(entry not in ZZ for entry in self.list())):
+                    raise TypeError
+                integer_matrix = self.change_ring(ZZ)
+            except (TypeError, ValueError):
+                raise TypeError("the matrix entries must be integers") from None
+
+        from sage.features.four_ti_2 import FourTi2
+        FourTi2().require()
+
+        from sage.interfaces.four_ti_2 import four_ti_2
+        return four_ti_2.markov(
+            mat=integer_matrix,
+            precision=precision,
+            algorithm=completion,
+            generation=generation,
+            minimal=minimal,
+        )
+
     def image(self):
         """
         Return the image of the homomorphism on rows defined by right

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -5658,8 +5658,8 @@ cdef class Matrix(Matrix1):
             M = MatrixSpace(ring, self.nrows(), self.ncols())(A)
             return M.kernel()
 
-    def markov_basis(self, algorithm='4ti2', *, precision=None,
-                     completion=None, generation=None, minimal=True):
+    def markov_basis_matrix(self, algorithm='4ti2', *, precision=None,
+                            completion=None, generation=None, minimal=True):
         r"""
         Return a Markov basis of this integer matrix using 4ti2.
 
@@ -5691,33 +5691,30 @@ cdef class Matrix(Matrix1):
             ....:                 [0, 0, 1, 1],
             ....:                 [1, 0, 1, 0],
             ....:                 [0, 1, 0, 1]])
-            sage: M = A.markov_basis()  # optional - 4ti2
+            sage: M = A.markov_basis_matrix()  # optional - 4ti2
             sage: M.dimensions()  # optional - 4ti2
             (1, 4)
             sage: A * M.transpose() == zero_matrix(ZZ, 4, 1)  # optional - 4ti2
             True
 
-        Matrices whose entries are not integers are rejected::
+        Denominators of rational matrices are cleared before calling 4ti2::
 
-            sage: matrix(QQ, [[1/2, 1]]).markov_basis()
-            Traceback (most recent call last):
-            ...
-            TypeError: the matrix entries must be integers
+            sage: A = matrix(QQ, [[1/2, 1]])
+            sage: M = A.markov_basis_matrix()  # optional - 4ti2
+            sage: M.dimensions()  # optional - 4ti2
+            (1, 2)
+            sage: A * M.transpose() == zero_matrix(QQ, 1, 1)  # optional - 4ti2
+            True
         """
         if algorithm != '4ti2':
             raise ValueError(f"unknown Markov basis algorithm: {algorithm!r}")
 
-        base_ring = self.base_ring()
-        if base_ring == ZZ:
+        if self.base_ring() == ZZ:
             integer_matrix = self
+        elif self.base_ring() == QQ:
+            integer_matrix, _ = self._clear_denom()
         else:
-            try:
-                if (not base_ring.is_exact()
-                        or any(entry not in ZZ for entry in self.list())):
-                    raise TypeError
-                integer_matrix = self.change_ring(ZZ)
-            except (TypeError, ValueError):
-                raise TypeError("the matrix entries must be integers") from None
+            raise TypeError("the matrix must be over the integers or rationals")
 
         from sage.features.four_ti_2 import FourTi2
         FourTi2().require()


### PR DESCRIPTION
This PR adds support for computing Markov bases using 4ti2.

It adds:

- a low-level `FourTi2.markov()` wrapper for the 4ti2 `markov` command;
- a high-level `Matrix.markov_basis()` method;
- options for precision, completion, generation, truncation, and minimality;
- the optional 4ti2 dependency for `sagemath-module


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.


