### PR TITLE
build/pkgs/python_discovery: Do not require if system tox available

### DIFF
--- a/build/pkgs/python_discovery/spkg-configure.m4
+++ b/build/pkgs/python_discovery/spkg-configure.m4
@@ -1,0 +1,7 @@
+SAGE_SPKG_CONFIGURE([python_discovery], [
+    sage_spkg_install_python_discovery=yes
+  ], [dnl REQUIRED-CHECK
+    AC_REQUIRE([SAGE_SPKG_CONFIGURE_TOX])
+    dnl python_discovery is only needed when we cannot use system tox.
+    AS_VAR_SET([SPKG_REQUIRE], [$sage_spkg_install_tox])
+  ])


### PR DESCRIPTION
Needed after:
- #2509

FYI @cxzhong 