### PR TITLE
src/sage/calculus/calculus.py: Revert incomplete rename of local variable

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -1712,18 +1712,18 @@ def limit(ex, *args, dir=None, taylor=False, algorithm='maxima', **kwargs):
             giac_dir_arg = 1
         elif dir in dir_minus:
             giac_dir_arg = -1
-        limit_result = libgiac.limit(ex, giac_v, giac_a, giac_dir_arg).sage()
+        l = libgiac.limit(ex, giac_v, giac_a, giac_dir_arg).sage()
     elif effective_algorithm == 'mathematica_free':
         # Ensuring mma_free_limit exists
-        limit_result = mma_free_limit(ex, v, a, dir)
+        l = mma_free_limit(ex, v, a, dir)
     elif effective_algorithm == 'mathics3':
-        limit_result = mathics3_limit(ex, v, a, dir)
+        l = mathics3_limit(ex, v, a, dir)
     else:
         raise ValueError("Unknown algorithm: %s" % effective_algorithm)
 
     original_parent = ex.parent()
 
-    return original_parent(limit_result)
+    return original_parent(l)
 
 
 # lim is alias for limit


### PR DESCRIPTION
From #2496 @rocky  

```
sage -t --warn-long 5.0 --random-seed=255619858341149086195314104132491514222 src/sage/functions/bessel.py
**********************************************************************
File "src/sage/functions/bessel.py", line 729, in sage.functions.bessel.Function_Bessel_I
Failed example:
    limit(bessel_I(0, x), x=oo)                                               # needs sage.symbolic
Exception raised:
    Traceback (most recent call last):
      File "/Users/mkoeppe/s/sage/sage-rebasing/local/var/lib/sage/venv-python3.14/lib/python3.14/site-packages/sage/doctest/forker.py", line 742, in _run
        self.compile_and_execute(example, compiler, test.globs)
        ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/mkoeppe/s/sage/sage-rebasing/local/var/lib/sage/venv-python3.14/lib/python3.14/site-packages/sage/doctest/forker.py", line 1166, in compile_and_execute
        exec(compiled, globs)
        ~~~~^^^^^^^^^^^^^^^^^
      File "<doctest sage.functions.bessel.Function_Bessel_I[15]>", line 1, in <module>
        limit(bessel_I(Integer(0), x), x=oo)                                               # needs sage.symbolic
        ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/mkoeppe/s/sage/sage-rebasing/local/var/lib/sage/venv-python3.14/lib/python3.14/site-packages/sage/calculus/calculus.py", line 1726, in limit
        return original_parent(limit_result)
                               ^^^^^^^^^^^^
    UnboundLocalError: cannot access local variable 'limit_result' where it is not associated with a value
```

Fix here