### PR TITLE
src/sage/env.py (cython_aliases): Workaround for broken flint.pc on ubuntu-noble

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -605,6 +605,10 @@ def cython_aliases(required_modules=None, optional_modules=None):
     aliases["OPENMP_CFLAGS"] = OPENMP_CFLAGS.split()
     aliases["OPENMP_CXXFLAGS"] = OPENMP_CXXFLAGS.split()
 
+    # FLINT: Broken .pc on ubuntu-noble does not contain -lflint
+    if "FLINT_LIBRARIES" in aliases and 'flint' not in aliases["FLINT_LIBRARIES"]:
+        aliases["FLINT_LIBRARIES"].insert(0, 'flint')
+
     return aliases
 
 


### PR DESCRIPTION
- Fixes https://github.com/passagemath/passagemath/issues/2500