### PR TITLE
build/pkgs/benzene: add mingw.txt

### DIFF
--- a/build/pkgs/benzene/distros/mingw.txt
+++ b/build/pkgs/benzene/distros/mingw.txt
@@ -1,0 +1,1 @@
+${MINGW_PACKAGE_PREFIX}-benzene


### PR DESCRIPTION
benzene has been added to the MSYS2 distribution
(<https://github.com/msys2/MINGW-packages/pull/30821>) and this
pull requests adds the corresponding information for the package.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

There's also a pull request with the same changes targeting the `passagemath-10.8.x` branch: https://github.com/passagemath/passagemath/pull/2548