### PR TITLE
build/pkgs/csdp/spkg-install.in: Use -std=gnu17

### DIFF
--- a/build/pkgs/csdp/spkg-install.in
+++ b/build/pkgs/csdp/spkg-install.in
@@ -3,6 +3,7 @@ echo "**************************************************"
 echo "NOTE that csdp's License is NOT GPL-compatible"
 echo "**************************************************"
 
+export CFLAGS="$CFLAGS -std=gnu17"
 
 cd src
 sdh_configure CPPFLAGS=-DNOSHORTS


### PR DESCRIPTION
Fixes build failures from K&R-isms seen in:

[stage-2-optional-0-o / local-macos (26, homebrew-macos-opthomebrew-standard)](https://github.com/passagemath/passagemath/actions/runs/30719691171/job/91617240464#logs)

```
  [csdp-6.2.p1]   [spkg-install] libtool: compile:  gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I.. -I../include -DNOSHORTS -g -O2 -c calc_dobj.c  -fno-common -DPIC -o .libs/libsdp_la-calc_dobj.o
  [csdp-6.2.p1]   [spkg-install] libtool: compile:  gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I.. -I../include -DNOSHORTS -g -O2 -c op_a.c  -fno-common -DPIC -o .libs/libsdp_la-op_a.o
  [csdp-6.2.p1]   [spkg-install] libtool: compile:  gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I.. -I../include -DNOSHORTS -g -O2 -c mat_mult.c  -fno-common -DPIC -o .libs/libsdp_la-mat_mult.o
  [csdp-6.2.p1]   [spkg-install] libtool: compile:  gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I.. -I../include -DNOSHORTS -g -O2 -c trace_prod.c  -fno-common -DPIC -o .libs/libsdp_la-trace_prod.o
  [csdp-6.2.p1]   [spkg-install] calc_dobj.c:7:18: error: unknown type name 'k'
  [csdp-6.2.p1]   [spkg-install]     7 | double calc_dobj(k,a,y,constant_offset)
  [csdp-6.2.p1]   [spkg-install]       |                  ^
  [csdp-6.2.p1]   [spkg-install] calc_dobj.c:7:20: error: unknown type name 'a'
  [csdp-6.2.p1]   [spkg-install]     7 | double calc_dobj(k,a,y,constant_offset)
  [csdp-6.2.p1]   [spkg-install]       |                    ^
  [csdp-6.2.p1]   [spkg-install] calc_dobj.c:7:22: error: unknown type name 'y'
  [csdp-6.2.p1]   [spkg-install]     7 | double calc_dobj(k,a,y,constant_offset)
  [csdp-6.2.p1]   [spkg-install]       |                      ^
  [csdp-6.2.p1]   [spkg-install] calc_dobj.c:7:24: error: unknown type name 'constant_offset'
  [csdp-6.2.p1]   [spkg-install]     7 | double calc_dobj(k,a,y,constant_offset)
  [csdp-6.2.p1]   [spkg-install]       |                        ^
  [csdp-6.2.p1]   [spkg-install] calc_dobj.c:7:40: error: expected ';' after top level declarator
  [csdp-6.2.p1]   [spkg-install]     7 | double calc_dobj(k,a,y,constant_offset)
  [csdp-6.2.p1]   [spkg-install]       |                                        ^
  [csdp-6.2.p1]   [spkg-install]       |                                        ;
  [csdp-6.2.p1]   [spkg-install] calc_dobj.c:12:1: error: expected identifier or '('
  [csdp-6.2.p1]   [spkg-install]    12 | {
  [csdp-6.2.p1]   [spkg-install]       | ^
  [csdp-6.2.p1]   [spkg-install] 6 errors generated.
```