### PR TITLE
build/pkgs/tdlib: Fix on conda-forge-macos-26

### DIFF
--- a/build/pkgs/tdlib/spkg-install.in
+++ b/build/pkgs/tdlib/spkg-install.in
@@ -1,5 +1,7 @@
 cd src
 
+cp "$SAGE_ROOT"/config/config.* .
+
 sdh_configure --with-python=no
 sdh_make
 sdh_make_install -j1


### PR DESCRIPTION
This is to fix:

[stage-2-optional-0-o / local-macos (26, conda-forge-macos-standard)](https://github.com/passagemath/passagemath/actions/runs/31042927009/job/92675980432#logs)

```
  [tdlib-0.9.3.p0]   [spkg-install] checking build system type... Invalid configuration `arm64-apple-darwin20.0.0': machine `arm64-apple' not recognized
  [tdlib-0.9.3.p0]   [spkg-install] configure: error: /bin/bash ./config.sub arm64-apple-darwin20.0.0 failed
```