### PR TITLE
pkgs/sagemath-*: Remove duplication of sage.ext_data.kenzo

### DIFF
--- a/pkgs/sagemath-ecl/setup.py
+++ b/pkgs/sagemath-ecl/setup.py
@@ -17,7 +17,6 @@ sage_setup('sagemath-ecl',
                ],
                "sage": [
                    "ext_data/*",
-                   "ext_data/kenzo/*",
                    "ext_data/singular/*",
                    "ext_data/singular/function_field/*",
                    "ext_data/magma/*",

--- a/pkgs/sagemath-maxima/setup.py
+++ b/pkgs/sagemath-maxima/setup.py
@@ -17,7 +17,6 @@ sage_setup('sagemath-maxima',
                ],
                "sage": [
                    "ext_data/*",
-                   "ext_data/kenzo/*",
                    "ext_data/singular/*",
                    "ext_data/singular/function_field/*",
                    "ext_data/magma/*",

--- a/pkgs/sagemath-standard-no-symbolics/pyproject.toml.m4
+++ b/pkgs/sagemath-standard-no-symbolics/pyproject.toml.m4
@@ -123,7 +123,6 @@ include-package-data = false
 [tool.setuptools.package-data]
 sage = [
     "ext_data/*",
-    "ext_data/kenzo/*",
     "ext_data/images/*",
     "ext_data/mwrank/*",
     "ext_data/notebook-ipython/*",

--- a/pkgs/sagemath-symbolics/MANIFEST.in
+++ b/pkgs/sagemath-symbolics/MANIFEST.in
@@ -38,7 +38,6 @@ include sage/interfaces/mathics3.p*
 include sage/interfaces/sympy*.p*
 include sage/interfaces/tides.p*
 
-graft sage/ext_data/kenzo
 graft sage/ext_data/magma
 
 graft sage/rings/asymptotic

--- a/pkgs/sagemath-symbolics/setup.py
+++ b/pkgs/sagemath-symbolics/setup.py
@@ -17,7 +17,6 @@ sage_setup('sagemath-symbolics',
                ],
                "sage": [
                    "ext_data/*",
-                   "ext_data/kenzo/*",
                    "ext_data/singular/*",
                    "ext_data/singular/function_field/*",
                    "ext_data/magma/*",


### PR DESCRIPTION
It is canonically shipped by passagemath-graphs.