### PR TITLE
`build/bin/sage-logger` [SAGE_CHECK=warn, V=0]: Scan for check failures

### DIFF
--- a/build/bin/sage-logger
+++ b/build/bin/sage-logger
@@ -142,7 +142,9 @@ if [ -n "$SAGE_SILENT_BUILD" -a ${use_prefix} = true ]; then
         fi
     else
         time=$(report_time)
-        if [ -n "$time" ]; then
+        if tail -20 $logfile 2>/dev/null | grep -E "^Warning: Failures testing package" &>/dev/null; then
+            echo "  [$logname] successfully ${verb}ed, but failures testing. Log file: $logfile"
+        elif [ -n "$time" ]; then
             echo "  [$logname] successfully ${verb}ed ($time)."
         else
             echo "  [$logname] successfully ${verb}ed."

--- a/build/make/install
+++ b/build/make/install
@@ -121,20 +121,6 @@ environment variable SAGE_KEEP_BUILT_SPKGS=yes to prevent this.
 EOF
     exit 1
 
-elif [ "$SAGE_CHECK" = "warn" ]; then
-    echo "SAGE_CHECK=warn, so scanning the log files. This may take a few seconds."
-    # The following warning message must be consistent with SAGE_ROOT/build/bin/sage-spkg (see trac:32781)
-    warnings=`look_for_errors "$SAGE_LOGS/*.log" 20 "^Warning: Failures testing package" package`
-    if [ -n "$warnings" ]; then
-        cat >&2 <<EOF
-***************************************************************
-Warning: the following package(s) may have failed their test suites
-(not necessarily during this run of 'make $@'):
-EOF
-
-        echo $warnings >&2
-    fi
-
 fi
 
 # Build succeeded.

--- a/build/pkgs/sagemath_objects/spkg-check
+++ b/build/pkgs/sagemath_objects/spkg-check
@@ -46,8 +46,8 @@ case $status:$SAGE_CHECK:$([ -r known-test-failures.json ]; echo $?) in
     0:no:*)   echo "Not testing the package because SAGE_CHECK=no";;
     0:*:0)    echo "Passed the test suite (modulo baseline known-test-failures*.json)";;
     0:*:*)    echo "Passed the test suite";;
-    *:warn:0) echo "Warning: New failures (not in baseline known-test-failures*.json (ignored)"; status=0;;
-    *:warn:*) echo "Warning: Failures testing the package (ignored)"; status=0;;
+    *:warn:0) echo "Warning: New failures, not in baseline known-test-failures*.json (ignored)";;
+    *:warn:*) echo "Warning: Failures testing the package (ignored)";;
     *:yes:0)  echo "New failures, not in baseline known-test-failures*.json";;
     *:yes:*)  echo "Failures testing the package";;
 esac


### PR DESCRIPTION
This eliminates the repeated output from the bulk scan for package check warnings, seen in particular during the tests of optional packages https://github.com/passagemath/passagemath/actions/runs/31332635390/job/93475521261#step:12:9127

```
make --no-print-directory sagemath_gap_pkg_caratinterface-SAGE_VENV-no-deps
[sagemath_gap_pkg_caratinterface-10.8.9] installing. Log file: /sage/logs/pkgs/sagemath_gap_pkg_caratinterface-10.8.9.log
  [sagemath_gap_pkg_caratinterface-10.8.9] successfully installed.
make[1]: Leaving directory '/sage/build/make'
SAGE_CHECK=warn, so scanning the log files. This may take a few seconds.
* package:         info-7.2
  last build time: Aug 9 20:02
  log file:        /sage/logs/pkgs/info-7.2.log
* package:         dot2tex-2.12.0
  last build time: Aug 9 20:26
  log file:        /sage/logs/pkgs/dot2tex-2.12.0.log
* package:         mpmath-1.3.0
  last build time: Aug 9 20:26
  log file:        /sage/logs/pkgs/mpmath-1.3.0.log
```

New output:
```
$ make SAGE_CHECK=warn SAGE_CHECK_PACKAGES='?sagemath_eclib' V=0 sagemath_eclib-no-deps
make[1]: `build/make/Makefile' is up to date.
build/bin/sage-logger \
		"cd build/make && ./install sagemath_eclib-no-deps" logs/install.log
[sagemath_eclib-10.8.9] installing. Log file: /Users/mkoeppe/s/sage/sage-rebasing/logs/pkgs/sagemath_eclib-10.8.9.log
  [sagemath_eclib-10.8.9] successfully installed, but failures testing. Log file: /Users/mkoeppe/s/sage/sage-rebasing/logs/pkgs/sagemath_eclib-10.8.9.log
real 2m29.758s user 3m31.792s sys 0m24.244s
```
