### PR TITLE
build/pkgs/scip_sdp: Work around outdated cmake version spec

### DIFF
--- a/build/pkgs/scip_sdp/spkg-install.in
+++ b/build/pkgs/scip_sdp/spkg-install.in
@@ -4,6 +4,7 @@ cd build
 sdh_cmake -GNinja \
           -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
           -DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON \
           -DBLA_VENDOR=OpenBLAS \
           -DBLAS_LIBRARIES="$(pkg-config --libs blas)" \


### PR DESCRIPTION
- Fixes #2589 