### PR TITLE
build/pkgs/modular_resolution/spkg-install.in: Use std=gnu17

### DIFF
--- a/build/pkgs/modular_resolution/spkg-install.in
+++ b/build/pkgs/modular_resolution/spkg-install.in
@@ -1,5 +1,8 @@
 cd src
 
+# https://github.com/passagemath/passagemath/issues/2593
+export CFLAGS="$CFLAGS -std=gnu17"
+
 # build and install modular_resolution
 sdh_configure
 sdh_make_install


### PR DESCRIPTION
- Fixes #2593