### PR TITLE
`build/pkgs/openssl`: Require 3.0.0, `curl`: Fix spkg-configure on almalinux-8-toolset-gcc_9-python3.12-standard

### DIFF
--- a/build/pkgs/curl/spkg-configure.m4
+++ b/build/pkgs/curl/spkg-configure.m4
@@ -1,11 +1,12 @@
 SAGE_SPKG_CONFIGURE([curl], [
-    # Only install curl (and libcurl) if we cannot find version 7.22 or
+    # Only install curl (and libcurl) if we cannot find libcurl version 7.22 or
     # later, since that is what R needs.
-    AC_CACHE_CHECK([for curl 7.22], [ac_cv_path_CURL], [
+    AC_CACHE_CHECK([for curl], [ac_cv_path_CURL], [
         AC_PATH_PROGS_FEATURE_CHECK([CURL], [curl], [
-          ${ac_path_CURL}-config --checkfor 7.22 >/dev/null 2>/dev/null &&
-                    ac_cv_path_CURL=${ac_path_CURL} &&
-                    ac_path_CURL_found=:
+            AS_IF([${ac_path_CURL} --version 2>/dev/null | grep -q '^curl [[78]][[.]]' 2>/dev/null], [dnl
+                ac_cv_path_CURL=${ac_path_CURL}
+                ac_path_CURL_found=:
+            ])
         ])
     ])
     AS_IF([test -z "$ac_cv_path_CURL"], [sage_spkg_install_curl=yes])

--- a/build/pkgs/openssl/spkg-configure.m4
+++ b/build/pkgs/openssl/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([openssl], [
   AX_CHECK_OPENSSL([
-    AC_MSG_CHECKING([whether OpenSSL >= 1.1.1, as required by PEP 644, and provides required APIs])
+    AC_MSG_CHECKING([whether OpenSSL >= 3.0.0 and provides required APIs])
     AC_COMPILE_IFELSE(
         dnl Issue #32580: Need OpenSSL >= 1.1.1 for PEP 644
         dnl From https://www.openssl.org/docs/man3.0/man3/OPENSSL_VERSION_NUMBER.html:
@@ -13,13 +13,15 @@ SAGE_SPKG_CONFIGURE([openssl], [
         dnl    S  is "status" (f = release)
         dnl -> OPENSSL_VERSION_NUMBER is 0xMNNFFPPSL
         dnl
+        dnl https://github.com/passagemath/passagemath/issues/2600: Need OpenSSL >= 3.0.0 for curl
+        dnl
         dnl Issue #34273: Test program from ​https://github.com/python/cpython/blob/3.10/configure.ac#L5845
         [AC_LANG_PROGRAM([[
             #include <openssl/opensslv.h>
             #include <openssl/evp.h>
             #include <openssl/ssl.h>
-            #if OPENSSL_VERSION_NUMBER < 0x10101000L
-            #error OpenSSL >= 1.1.1 is required according to PEP 644
+            #if OPENSSL_VERSION_NUMBER < 0x30000000L
+            #error OpenSSL >= 3.0.0 is required
             #endif
             static void keylog_cb(const SSL *ssl, const char *line) {}
           ]], [[


### PR DESCRIPTION
- Fixes https://github.com/passagemath/passagemath/issues/2600