### PR TITLE
.github/workflows/dist.yml: Do not exclude Python versions covered by cp312-abi3

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -592,48 +592,36 @@ jobs:
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_planarity
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-rankwidth
         id:   sagemath-rankwidth
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_rankwidth
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-tachyon
         id:   sagemath-tachyon
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_tachyon
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-cddlib
         id:   sagemath-cddlib
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_cddlib
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-latte-4ti2
         id:   sagemath-latte-4ti2
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_latte_4ti2
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-nauty
         id:   sagemath-nauty
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_nauty
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-libecm
         id:   sagemath-libecm
@@ -646,136 +634,102 @@ jobs:
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_libbraiding
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap-pkg-caratinterface
         id:   sagemath-gap-pkg-caratinterface
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap_pkg_caratinterface
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap-pkg-cddinterface
         id:   sagemath-gap-pkg-cddinterface
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap_pkg_cddinterface
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap-pkg-curlinterface
         id:   sagemath-gap-pkg-curlinterface
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap_pkg_curlinterface
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap-pkg-float
         id:   sagemath-gap-pkg-float
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap_pkg_float
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap-pkg-normalizinterface
         id:   sagemath-gap-pkg-normalizinterface
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap_pkg_normalizinterface
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap-pkg-semigroups
         id:   sagemath-gap-pkg-semigroups
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap_pkg_semigroups
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-cliquer
         id:   sagemath-cliquer
         if:   (success() || failure()) && steps.sagemath-categories.outcome == 'success'
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_cliquer
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-rubiks
         id:   sagemath-rubiks
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_rubiks
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-plantri
         id:   sagemath-plantri
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_plantri
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-buckygen
         id:   sagemath-buckygen
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_buckygen
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-benzene
         id:   sagemath-benzene
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_benzene
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-glucose
         id:   sagemath-glucose
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_glucose
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-kissat
         id:   sagemath-kissat
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_kissat
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-tdlib
         id:   sagemath-tdlib
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_tdlib
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-bliss
         id:   sagemath-bliss
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_bliss
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-mcqd
         id:   sagemath-mcqd
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_mcqd
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-coxeter3
         id:   sagemath-coxeter3
@@ -788,16 +742,12 @@ jobs:
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_lrslib
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-palp
         id:   sagemath-palp
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_palp
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-brial
         id:   sagemath-brial
@@ -1082,8 +1032,6 @@ jobs:
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_sympow
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap
         id:   sagemath-gap
@@ -1401,24 +1349,18 @@ jobs:
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_msolve
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-kenzo
         id:   sagemath-kenzo
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_kenzo
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gap3
         id:   sagemath-gap3
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gap3
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       # Broken on some platforms
 
@@ -1427,40 +1369,30 @@ jobs:
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_macaulay2
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-frobby
         id:   sagemath-frobby
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_frobby
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-gfan
         id:   sagemath-gfan
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_gfan
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-qepcad
         id:   sagemath-qepcad
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_qepcad
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
       - name: sagemath-topcom
         id:   sagemath-topcom
         if:   (success() || failure())
         run: |
           ~/runner-venv/bin/python3 -m cibuildwheel unpacked/passagemath_topcom
-        env:
-          CIBW_SKIP: "cp313-* cp314-*"
 
 
       - name: Upload wheels artifact


### PR DESCRIPTION
cibuildwheel takes care of skipping Python versions that are covered by previously built abi3 wheels automatically.

This fixes runs of ci-wheels on PRs for Python 3.14 (https://github.com/passagemath/passagemath/pull/2608#issuecomment-5308126371)
