### PR TITLE
build/bin/sage-venv: Install activate/deactivate scripts

### DIFF
--- a/build/bin/sage-venv
+++ b/build/bin/sage-venv
@@ -47,5 +47,4 @@ b = venv.EnvBuilder(system_site_packages=options.system_site,
 c = b.ensure_directories(options.env_dir)
 b.setup_python(c)
 b.create_configuration(c)
-# We do not call setup_scripts, which would install the venv 'activate'/'deactivate' scripts.
-
+b.setup_scripts(c)


### PR DESCRIPTION
The reasons for not installing `activate`/`deactivate` scripts in the venv managed by the Sage distribution are long obsolete in passagemath: Everything should be fully functional directly in the venv, without running `sage -sh` and its legacy environment settings.
