### PR TITLE
build/pkgs/kissat/spkg-install.in: Use -std=gnu17 (fixup)

### DIFF
--- a/build/pkgs/kissat/spkg-install.in
+++ b/build/pkgs/kissat/spkg-install.in
@@ -1,6 +1,5 @@
 cd src
-export CFLAGS="-std=gnu17 $CFLAGS"
-./configure CC="$CC" --test --kitten
+./configure CC="$CC -std=gnu17" --test --kitten
 cd build
 sdh_make
 sdh_install kissat kitten "$SAGE_LOCAL"/bin


### PR DESCRIPTION
Our setting of CFLAGS was being ignored