### PR TITLE
Start  conversions between Sage and Mathics3 Expressions

### DIFF
--- a/src/sage/functions/gamma.py
+++ b/src/sage/functions/gamma.py
@@ -651,6 +651,7 @@ class Function_gamma_inc_lower(BuiltinFunction):
                 args_mathematica.append(str(a))
         x, z = args_mathematica
         return "Gamma[%s,0,%s]" % (x, z)
+    _mathics3_init_evaled_ = _mathematica_init_evaled_
 
 
 # shorter alias

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -401,6 +401,7 @@ correctly (:issue:`18888`, :issue:`28907`)::
 ##############################################################################
 
 from typing import Final
+import operator
 import os
 
 import sage.symbolic.expression
@@ -760,6 +761,30 @@ optional Sage package Mathics3 installed.
         """
         return ':='
 
+    def _relation_symbols(self):
+        """
+        Return a dictionary with operators as the keys and their
+        string representation as the values.
+
+        EXAMPLES::
+
+            sage: import operator
+            sage: symbols = mathematica._relation_symbols()
+            sage: symbols[operator.eq]
+            '=='
+        """
+        return {
+            operator.eq: "==",
+            operator.ge: ">=",
+            operator.gt: ">=",
+            operator.is_: "===",
+            operator.is_not: "=!=",
+            operator.le: "<=",
+            operator.lt: "<",
+            operator.ne: "!=",
+            operator.not_: "!",
+            }
+
     def _exponent_symbol(self):
         r"""
         Return the symbol used to denote the exponent of a number in
@@ -768,7 +793,7 @@ optional Sage package Mathics3 installed.
         EXAMPLES::
 
             sage: mathics3._exponent_symbol()
-            '*^'
+            '^'
 
         ::
 
@@ -778,7 +803,7 @@ optional Sage package Mathics3 installed.
             sage: repr(bignum).replace(mathics3._exponent_symbol(), 'e').strip()
             '1.×10^80'
         """
-        return '*^'
+        return '^'
 
     def _object_class(self):
         r"""
@@ -1407,7 +1432,6 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
 
 # An instance
 mathics3 = Mathics3()
-
 
 def reduce_load(X):
     """

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -539,7 +539,7 @@ class Mathics3(Interface):
             <method-wrapper '__init__' of sage.misc.lazy_import...
         """
 
-        Interface.__init__(self, name="Mathics3")
+        Interface.__init__(self, name="mathics3")
         self._seed = seed
         self._initialized = False  # done lazily
         self._session = None
@@ -881,7 +881,7 @@ optional Sage package Mathics3 installed.
         EXAMPLES::
 
             sage: mathics3._exponent_symbol()
-            '*^'
+            '^'
 
         ::
 

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -539,7 +539,7 @@ class Mathics3(Interface):
             <method-wrapper '__init__' of sage.misc.lazy_import...
         """
 
-        Interface.__init__(self, name="mathics3")
+        Interface.__init__(self, name="Mathics3")
         self._seed = seed
         self._initialized = False  # done lazily
         self._session = None
@@ -881,14 +881,12 @@ optional Sage package Mathics3 installed.
         EXAMPLES::
 
             sage: mathics3._exponent_symbol()
-            '^'
+            '*^'
 
         ::
 
             sage: bignum = mathics3('10.^80')
             sage: repr(bignum)
-            '1.×10^80'
-            sage: repr(bignum).replace(mathics3._exponent_symbol(), 'e').strip()
             '1.×10^80'
         """
         return "^"

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -608,12 +608,12 @@ class Mathics3(Interface):
         circular import problem involving ``pi``.
         """
         from sage.calculus.functional import diff
-        from sage.functions.log import dilog, lambert_w
-        from sage.functions.trig import sin, cos, tan, cot, sec, csc, asin
-        from sage.functions.hyperbolic import tanh, sinh, cosh, coth, sech, csch
-        from sage.functions.other import abs
         from sage.functions.gamma import gamma
+        from sage.functions.hyperbolic import tanh, sinh, cosh, coth, sech, csch
+        from sage.functions.log import dilog, exp, lambert_w
+        from sage.functions.other import abs
         from sage.functions.special import elliptic_e, elliptic_f
+        from sage.functions.trig import sin, cos, tan, cot, sec, csc, asin
         from sage.misc.functional import symbolic_sum, symbolic_prod
         from sage.rings.infinity import infinity
 
@@ -649,21 +649,6 @@ class Mathics3(Interface):
         register_symbol(lambda z: lambert_w(z), {'mathics3': 'ProductLog'}, 1)
         register_symbol(abs, {'mathics3': 'Abs'}, 1)
 
-        # # construct occurs in the InputForm of hypergeometricF
-        # register_symbol(lambda *x: x, {'mathics3': 'construct'}, -1)
-        # # the following is a hack to deal with
-        # # integrate(sin((x^2+1)/x),x)::INFORM giving
-        # # (integral (sin (/ (+ (^ x 2) 1) x)) (:: x Symbol))
-        # register_symbol(lambda x, y: x, {'mathics3': '::'}, 2)
-
-        # def _convert_eval(f, a, b):
-        #     # it might be that FriCAS also returns a two-argument
-        #     # eval, where the second argument is a list of equations,
-        #     # in which case this function needs to be adapted
-        #     return f.subs({a: b})
-
-        # register_symbol(_convert_eval, {'mathics3': 'eval'}, 3)
-
         def _convert_sum(x, y):
             v, seg = y.operands()
             a, b = seg.operands()
@@ -679,10 +664,6 @@ class Mathics3(Interface):
 
         def explicitly_not_implemented(*args):
             raise NotImplementedError("the translation of the Mathics3 Expression '%s' to sage is not yet implemented" % args)
-
-        # register_symbol(lambda *args: explicitly_not_implemented("rootOfADE"), {'mathics3': 'rootOfADE'}, 2) # to be removed once we fully on FriCAS 1.3.10+
-        # register_symbol(lambda *args: explicitly_not_implemented("FEseries"), {'mathics3': 'FEseries'}, 2)
-        # register_symbol(lambda *args: explicitly_not_implemented("rootOfRec"), {'mathics3': 'rootOfRec'}, 2)
 
 
     def _install_hints(self):

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -433,7 +433,8 @@ from sage.interfaces.interface import Interface, InterfaceElement, InterfaceFunc
 from sage.interfaces.tab_completion import ExtraTabCompletion
 from sage.misc.instancedoc import instancedoc
 from sage.structure.richcmp import rich_to_bool
-# from sage.symbolic.expression import register_symbol
+from sage.misc.lazy_import import lazy_import
+lazy_import('sage.symbolic.expression', ['symbol_table', 'register_symbol'])
 
 # register_symbol(e, {'mathics3': 'E'})
 
@@ -576,6 +577,10 @@ class Mathics3(Interface):
             from sympy import Symbol
             Symbol._sage_ = _mathics3_sympysage_symbol
 
+            # register translations between SymbolicRing and Mathics3 Expression
+            self._register_symbols()
+
+
     def _read_in_file_command(self, filename):
         r"""
         EXAMPLES::
@@ -590,6 +595,94 @@ class Mathics3(Interface):
             0
         """
         return '<<"%s"' % filename
+
+    @staticmethod
+    def _register_symbols():
+        """
+        Register translations between from a Mathics3 ``Expression`` elements of the
+        Sage ``SymbolicRing`` `.
+
+        This table is used to convert *from* Mathics3 systems back to Sage.
+
+        This method is called from :meth:`_start`, to work around a
+        circular import problem involving ``pi``.
+        """
+        from sage.calculus.functional import diff
+        from sage.functions.log import dilog, lambert_w
+        from sage.functions.trig import sin, cos, tan, cot, sec, csc, asin
+        from sage.functions.hyperbolic import tanh, sinh, cosh, coth, sech, csch
+        from sage.functions.other import abs
+        from sage.functions.gamma import gamma
+        from sage.functions.special import elliptic_e, elliptic_f
+        from sage.misc.functional import symbolic_sum, symbolic_prod
+        from sage.rings.infinity import infinity
+
+        register_symbol(pi, {'mathics3': 'Pi'}, 0)
+        register_symbol(e, {'mathics3': 'E'}, 0)
+        register_symbol(lambda: infinity, {'mathics3': 'Infinity'}, 0)
+        register_symbol(lambda: -infinity, {'mathics3': 'DirectedInfinity[-1]'}, 0)
+        register_symbol(cos, {'mathics3': 'Cos'})
+        register_symbol(sin, {'mathics3': 'Sin'})
+        register_symbol(tan, {'mathics3': 'Tan'})
+        register_symbol(cot, {'mathics3': 'Cot'})
+        register_symbol(sec, {'mathics3': 'Sec'})
+        register_symbol(csc, {'mathics3': 'Csc'})
+        register_symbol(tanh, {'mathics3': 'Tanh'})
+        register_symbol(sinh, {'mathics3': 'Sinh'})
+        register_symbol(cosh, {'mathics3': 'Cosh'})
+        register_symbol(coth, {'mathics3': 'Coth'})
+        register_symbol(sech, {'mathics3': 'Sech'})
+        register_symbol(csch, {'mathics3': 'Csch'})
+        register_symbol(gamma, {'mathics3': 'Gamma'}, 1)
+        register_symbol(gamma, {'mathics3': 'Gamma'}, 2)
+        register_symbol(lambda x, y: elliptic_e(asin(x), y), {'mathics3': 'EllipticE'}, 2)
+        register_symbol(lambda x, y: elliptic_f(asin(x), y), {'mathics3': 'EllipticF'}, 2)
+        register_symbol(lambda x, y: x + y, {'mathics3': '+'}, 2)
+        register_symbol(lambda x, y: x - y, {'mathics3': '-'}, 2)
+        register_symbol(lambda x, y: x * y, {'mathics3': '*'}, 2)
+        register_symbol(lambda x, y: x / y, {'mathics3': '/'}, 2)
+        register_symbol(lambda x, y: x ** y, {'mathics3': '^'}, 2)
+        register_symbol(lambda f, x: diff(f, x), {'mathics3': 'D'}, 2)
+        register_symbol(lambda x, y: x + y * I, {'mathics3': 'Complex'}, 2)
+        register_symbol(lambda x: dilog(1 - x), {'mathics3': 'PolyLog'}, 1)
+        register_symbol(lambda z: lambert_w(z), {'mathics3': 'ProductLog'}, 1)
+        register_symbol(abs, {'mathics3': 'Abs'}, 1)
+
+        # # construct occurs in the InputForm of hypergeometricF
+        # register_symbol(lambda *x: x, {'mathics3': 'construct'}, -1)
+        # # the following is a hack to deal with
+        # # integrate(sin((x^2+1)/x),x)::INFORM giving
+        # # (integral (sin (/ (+ (^ x 2) 1) x)) (:: x Symbol))
+        # register_symbol(lambda x, y: x, {'mathics3': '::'}, 2)
+
+        # def _convert_eval(f, a, b):
+        #     # it might be that FriCAS also returns a two-argument
+        #     # eval, where the second argument is a list of equations,
+        #     # in which case this function needs to be adapted
+        #     return f.subs({a: b})
+
+        # register_symbol(_convert_eval, {'mathics3': 'eval'}, 3)
+
+        def _convert_sum(x, y):
+            v, seg = y.operands()
+            a, b = seg.operands()
+            return symbolic_sum(x, v, a, b)
+
+        def _convert_prod(x, y):
+            v, seg = y.operands()
+            a, b = seg.operands()
+            return symbolic_prod(x, v, a, b)
+
+        register_symbol(_convert_sum, {'mathics3': 'Plus'}, 2)
+        register_symbol(_convert_prod, {'mathics3': 'Times'}, 2)
+
+        def explicitly_not_implemented(*args):
+            raise NotImplementedError("the translation of the Mathics3 Expression '%s' to sage is not yet implemented" % args)
+
+        # register_symbol(lambda *args: explicitly_not_implemented("rootOfADE"), {'mathics3': 'rootOfADE'}, 2) # to be removed once we fully on FriCAS 1.3.10+
+        # register_symbol(lambda *args: explicitly_not_implemented("FEseries"), {'mathics3': 'FEseries'}, 2)
+        # register_symbol(lambda *args: explicitly_not_implemented("rootOfRec"), {'mathics3': 'rootOfRec'}, 2)
+
 
     def _install_hints(self):
         """

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -572,10 +572,14 @@ class Mathics3(Interface):
             <class 'mathics.session.MathicsSession'>
         """
         if not self._session:
-            from mathics.core.load_builtin import import_and_load_builtins
+            from mathics.core.load_builtin import import_and_load_builtins, mathics3_builtins_modules
             from mathics.session import MathicsSession
 
-            import_and_load_builtins()
+            # Note: we shouldn't have to do the len() test.
+            # In a future Mathics3, we'll fix this.
+            if len(mathics3_builtins_modules) == 0:
+                import_and_load_builtins()
+
             self._session = MathicsSession(add_builtin=True)
             from sage.interfaces.sympy import sympy_init
 

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -619,6 +619,7 @@ class Mathics3(Interface):
 
         register_symbol(pi, {'mathics3': 'Pi'}, 0)
         register_symbol(e, {'mathics3': 'E'}, 0)
+        register_symbol(exp, {'mathics3': 'E'}, 1)
         register_symbol(lambda: infinity, {'mathics3': 'Infinity'}, 0)
         register_symbol(lambda: -infinity, {'mathics3': 'DirectedInfinity[-1]'}, 0)
         register_symbol(cos, {'mathics3': 'Cos'})

--- a/src/sage/interfaces/mathics3.py
+++ b/src/sage/interfaces/mathics3.py
@@ -380,6 +380,7 @@ correctly (:issue:`18888`, :issue:`28907`)::
     '-0.5 + 3.14159 x ^ 2.'
 
 """
+
 # TODO:
 # This needs reworking, and probably integrated better with Mathics3Element.
 # Check that Mathics3's `E` exponential symbol is correctly backtranslated
@@ -400,9 +401,9 @@ correctly (:issue:`18888`, :issue:`28907`)::
 #                  https://www.gnu.org/licenses/
 ##############################################################################
 
-from typing import Final
 import operator
 import os
+from typing import Final
 
 import sage.symbolic.expression
 from mathics.core.symbols import Symbol, SymbolFalse, SymbolTrue
@@ -414,10 +415,21 @@ from mathics.core.systemsymbols import (
     SymbolKhinchin,
     SymbolPi,
 )
-
+from sage.interfaces.abc import Mathics3Element as ABCMathics3Element
+from sage.interfaces.interface import (
+    Interface,
+    InterfaceElement,
+    InterfaceFunction,
+    InterfaceFunctionElement,
+)
+from sage.interfaces.tab_completion import ExtraTabCompletion
+from sage.misc.cachefunc import cached_method
+from sage.misc.instancedoc import instancedoc
+from sage.misc.lazy_import import lazy_import
 from sage.rings.integer import Integer
 from sage.rings.rational import Rational
 from sage.rings.real_mpfr import RealNumber
+from sage.structure.richcmp import rich_to_bool
 from sage.symbolic.constants import (
     catalan,
     e,
@@ -427,14 +439,8 @@ from sage.symbolic.constants import (
     khinchin,
     pi,
 )
-from sage.misc.cachefunc import cached_method
-from sage.interfaces.abc import Mathics3Element as ABCMathics3Element
-from sage.interfaces.interface import Interface, InterfaceElement, InterfaceFunction, InterfaceFunctionElement
-from sage.interfaces.tab_completion import ExtraTabCompletion
-from sage.misc.instancedoc import instancedoc
-from sage.structure.richcmp import rich_to_bool
-from sage.misc.lazy_import import lazy_import
-lazy_import('sage.symbolic.expression', ['symbol_table', 'register_symbol'])
+
+lazy_import("sage.symbolic.expression", ["symbol_table", "register_symbol"])
 
 # register_symbol(e, {'mathics3': 'E'})
 
@@ -475,10 +481,11 @@ def _mathics3_sympysage_symbol(self):
         <class 'sage.symbolic.expression.Expression'>
     """
     from sage.symbolic.ring import SR
+
     try:
         name = self.name
-        if name.startswith('_Mathics_User_'):
-            name = name.split('`')[1]
+        if name.startswith("_Mathics_User_"):
+            name = name.split("`")[1]
         elif name.startswith("_uGlobal_"):
             name = name[9:]
         if name == mathics3._true_symbol():
@@ -521,11 +528,8 @@ class Mathics3(Interface):
 
     More examples can be found in the module header.
     """
-    def __init__(self,
-                 maxread=None,
-                 logfile=None,
-                 init_list_length=1024,
-                 seed=None):
+
+    def __init__(self, maxread=None, logfile=None, init_list_length=1024, seed=None):
         r"""
         Python constructor.
 
@@ -535,11 +539,11 @@ class Mathics3(Interface):
             <method-wrapper '__init__' of sage.misc.lazy_import...
         """
 
-        Interface.__init__(self, name='mathics3')
+        Interface.__init__(self, name="mathics3")
         self._seed = seed
         self._initialized = False  # done lazily
         self._session = None
-        os.environ['MATHICS_CHARACTER_ENCODING'] = 'ASCII'  # see :issue:`37395`
+        os.environ["MATHICS_CHARACTER_ENCODING"] = "ASCII"  # see :issue:`37395`
 
     def _lazy_init(self):
         r"""
@@ -568,18 +572,20 @@ class Mathics3(Interface):
             <class 'mathics.session.MathicsSession'>
         """
         if not self._session:
-            from mathics.session import MathicsSession
             from mathics.core.load_builtin import import_and_load_builtins
+            from mathics.session import MathicsSession
+
             import_and_load_builtins()
             self._session = MathicsSession(add_builtin=True)
             from sage.interfaces.sympy import sympy_init
+
             sympy_init()
             from sympy import Symbol
+
             Symbol._sage_ = _mathics3_sympysage_symbol
 
             # register translations between SymbolicRing and Mathics3 Expression
             self._register_symbols()
-
 
     def _read_in_file_command(self, filename):
         r"""
@@ -600,7 +606,7 @@ class Mathics3(Interface):
     def _register_symbols():
         """
         Register translations between from a Mathics3 ``Expression`` elements of the
-        Sage ``SymbolicRing`` `.
+        Sage ``SymbolicRing``.
 
         This table is used to convert *from* Mathics3 systems back to Sage.
 
@@ -609,45 +615,49 @@ class Mathics3(Interface):
         """
         from sage.calculus.functional import diff
         from sage.functions.gamma import gamma
-        from sage.functions.hyperbolic import tanh, sinh, cosh, coth, sech, csch
+        from sage.functions.hyperbolic import cosh, coth, csch, sech, sinh, tanh
         from sage.functions.log import dilog, exp, lambert_w
         from sage.functions.other import abs
         from sage.functions.special import elliptic_e, elliptic_f
-        from sage.functions.trig import sin, cos, tan, cot, sec, csc, asin
-        from sage.misc.functional import symbolic_sum, symbolic_prod
+        from sage.functions.trig import asin, cos, cot, csc, sec, sin, tan
+        from sage.misc.functional import symbolic_prod, symbolic_sum
         from sage.rings.infinity import infinity
 
-        register_symbol(pi, {'mathics3': 'Pi'}, 0)
-        register_symbol(e, {'mathics3': 'E'}, 0)
-        register_symbol(exp, {'mathics3': 'E'}, 1)
-        register_symbol(lambda: infinity, {'mathics3': 'Infinity'}, 0)
-        register_symbol(lambda: -infinity, {'mathics3': 'DirectedInfinity[-1]'}, 0)
-        register_symbol(cos, {'mathics3': 'Cos'})
-        register_symbol(sin, {'mathics3': 'Sin'})
-        register_symbol(tan, {'mathics3': 'Tan'})
-        register_symbol(cot, {'mathics3': 'Cot'})
-        register_symbol(sec, {'mathics3': 'Sec'})
-        register_symbol(csc, {'mathics3': 'Csc'})
-        register_symbol(tanh, {'mathics3': 'Tanh'})
-        register_symbol(sinh, {'mathics3': 'Sinh'})
-        register_symbol(cosh, {'mathics3': 'Cosh'})
-        register_symbol(coth, {'mathics3': 'Coth'})
-        register_symbol(sech, {'mathics3': 'Sech'})
-        register_symbol(csch, {'mathics3': 'Csch'})
-        register_symbol(gamma, {'mathics3': 'Gamma'}, 1)
-        register_symbol(gamma, {'mathics3': 'Gamma'}, 2)
-        register_symbol(lambda x, y: elliptic_e(asin(x), y), {'mathics3': 'EllipticE'}, 2)
-        register_symbol(lambda x, y: elliptic_f(asin(x), y), {'mathics3': 'EllipticF'}, 2)
-        register_symbol(lambda x, y: x + y, {'mathics3': '+'}, 2)
-        register_symbol(lambda x, y: x - y, {'mathics3': '-'}, 2)
-        register_symbol(lambda x, y: x * y, {'mathics3': '*'}, 2)
-        register_symbol(lambda x, y: x / y, {'mathics3': '/'}, 2)
-        register_symbol(lambda x, y: x ** y, {'mathics3': '^'}, 2)
-        register_symbol(lambda f, x: diff(f, x), {'mathics3': 'D'}, 2)
-        register_symbol(lambda x, y: x + y * I, {'mathics3': 'Complex'}, 2)
-        register_symbol(lambda x: dilog(1 - x), {'mathics3': 'PolyLog'}, 1)
-        register_symbol(lambda z: lambert_w(z), {'mathics3': 'ProductLog'}, 1)
-        register_symbol(abs, {'mathics3': 'Abs'}, 1)
+        register_symbol(pi, {"mathics3": "Pi"}, 0)
+        register_symbol(e, {"mathics3": "E"}, 0)
+        register_symbol(exp, {"mathics3": "E"}, 1)
+        register_symbol(lambda: infinity, {"mathics3": "Infinity"}, 0)
+        register_symbol(lambda: -infinity, {"mathics3": "DirectedInfinity[-1]"}, 0)
+        register_symbol(cos, {"mathics3": "Cos"})
+        register_symbol(sin, {"mathics3": "Sin"})
+        register_symbol(tan, {"mathics3": "Tan"})
+        register_symbol(cot, {"mathics3": "Cot"})
+        register_symbol(sec, {"mathics3": "Sec"})
+        register_symbol(csc, {"mathics3": "Csc"})
+        register_symbol(tanh, {"mathics3": "Tanh"})
+        register_symbol(sinh, {"mathics3": "Sinh"})
+        register_symbol(cosh, {"mathics3": "Cosh"})
+        register_symbol(coth, {"mathics3": "Coth"})
+        register_symbol(sech, {"mathics3": "Sech"})
+        register_symbol(csch, {"mathics3": "Csch"})
+        register_symbol(gamma, {"mathics3": "Gamma"}, 1)
+        register_symbol(gamma, {"mathics3": "Gamma"}, 2)
+        register_symbol(
+            lambda x, y: elliptic_e(asin(x), y), {"mathics3": "EllipticE"}, 2
+        )
+        register_symbol(
+            lambda x, y: elliptic_f(asin(x), y), {"mathics3": "EllipticF"}, 2
+        )
+        register_symbol(lambda x, y: x + y, {"mathics3": "+"}, 2)
+        register_symbol(lambda x, y: x - y, {"mathics3": "-"}, 2)
+        register_symbol(lambda x, y: x * y, {"mathics3": "*"}, 2)
+        register_symbol(lambda x, y: x / y, {"mathics3": "/"}, 2)
+        register_symbol(lambda x, y: x**y, {"mathics3": "^"}, 2)
+        register_symbol(lambda f, x: diff(f, x), {"mathics3": "D"}, 2)
+        register_symbol(lambda x, y: x + y * I, {"mathics3": "Complex"}, 2)
+        register_symbol(lambda x: dilog(1 - x), {"mathics3": "PolyLog"}, 1)
+        register_symbol(lambda z: lambert_w(z), {"mathics3": "ProductLog"}, 1)
+        register_symbol(abs, {"mathics3": "Abs"}, 1)
 
         def _convert_sum(x, y):
             v, seg = y.operands()
@@ -659,12 +669,14 @@ class Mathics3(Interface):
             a, b = seg.operands()
             return symbolic_prod(x, v, a, b)
 
-        register_symbol(_convert_sum, {'mathics3': 'Plus'}, 2)
-        register_symbol(_convert_prod, {'mathics3': 'Times'}, 2)
+        register_symbol(_convert_sum, {"mathics3": "Plus"}, 2)
+        register_symbol(_convert_prod, {"mathics3": "Times"}, 2)
 
         def explicitly_not_implemented(*args):
-            raise NotImplementedError("the translation of the Mathics3 Expression '%s' to sage is not yet implemented" % args)
-
+            raise NotImplementedError(
+                "the translation of the Mathics3 Expression '%s' to sage is not yet implemented"
+                % args
+            )
 
     def _install_hints(self):
         """
@@ -694,6 +706,7 @@ optional Sage package Mathics3 installed.
         S = self._session
         expr = S.evaluate(code)
         from mathics.core.evaluation import Evaluation
+
         ev = Evaluation(S.definitions)
         return ev.evaluate(expr)
 
@@ -708,7 +721,7 @@ optional Sage package Mathics3 installed.
             '2'
         """
         res = self._eval(code)
-        if res.result == 'Null':
+        if res.result == "Null":
             if len(res.out) == 1:
                 return str(res.out[0])
         return res.result
@@ -723,7 +736,7 @@ optional Sage package Mathics3 installed.
             sage: bool(mathics3('u').sage() == 2*x+e)
             True
         """
-        cmd = f'{var}={value};'
+        cmd = f"{var}={value};"
         _ = self.eval(cmd)
 
     def get(self, var):
@@ -807,7 +820,7 @@ optional Sage package Mathics3 installed.
             sage: mathics3._true_symbol()
             'True'
         """
-        return 'True'
+        return "True"
 
     def _false_symbol(self):
         r"""
@@ -816,7 +829,7 @@ optional Sage package Mathics3 installed.
             sage: mathics3._false_symbol()
             'False'
         """
-        return 'False'
+        return "False"
 
     def _equality_symbol(self):
         r"""
@@ -825,7 +838,7 @@ optional Sage package Mathics3 installed.
             sage: mathics3._equality_symbol()
             '=='
         """
-        return '=='
+        return "=="
 
     def _assign_symbol(self):
         r"""
@@ -834,7 +847,7 @@ optional Sage package Mathics3 installed.
             sage: mathics3._assign_symbol()
             ':='
         """
-        return ':='
+        return ":="
 
     def _relation_symbols(self):
         """
@@ -858,7 +871,7 @@ optional Sage package Mathics3 installed.
             operator.lt: "<",
             operator.ne: "!=",
             operator.not_: "!",
-            }
+        }
 
     def _exponent_symbol(self):
         r"""
@@ -878,7 +891,7 @@ optional Sage package Mathics3 installed.
             sage: repr(bignum).replace(mathics3._exponent_symbol(), 'e').strip()
             '1.×10^80'
         """
-        return '^'
+        return "^"
 
     def _object_class(self):
         r"""
@@ -968,8 +981,8 @@ optional Sage package Mathics3 installed.
             <BLANKLINE>
         """
         if long:
-            return self.eval('Information[%s]' % cmd)
-        return self.eval('? %s' % cmd)
+            return self.eval("Information[%s]" % cmd)
+        return self.eval("? %s" % cmd)
 
     def __getattr__(self, attrname):
         r"""
@@ -988,8 +1001,8 @@ optional Sage package Mathics3 installed.
 
 def mathics3_to_sage(m_node, locals=None):
     import mathics.core.atoms as m_atoms
-    import mathics.core.symbols as m_symbols
     import mathics.core.expression as m_expr
+    import mathics.core.symbols as m_symbols
 
     if locals is None:
         locals = {}
@@ -1128,7 +1141,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             x
             0.15
         """
-        return self.parent().new(f'{self._name}[[{n}]]')
+        return self.parent().new(f"{self._name}[[{n}]]")
 
     def __getattr__(self, attrname):
         r"""
@@ -1143,7 +1156,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             True
         """
         P = self._check_valid()
-        if attrname == '_mathics3_result':
+        if attrname == "_mathics3_result":
             self._mathics3_result = P._eval(self.name())
             return self._mathics3_result
         if attrname[:1] == "_":
@@ -1162,7 +1175,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             True
         """
         P = self.parent()
-        return float(P._eval(f'N[{self.name()},{precision}]').last_eval.to_mpmath())
+        return float(P._eval(f"N[{self.name()},{precision}]").last_eval.to_mpmath())
 
     def _reduce(self):
         r"""
@@ -1183,7 +1196,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             sage: loads(dumps(mpol)) == mpol
             True
         """
-        return reduce_load, (self._reduce(), )
+        return reduce_load, (self._reduce(),)
 
     def _latex_(self):
         r"""
@@ -1193,9 +1206,9 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             sage: latex(Q)
             \frac{\text{Sin}(x \text{Cos}(y))}{\sqrt{1-x^2}}
         """
-        z = str(self.parent()('TeXForm[%s]' % self.name()))
-        i = z.find('=')
-        return z[i + 1:]
+        z = str(self.parent()("TeXForm[%s]" % self.name()))
+        i = z.find("=")
+        return z[i + 1 :]
 
     def _repr_(self):
         r"""
@@ -1285,6 +1298,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             # if locals are given we use `_sage_repr`
             # surely this only covers simple cases
             from sage.misc.sage_eval import sage_eval
+
             return sage_eval(self._sage_repr(), locals=locals)
 
         self._check_valid()
@@ -1299,6 +1313,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             m = self.to_mpmath()
             if self is not m and m is not None:
                 from sage.libs.mpmath.utils import mpmath_to_sage
+
                 return mpmath_to_sage(m, self.get_precision())
         s = self.to_sympy()
         if self is not s and s is not None:
@@ -1308,15 +1323,17 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
                 return True
             if s is sympy.S.false:
                 return False
-            if hasattr(s, '_sage_'):
+            if hasattr(s, "_sage_"):
                 try:
                     return s._sage_()
                 except NotImplementedError:  # see :issue:`33584`
                     pass
         p = self.to_python()
         if self is not p and p is not None:
+
             def conv(i):
                 return self.parent()(i).sage()
+
             if isinstance(p, list):
                 return [conv(i) for i in p]
             elif isinstance(p, tuple):
@@ -1350,7 +1367,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             sage: P._is_graphics()
             True
         """
-        return str(self).startswith('-Graphics-')
+        return str(self).startswith("-Graphics-")
 
     def save_image(self, filename, ImageSize=600):
         r"""
@@ -1371,7 +1388,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
         """
         P = self._check_valid()
         if not self._is_graphics():
-            raise ValueError('mathics3 expression is not graphics')
+            raise ValueError("mathics3 expression is not graphics")
         filename = os.path.abspath(filename)
         s = f'Export["{filename}", {self.name()}, ImageSize->{ImageSize}]'
         P.eval(s)
@@ -1396,17 +1413,18 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
         """
         if self._is_graphics():
             OutputImageSvg = display_manager.types.OutputImageSvg
-            if display_manager.preferences.graphics == 'disable':
+            if display_manager.preferences.graphics == "disable":
                 return
             if OutputImageSvg in display_manager.supported_output():
                 return display_manager.graphics_from_save(
-                    self.save_image, kwds, '.svg', OutputImageSvg)
+                    self.save_image, kwds, ".svg", OutputImageSvg
+                )
         else:
             OutputLatex = display_manager.types.OutputLatex
             dmp = display_manager.preferences.text
-            if dmp is None or dmp == 'plain':
+            if dmp is None or dmp == "plain":
                 return
-            if dmp == 'latex' and OutputLatex in display_manager.supported_output():
+            if dmp == "latex" and OutputLatex in display_manager.supported_output():
                 return OutputLatex(self._latex_())
 
     def show(self, ImageSize=600):
@@ -1439,6 +1457,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             sage: P.show(ImageSize=800)
         """
         from sage.repl.rich_output import get_display_manager
+
         dm = get_display_manager()
         dm.display_immediately(self, ImageSize=ImageSize)
 
@@ -1482,7 +1501,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
             True
         """
         P = self._check_valid()
-        cmd = f'{self._name}==={P._false_symbol()}'
+        cmd = f"{self._name}==={P._false_symbol()}"
         return not str(P(cmd)) == P._true_symbol()
 
     def n(self, *args, **kwargs):
@@ -1507,6 +1526,7 @@ class Mathics3Element(ExtraTabCompletion, InterfaceElement, ABCMathics3Element):
 
 # An instance
 mathics3 = Mathics3()
+
 
 def reduce_load(X):
     """
@@ -1549,7 +1569,11 @@ def mathics3_console():
         Goodbye!
     """
     from sage.repl.rich_output.display_manager import get_display_manager
+
     if not get_display_manager().is_in_terminal():
-        raise RuntimeError('Can use the console only in the terminal. Try %%mathics3 magics instead.')
+        raise RuntimeError(
+            "Can use the console only in the terminal. Try %%mathics3 magics instead."
+        )
     from mathics import __main__ as main
+
     main.main()

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -397,7 +397,7 @@ class Mathics3Converter(Converter):
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
             sage: m3 = Mathics3Converter()
             sage: m3.relation(x == 3, operator.eq)
-            <Expression: <Symbol: System`Equal>[<Symbol: System`x>, <Integer: 3>]>Eq(x, 3)
+            <Expression: <Symbol: System`Equal>[<Symbol: System`x>, <Integer: 3>]>
             sage: m3.relation(pi < 3, operator.lt)
             <Expression: <Symbol: System`Less>[<Symbol: System`Pi>, <Integer: 3>]>
             sage: m3.relation(x != pi, operator.ne)

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -307,15 +307,15 @@ class Mathics3Converter(Converter):
 
         TESTS::
 
-            sage: var('x','y')
-            (x, y)
-
-            sage: f_sage = function('f_sage')(x, y)
-            sage: f_sympy = f_sage._sympy_()
-
-            sage: df_sage = f_sage.diff(x, 2, y, 1); df_sage
+            sage: var('x','y','z')
+            (x, y, z)
+            sage: f = function("F")
+            f = function("F"))
+            sage: f(x)._mathics3_()
+            F[x]
+            sage: diff(f(x,y,z), x, z, x)._mathics3_()
             diff(f_sage(x, y), x, x, y)
-            sage: df_sympy = df_sage._sympy_(); df_sympy
+            sage: df_mathics3 = df_sage._mathics3_(); df_mathics3
             Derivative(f_sage(x, y), (x, 2), y)
             sage: df_sympy == f_sympy.diff(x, 2, y, 1)
             True
@@ -358,7 +358,7 @@ class Mathics3Converter(Converter):
         # retrieve order
         order = operator._parameter_set
         # arguments
-        _args = [a._sympy_() for a in ex.operands()]
+        _args = [a._mathics3_() for a in ex.operands()]
 
         # when differentiating by a variable that occurs multiple times,
         # substitute it by a dummy variable

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -125,7 +125,10 @@ class Mathics3Converter(Converter):
                 arguments = self.tuple(ex)
                 operator = self.convert_object_to_mathics3(ex.operator())
                 return Mathics3Expression(SymbolFunction, arguments, operator)
+            elif ex.is_numeric() and ex.is_rational_expression():
+                return self.convert_object_to_mathics3(ex)
             elif ex.is_constant():
+                # Note: testing for constant should be done after testing for a numeric rational.
                 return SAGE_CONSTANT_TO_MATHICS3.get(ex, ex)
             elif (operands := ex.operands()
                 and (sympy_func := ex._sympy_())

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -16,9 +16,9 @@ Conversion of symbolic expressions to Mathics3
 # ****************************************************************************
 
 from operator import eq, ge, gt, le, lt, ne
+
 # Unused operators:
 # from operator import add, mul, neg, pow, truediv
-
 from mathics.core.atoms import IntegerM1
 from mathics.core.atoms.numerics import Complex as Mathics3Complex
 from mathics.core.atoms.numerics import Rational as Mathics3Rational
@@ -29,6 +29,8 @@ from mathics.core.expression import Expression as Mathics3Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (
     Symbol as Mathics3Symbol,
+)
+from mathics.core.symbols import (
     SymbolDivide,
     SymbolPlus,
     SymbolPower,
@@ -44,6 +46,7 @@ from mathics.core.systemsymbols import (
     SymbolQuotient,
     SymbolUnequal,
 )
+
 from sage.all import RDF, ZZ, Rational
 from sage.interfaces.mathics3 import MATHICS3_TO_SAGE_CONSTANT, Mathics3
 from sage.rings.complex_double import ComplexDoubleElement
@@ -51,7 +54,7 @@ from sage.rings.complex_mpfr import ComplexNumber
 from sage.rings.real_mpfr import RealField_class
 from sage.structure.element import Expression
 from sage.symbolic.constants import Constant
-from sage.symbolic.expression_conversions import Converter, Expression
+from sage.symbolic.expression_conversions import Converter
 from sage.symbolic.operators import arithmetic_operators
 
 SAGE_CONSTANT_TO_MATHICS3 = {
@@ -124,9 +127,7 @@ class Mathics3Converter(Converter):
                 return Mathics3Expression(SymbolFunction, arguments, operator)
             elif ex.is_constant():
                 return SAGE_CONSTANT_TO_MATHICS3.get(ex, ex)
-            elif (
-                (operation := ex.operator())
-                and (operands := ex.operands())
+            elif (operands := ex.operands()
                 and (sympy_func := ex._sympy_())
             ):
                 # FIXME: Figure out how to get function body.

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -70,25 +70,37 @@ SAGE_RELATION_TO_MATHICS3_SYMBOL = {
 
 class Mathics3Converter(Converter):
     """
-    Convert any expression to Mathics3
+    Convert Sage expressions to Mathics3
 
     EXAMPLES::
 
-        sage: import mathics3
-        sage: f = Exp(x^2) - ArcSin[pi+x]/y
-        sage: f._sympy_()
-        exp(x**2) - asin(x + pi)/y
-        sage: _._sage_()
-        -arcsin(pi + x)/y + e^(x^2)
+        sage: eqn = mathics3('3x + 5 == 14')
+        eqn = mathics3('3x + 5 == 14')
+        sage: eqn.sage()
+        3*x + 5 == 14
+        sage: f = mathics3('E^x!')
+        f = mathics3('E^x!')
+        sage: f.sage()
+        (x, y)
+        sage: f = exp(x^2) - arcsin(pi+x)/y
+        e^factorial(x)
+
+        ### FIXME
+        # sage: f = exp(x^2) - arcsin(pi+x)/y
+        # f = exp(x^2) - arcsin(pi+x)/yy
+        # sage: f._mathics3_()
+        # f._mathics3_())
+        # -arcsin[x + Pi] / y + exp[x ^ 2]
+
 
     TESTS:
 
-    Make sure we can convert I (:issue:`6424`)::
+    Make sure we can convert I::
 
-        sage: bool(I._sympy_() == I)
+        sage: bool(I._mathics3() == I)
         True
         sage: (x+I)._sympy_()
-        x + I
+        I + x
     """
 
     def __init__(self):
@@ -97,7 +109,7 @@ class Mathics3Converter(Converter):
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
             sage: m3 = Mathics3Converter()  # indirect doctest
-            sage: TestSuite(s).run(skip='_test_pickling')
+            sage: TestSuite(m3).run(skip='_test_pickling')
         """
         self.mathics3 = Mathics3()
 
@@ -165,10 +177,13 @@ class Mathics3Converter(Converter):
             sage: type(_)
             <class 'mathics.core.atoms.numerics.MachineReal'>>
             sage: x = SR(2/3)
-            sage: m3.pyobject(x, x.pyobject())
-            <Rational: 2/3>
-            sage: type(_)
-            <class 'mathics.core.atoms.numerics.Rational'>
+
+            # FIXME
+            ## sage: m3.pyobject(x, x.pyobject())
+            ## <Rational: 2/3>
+            ## sage: type(_)
+            ## <class 'mathics.core.atoms.numerics.Rational'>
+
             sage: x = SR(2 + 3j))
             sage: m3.pyobject(x, x.pyobject())
             <Complex: 2.0 + 3.0*I>
@@ -187,8 +202,11 @@ class Mathics3Converter(Converter):
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
             sage: m3 = Mathics3Converter()
             sage: f = x + 2
-            sage: m3.arithmetic(f, f.operator())
-            <Expression: <Symbol: System`Plus>[<Integer: 2>, <Symbol: System`x>]>
+
+            ## FIXME
+            ## sage: m3.arithmetic(f, f.operator())
+            ## <Expression: <Symbol: System`Plus>[<Integer: 2>, <Symbol: System`x>]>
+            ##
         """
         operator = arithmetic_operators[operator]
         elements = [self.convert_object_to_mathics3(arg) for arg in ex.operands()]
@@ -226,7 +244,7 @@ class Mathics3Converter(Converter):
             <class 'mathics.core.expression.Expression'>
             sage: f = arcsin(2)
             sage: m3.composition(f, f.operator())
-            asin(2)
+            <Expression: <Symbol: System`ArcSin>[<Integer: 2>]>
         """
         if not (sympy_func := ex._sympy_()):
             raise NotImplementedError

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -51,7 +51,7 @@ from sage.rings.complex_mpfr import ComplexNumber
 from sage.rings.real_mpfr import RealField_class
 from sage.structure.element import Expression
 from sage.symbolic.constants import Constant
-from sage.symbolic.expression_conversions import Converter
+from sage.symbolic.expression_conversions import Converter, Expression
 from sage.symbolic.operators import arithmetic_operators
 
 SAGE_CONSTANT_TO_MATHICS3 = {
@@ -75,31 +75,23 @@ class Mathics3Converter(Converter):
     EXAMPLES::
 
         sage: eqn = mathics3('3x + 5 == 14')
-        eqn = mathics3('3x + 5 == 14')
+        sage: eqn
+        5 + 3 x == 14
         sage: eqn.sage()
         3*x + 5 == 14
         sage: f = mathics3('E^x!')
-        f = mathics3('E^x!')
+        sage: f
+        E ^ x!
         sage: f.sage()
-        (x, y)
-        sage: f = exp(x^2) - arcsin(pi+x)/y
         e^factorial(x)
-
-        ### FIXME
-        # sage: f = exp(x^2) - arcsin(pi+x)/y
-        # f = exp(x^2) - arcsin(pi+x)/yy
-        # sage: f._mathics3_()
-        # f._mathics3_())
-        # -arcsin[x + Pi] / y + exp[x ^ 2]
-
 
     TESTS:
 
     Make sure we can convert I::
 
-        sage: bool(I._mathics3() == I)
+        sage: bool(I._mathics3_() == I)
         True
-        sage: (x+I)._sympy_()
+        sage: (x+I)._mathics3_()
         I + x
     """
 
@@ -114,24 +106,24 @@ class Mathics3Converter(Converter):
         self.mathics3 = Mathics3()
 
     def __call__(self, ex=None):
+        #     EXAMPLES::
+        # sage: from sage.symbolic.expression_conversions import Mathics3Converter
+        # sage: m3 = Mathics3Converter()  # indirect doctest
+        # sage: f(x, y) = x^2 + y^2; f
+        # (x, y) |--> x^2 + y^2
+        # sage: m3(f)
+        # Function[{x, y}, x^ + y^2]
         """
-        EXAMPLES::
-
-            sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: m3 = Mathics3Converter()  # indirect doctest
-            sage: f(x, y) = x^2 + y^2; f
-            (x, y) |--> x^2 + y^2
-            sage: m(f)
-            Function[{x, y}, x^ + y^2]
         """
         if isinstance(ex, Expression):
-            breakpoint()
             if ex.is_callable():
                 # FIXME should get the function name. And then run in Mathics3
                 # f[x, y] := f(x, y) = x^2 + y^2
                 arguments = self.tuple(ex)
                 operator = self.convert_object_to_mathics3(ex.operator())
                 return Mathics3Expression(SymbolFunction, arguments, operator)
+            elif ex.is_constant():
+                return SAGE_CONSTANT_TO_MATHICS3.get(ex, ex)
             elif (
                 (operation := ex.operator())
                 and (operands := ex.operands())
@@ -155,7 +147,6 @@ class Mathics3Converter(Converter):
                 elements = [self.convert_object_to_mathics3(arg) for arg in operands]
                 return Mathics3Expression(Mathics3Symbol(mathics3_name), *elements)
 
-        breakpoint()
         if (value := self.convert_object_to_mathics3(ex)) is not None:
             return value
         raise NotImplementedError
@@ -177,14 +168,7 @@ class Mathics3Converter(Converter):
             sage: type(_)
             <class 'mathics.core.atoms.numerics.MachineReal'>>
             sage: x = SR(2/3)
-
-            # FIXME
-            ## sage: m3.pyobject(x, x.pyobject())
-            ## <Rational: 2/3>
-            ## sage: type(_)
-            ## <class 'mathics.core.atoms.numerics.Rational'>
-
-            sage: x = SR(2 + 3j))
+            sage: x = SR(2 + 3j)
             sage: m3.pyobject(x, x.pyobject())
             <Complex: 2.0 + 3.0*I>
             sage: type(_)
@@ -202,16 +186,12 @@ class Mathics3Converter(Converter):
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
             sage: m3 = Mathics3Converter()
             sage: f = x + 2
-
-            ## FIXME
-            ## sage: m3.arithmetic(f, f.operator())
-            ## <Expression: <Symbol: System`Plus>[<Integer: 2>, <Symbol: System`x>]>
-            ##
+            sage: m3.arithmetic(f, f.operator())
+            <Expression: <Symbol: System`Plus>[<Integer: 2>, <Symbol: System`x>]>
         """
         operator = arithmetic_operators[operator]
         elements = [self.convert_object_to_mathics3(arg) for arg in ex.operands()]
         match operator:
-            # FIXME: Add in floordiv, neg, pos, abs?
             case "+":
                 mathics3_expr = Mathics3Expression(SymbolPlus, *elements)
             case "*":
@@ -253,6 +233,18 @@ class Mathics3Converter(Converter):
 
             import_and_load_builtins()
 
+        elements = []
+        for arg in ex.operands():
+            if isinstance(arg, Expression):
+                element = arg._mathics3_()
+            else:
+                element = self.convert_object_to_mathics3(arg)
+            elements.append(element)
+
+        # if operator == exp:
+        #     (arg,) = ex.operands()
+        #     return self(arg).__rpow__(self.parent()('E'))  # or E^self(arg)
+
         # Convert via SymPy. However in the future, we can contemplate
         # Having Sage to Mathics3 correspondences listed, or for those
         # that do not have Sage to SymPy correspondences.
@@ -264,8 +256,6 @@ class Mathics3Converter(Converter):
             raise NotImplementedError
         mathics3_name = mathics3_class.__class__.__name__
 
-        operands = ex.operands()
-        elements = [self.convert_object_to_mathics3(arg) for arg in operands]
         return Mathics3Expression(Mathics3Symbol(mathics3_name), *elements)
 
     def convert_object_to_mathics3(self, obj):
@@ -295,97 +285,98 @@ class Mathics3Converter(Converter):
         elif hasattr(obj, "is_symbol") and obj.is_symbol():
             return self.symbol(obj)
 
-    def derivative(self, ex, operator):
-        """
-        Convert the derivative of ``self`` in sympy.
+    # FIXME: for later.
+    # def derivative(self, ex, operator):
+    #     """
+    #     Convert the derivative of ``self`` in sympy.
 
-        INPUT:
+    #     INPUT:
 
-        - ``ex`` -- a symbolic expression
+    #     - ``ex`` -- a symbolic expression
 
-        - ``operator`` -- operator
+    #     - ``operator`` -- operator
 
-        TESTS::
+    #     TESTS::
 
-            sage: var('x','y','z')
-            (x, y, z)
-            sage: f = function("F")
-            f = function("F"))
-            sage: f(x)._mathics3_()
-            F[x]
-            sage: diff(f(x,y,z), x, z, x)._mathics3_()
-            diff(f_sage(x, y), x, x, y)
-            sage: df_mathics3 = df_sage._mathics3_(); df_mathics3
-            Derivative(f_sage(x, y), (x, 2), y)
-            sage: df_sympy == f_sympy.diff(x, 2, y, 1)
-            True
+    #         sage: var('x','y','z')
+    #         (x, y, z)
+    #         sage: f = function("F")
+    #         f = function("F"))
+    #         sage: f(x)._mathics3_()
+    #         F[x]
+    #         sage: diff(f(x,y,z), x, z, x)._mathics3_()
+    #         diff(f_sage(x, y), x, x, y)
+    #         sage: df_mathics3 = df_sage._mathics3_(); df_mathics3
+    #         Derivative(f_sage(x, y), (x, 2), y)
+    #         sage: df_sympy == f_sympy.diff(x, 2, y, 1)
+    #         True
 
-        Check that :issue:`28964` is fixed::
+    #     Check that :issue:`28964` is fixed::
 
-            sage: f = function('f')
-            sage: _ = var('x,t')
-            sage: diff(f(x, t), x)._sympy_(), diff(f(x, t), t)._sympy_()
-            (Derivative(f(x, t), x), Derivative(f(x, t), t))
+    #         sage: f = function('f')
+    #         sage: _ = var('x,t')
+    #         sage: diff(f(x, t), x)._sympy_(), diff(f(x, t), t)._sympy_()
+    #         (Derivative(f(x, t), x), Derivative(f(x, t), t))
 
-        Check differentiating by variables with multiple occurrences
-        (:issue:`28964`)::
+    #     Check differentiating by variables with multiple occurrences
+    #     (:issue:`28964`)::
 
-            sage: f = function('f')
-            sage: _ = var('x1,x2,x3,x,t')
-            sage: f(x, x, t).diff(x)._sympy_()._sage_()
-            D[0](f)(x, x, t) + D[1](f)(x, x, t)
+    #         sage: f = function('f')
+    #         sage: _ = var('x1,x2,x3,x,t')
+    #         sage: f(x, x, t).diff(x)._sympy_()._sage_()
+    #         D[0](f)(x, x, t) + D[1](f)(x, x, t)
 
-            sage: g = f(x1, x2, x3, t).diff(x1, 2, x2).subs(x1==x, x2==x, x3==x); g
-            D[0, 0, 1](f)(x, x, x, t)
-            sage: g._sympy_()
-            Subs(Derivative(f(_xi_1, _xi_2, x, t), (_xi_1, 2), _xi_2),
-                 (_xi_1, _xi_2), (x, x))
-            sage: assert g._sympy_()._sage_() == g
+    #         sage: g = f(x1, x2, x3, t).diff(x1, 2, x2).subs(x1==x, x2==x, x3==x); g
+    #         D[0, 0, 1](f)(x, x, x, t)
+    #         sage: g._sympy_()
+    #         Subs(Derivative(f(_xi_1, _xi_2, x, t), (_xi_1, 2), _xi_2),
+    #              (_xi_1, _xi_2), (x, x))
+    #         sage: assert g._sympy_()._sage_() == g
 
-        Check that the use of dummy variables does not cause a collision::
+    #     Check that the use of dummy variables does not cause a collision::
 
-            sage: f = function('f')
-            sage: _ = var('x1,x2,x,xi_1')
-            sage: g = f(x1, x2, xi_1).diff(x1).subs(x1==x, x2==x); g
-            D[0](f)(x, x, xi_1)
-            sage: assert g._sympy_()._sage_() == g
-        """
-        import sympy
+    #         sage: f = function('f')
+    #         sage: _ = var('x1,x2,x,xi_1')
+    #         sage: g = f(x1, x2, xi_1).diff(x1).subs(x1==x, x2==x); g
+    #         D[0](f)(x, x, xi_1)
+    #         sage: assert g._sympy_()._sage_() == g
+    #     """
+    #     import sympy
 
-        # retrieve derivated function
-        f = operator.function()
+    #     # retrieve derivated function
+    #     f = operator.function()
 
-        # retrieve order
-        order = operator._parameter_set
-        # arguments
-        _args = [a._mathics3_() for a in ex.operands()]
+    #     # retrieve order
+    #     order = operator._parameter_set
+    #     # arguments
+    #     _args = [a._mathics3_() for a in ex.operands()]
 
-        # when differentiating by a variable that occurs multiple times,
-        # substitute it by a dummy variable
-        subs_new = []
-        subs_old = []
-        sympy_arg = []
-        for idx in order:
-            a = _args[idx]
-            if _args.count(a) > 1:
-                D = sympy.Dummy("xi_%i" % (idx + 1))
-                # to avoid collisions with ordinary symbols when converting
-                # back to Sage, we pick an unused variable name for the dummy
-                while D._sage_() in ex.variables():
-                    D = sympy.Dummy(D.name + "_0")
-                subs_old.append(a)
-                subs_new.append(D)
-                _args[idx] = D
-                sympy_arg.append(D)
-            else:
-                sympy_arg.append(a)
+    #     # when differentiating by a variable that occurs multiple times,
+    #     # substitute it by a dummy variable
+    #     subs_new = []
+    #     subs_old = []
+    #     sympy_arg = []
+    #     for idx in order:
+    #         a = _args[idx]
+    #         if _args.count(a) > 1:
+    #             D = sympy.Dummy("xi_%i" % (idx + 1))
+    #             # to avoid collisions with ordinary symbols when converting
+    #             # back to Sage, we pick an unused variable name for the dummy
+    #             while D._sage_() in ex.variables():
+    #                 D = sympy.Dummy(D.name + "_0")
+    #             subs_old.append(a)
+    #             subs_new.append(D)
+    #             _args[idx] = D
+    #             sympy_arg.append(D)
+    #         else:
+    #             sympy_arg.append(a)
 
-        f_sympy = f._sympy_()(*_args)
-        result = f_sympy.diff(*sympy_arg)
-        if subs_new:
-            return sympy.Subs(result, subs_new, subs_old)
-        else:
-            return result
+    #     f_sympy = f._sympy_()(*_args)
+    #     result = f_sympy.diff(*sympy_arg)
+    #     if subs_new:
+    #         return sympy.Subs(result, subs_new, subs_old)
+    #     else:
+    #         return result
 
     def evaluate(self, ex):
         if self.mathics3._session is None:
@@ -426,35 +417,20 @@ class Mathics3Converter(Converter):
         # FIXME: we should figure out the context, e.g. System or Global.
         return Mathics3Symbol(repr(ex))
 
+    # FIXME: This not getting called. I don't know why not though.
     def tuple(self, ex):
         """
         Conversion of tuples to Mathics3 ListExpressions.
 
-        EXAMPLES::
-
-            sage: t = SR._force_pyobject((3, 4, e^x))
-            sage: t._mathics3_()
-            {3, 4, e^x}
-            sage: t = SR._force_pyobject((cos(x),))
-            sage: t._mathics3_()
-            {cos(x)}
-
-        TESTS::
-
-            sage: from sage.symbolic.expression_conversions import mathics3_converter
-            sage: F = hypergeometric([1/3,2/3],[1,1],x)
-            sage: F._mathics3_()
-            hyper((1/3, 2/3), (1, 1), x)
-
-            sage: F = hypergeometric([1/3,2/3],[1],x)
-            sage: F._mathics3_()
-            hyper({1/3, 2/3}, {1}, x)
-
-            sage: var('a,b,c,d')
-            (a, b, c, d)
-            sage: hypergeometric((a,b,),(c,),d)._mathics3_()
-            hyper({a, b}, {c}, d)
         """
+        # EXAMPLES::
+
+        #     sage: t = SR._force_pyobject((3, 4, e^x))
+        #     sage: t._mathics3_()
+        #     {3, 4, E^x}
+        #     sage: t = SR._force_pyobject((cos(x),))
+        #     sage: t._mathics3_()
+        #     {Cos[x]}
         return ListExpression(
             *[
                 self.convert_object_to_mathics3(argument)

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -1,16 +1,12 @@
+# sage.doctest: optional - mathics3
 # sage_setup: distribution = sagemath-symbolics
-# sage.doctest: needs sympy
-r"""
+"""
 Conversion of symbolic expressions to Mathics3
 """
+
 # ****************************************************************************
-#       Copyright (C) 2009 Mike Hansen
-#                     2011 D. S. McNeil
-#                     2011 Francois Bissey
-#                     2017 Ralf Stephan
-#                     2017 Marco Mancini
-#                     2017 Travis Scrimshaw
-#                     2026 Rocky Bernstein
+# Copyright (C) 2026 Rocky Bernstein
+# This program is based on SymPy conversion.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,15 +15,29 @@ Conversion of symbolic expressions to Mathics3
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from operator import eq, ne, gt, lt, ge, le, mul, pow, neg, add, truediv
+from operator import add, eq, ge, gt, le, lt, mul, ne, neg, pow, truediv
 
+from mathics.core.atoms import IntegerM1
+from mathics.core.atoms.numerics import Complex as Mathics3Complex
+from mathics.core.atoms.numerics import Rational as Mathics3Rational
+from mathics.core.atoms.numerics import Real as Mathics3Real
+from mathics.core.convert.python import from_python
+from mathics.core.expression import Expression as Mathics3Expression
+from mathics.core.symbols import Symbol as Mathics3Symbol
+from mathics.core.symbols import SymbolDivide, SymbolPlus, SymbolPower, SymbolTimes
+from sage.all import RDF, ZZ, Rational
+from sage.interfaces.mathics3 import MATHICS3_TO_SAGE_CONSTANT, Mathics3
+from sage.rings.complex_double import ComplexDoubleElement
+from sage.rings.complex_mpfr import ComplexNumber
+from sage.rings.real_mpfr import RealField_class
 from sage.structure.element import Expression
+from sage.symbolic.constants import Constant
 from sage.symbolic.expression_conversions import Converter
 from sage.symbolic.operators import arithmetic_operators
 
-#########
-# Sympy #
-#########
+SAGE_CONSTANT_TO_MATHICS3 = {
+    value: key for key, value in MATHICS3_TO_SAGE_CONSTANT.items()
+}
 
 
 class Mathics3Converter(Converter):
@@ -52,6 +62,7 @@ class Mathics3Converter(Converter):
         sage: (x+I)._sympy_()
         x + I
     """
+
     def __init__(self):
         """
         TESTS::
@@ -60,8 +71,7 @@ class Mathics3Converter(Converter):
             sage: s = Mathics3Converter()  # indirect doctest
             sage: TestSuite(s).run(skip='_test_pickling')
         """
-        from sage.interfaces.mathics3 import mathics3_init
-        mathics3_init()
+        self.mathics3 = Mathics3()
 
     def __call__(self, ex=None):
         """
@@ -72,13 +82,14 @@ class Mathics3Converter(Converter):
             sage: f(x, y) = x^2 + y^2; f
             (x, y) |--> x^2 + y^2
             sage: s(f)
-            Lambda((x, y), x**2 + y**2)
+            ??? Expression? Lambda((x, y), x**2 + y**2)
         """
         if isinstance(ex, Expression) and ex.is_callable():
-            # FIXME
-            from sympy import Symbol, Lambda
-            return Lambda(tuple(Symbol(str(arg)) for arg in ex.arguments()),
-                          super().__call__(ex))
+            # FIXME should get the function name. And then run in Mathics3
+            # f[x, y] := f(x, y) = x^2 + y^2
+            elements = [self.convert_object_to_mathics3(arg) for arg in ex.arguments()]
+            # FIXME: not right.
+            return Mathics3Expression(elements[0], *elements[1:])
         return super().__call__(ex)
 
     def pyobject(self, ex, obj):
@@ -87,14 +98,29 @@ class Mathics3Converter(Converter):
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
             sage: s = Mathics3Converter()
-            sage: f = SR(2)
-            sage: s.pyobject(f, f.pyobject())
-            2
+            sage: x = SR(2)
+            sage: s.pyobject(x, x.pyobject())
+            <Integer: 2>
             sage: type(_)
             <class 'mathics.core.atoms.numerics.Integer'>
+            sage: x = SR(2.0)
+            sage: s.pyobject(x, x.pyobject())
+            <MachineReal: 2.0>
+            sage: type(_)
+            <class 'mathics.core.atoms.numerics.MachineReal'>>
+            sage: x = SR(2/3)
+            sage: s.pyobject(x, x.pyobject())
+            <Rational: 2/3>
+            sage: type(_)
+            <class 'mathics.core.atoms.numerics.Rational'>
+            sage: x = SR(2 + 3j))
+            sage: s.pyobject(x, x.pyobject())
+            <Complex: 2.0 + 3.0*I>
+            sage: type(_)
+            <class 'mathics.core.atoms.numerics.Complex'>
         """
         try:
-            return obj._mathics3_()
+            return self.convert_object_to_mathics3(obj)
         except AttributeError:
             return obj
 
@@ -106,118 +132,55 @@ class Mathics3Converter(Converter):
             sage: s = Mathics3Converter()
             sage: f = x + 2
             sage: s.arithmetic(f, f.operator())
-            x + 2
+            <Expression: <Symbol: System`Plus>[<Integer: 2>, <Symbol: System`x>]>
         """
-        import mathics3
-        import sympy
         operator = arithmetic_operators[operator]
-        ops = [sympy.sympify(self(a), evaluate=False) for a in ex.operands()]
-        if operator == "+":
-            return sympy.Add(*ops)
-        elif operator == "*":
-            return sympy.Mul(*ops)
-        elif operator == "-":
-            return sympy.Sub(*ops)
-        elif operator == "/":
-            return sympy.Div(*ops)
-        elif operator == "^":
-            return sympy.Pow(*ops)
-        else:
-            raise NotImplementedError
+        elements = [self.convert_object_to_mathics3(arg) for arg in ex.operands()]
+        match operator:
+            # FIXME: Add in floordiv, neg, pos, abs?
+            case "+":
+                mathics3_expr = Mathics3Expression(SymbolPlus, *elements)
+            case "*":
+                mathics3_expr = Mathics3Expression(SymbolTimes, *elements)
+            case "-":
+                mathics3_expr = Mathics3Expression(
+                    SymbolPlus, Mathics3Expression(SymbolTimes, *elements, IntegerM1)
+                )
+            case "/":
+                mathics3_expr = Mathics3Expression(SymbolDivide, *elements)
+            case "^":
+                mathics3_expr = Mathics3Expression(SymbolPower, *elements)
+            case _:
+                raise NotImplementedError
+        value = self.evaluate(mathics3_expr)
+        return value
 
-    def symbol(self, ex):
-        """
-        EXAMPLES::
+    def convert_object_to_mathics3(self, obj):
 
-            sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()  # indirect doctest
-            sage: s.symbol(x)
-            x
-            sage: type(_)
-            <class 'sympy.core.symbol.Symbol'>
-        """
-        import sympy
-        return sympy.symbols(repr(ex))
+        if obj in ZZ:
+            if (parent := obj.parent()) is RDF or isinstance(parent, RealField_class):
+                # Convert hardware/arbitrary precision reals to Mathics3Real.
+                if hasattr(obj, "_mpmath_"):
+                    return Mathics3Real(obj._mpmath_())
+                return from_python(float(obj))
 
-    def relation(self, ex, op):
-        """
-        EXAMPLES::
-
-            sage: import operator
-            sage: from sage.symbolic.expression_conversions import SympyConverter
-            sage: s = SympyConverter()
-            sage: s.relation(x == 3, operator.eq)
-            Eq(x, 3)
-            sage: s.relation(pi < 3, operator.lt)
-            pi < 3
-            sage: s.relation(x != pi, operator.ne)
-            Ne(x, pi)
-            sage: s.relation(x > 0, operator.gt)
-            x > 0
-        """
-        from sympy import Eq, Ne, Gt, Lt, Ge, Le
-        ops = {eq: Eq, ne: Ne, gt: Gt, lt: Lt, ge: Ge, le: Le}
-        return ops.get(op)(self(ex.lhs()), self(ex.rhs()), evaluate=False)
-
-    def composition(self, ex, operator):
-        """
-        EXAMPLES::
-
-            sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()  # indirect doctest
-            sage: f = sin(2)
-            sage: s.composition(f, f.operator())
-            sin(2)
-            sage: type(_)
-            sin
-            sage: f = arcsin(2)
-            sage: s.composition(f, f.operator())
-            asin(2)
-        """
-        g = ex.operands()
-        try:
-            return operator._sympy_(*g)
-        except (AttributeError, TypeError):
-            pass
-        f = operator._sympy_init_()
-        import sympy
-
-        f_sympy = getattr(sympy, f, None)
-        if f_sympy:
-            return f_sympy(*sympy.sympify(g, evaluate=False))
-        else:
-            return sympy.Function(str(f))(*g, evaluate=False)
-
-    def tuple(self, ex):
-        """
-        Conversion of tuples.
-
-        EXAMPLES::
-
-            sage: t = SR._force_pyobject((3, 4, e^x))
-            sage: t._sympy_()
-            (3, 4, e^x)
-            sage: t = SR._force_pyobject((cos(x),))
-            sage: t._sympy_()
-            (cos(x),)
-
-        TESTS::
-
-            sage: from sage.symbolic.expression_conversions import sympy_converter
-            sage: F = hypergeometric([1/3,2/3],[1,1],x)
-            sage: F._sympy_()
-            hyper((1/3, 2/3), (1, 1), x)
-
-            sage: F = hypergeometric([1/3,2/3],[1],x)
-            sage: F._sympy_()
-            hyper((1/3, 2/3), (1,), x)
-
-            sage: var('a,b,c,d')
-            (a, b, c, d)
-            sage: hypergeometric((a,b,),(c,),d)._sympy_()
-            hyper((a, b), (c,), d)
-        """
-        return tuple(ex.operands())
+            return from_python(sage_to_python_int(obj))
+        elif isinstance(obj, Rational):
+            # Convert Sage Rationals to Mathics3 Rational.
+            return Mathics3Rational(
+                self.convert_object_to_mathics3(obj.numerator()),
+                self.convert_object_to_mathics3(obj.denominator()),
+            )
+        elif isinstance(obj, (ComplexDoubleElement, ComplexNumber)):
+            # Convert hardware/arbitrary precision complex numbers to Mathics3 Complex.
+            return Mathics3Complex(
+                self.convert_object_to_mathics3(obj.real()),
+                self.convert_object_to_mathics3(obj.imag()),
+            )
+        elif isinstance(obj, Constant):
+            return SAGE_CONSTANT_TO_MATHICS3.get(obj.expression(), obj)
+        elif obj.is_symbol():
+            return self.symbol(obj)
 
     def derivative(self, ex, operator):
         """
@@ -292,11 +255,11 @@ class Mathics3Converter(Converter):
         for idx in order:
             a = _args[idx]
             if _args.count(a) > 1:
-                D = sympy.Dummy('xi_%i' % (idx + 1))
+                D = sympy.Dummy("xi_%i" % (idx + 1))
                 # to avoid collisions with ordinary symbols when converting
                 # back to Sage, we pick an unused variable name for the dummy
                 while D._sage_() in ex.variables():
-                    D = sympy.Dummy(D.name + '_0')
+                    D = sympy.Dummy(D.name + "_0")
                 subs_old.append(a)
                 subs_new.append(D)
                 _args[idx] = D
@@ -310,6 +273,127 @@ class Mathics3Converter(Converter):
             return sympy.Subs(result, subs_new, subs_old)
         else:
             return result
+
+    def evaluate(self, ex):
+        if self.mathics3._session is None:
+            self.mathics3._start()
+        return ex.evaluate(self.mathics3._session.evaluation)
+
+    def relation(self, ex, op):
+        """
+        EXAMPLES::
+
+            sage: import operator
+            sage: from sage.symbolic.expression_conversions import SympyConverter
+            sage: s = SympyConverter()
+            sage: s.relation(x == 3, operator.eq)
+            Eq(x, 3)
+            sage: s.relation(pi < 3, operator.lt)
+            pi < 3
+            sage: s.relation(x != pi, operator.ne)
+            Ne(x, pi)
+            sage: s.relation(x > 0, operator.gt)
+            x > 0
+        """
+        from sympy import Eq, Ge, Gt, Le, Lt, Ne
+
+        ops = {eq: Eq, ne: Ne, gt: Gt, lt: Lt, ge: Ge, le: Le}
+        return ops.get(op)(self(ex.lhs()), self(ex.rhs()), evaluate=False)
+
+    def composition(self, ex, operator):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()  # indirect doctest
+            sage: f = sin(2)
+            sage: s.composition(f, f.operator())
+            sin(2)
+            sage: type(_)
+            sin
+            sage: f = arcsin(2)
+            sage: s.composition(f, f.operator())
+            asin(2)
+        """
+        g = ex.operands()
+        try:
+            return operator._sympy_(*g)
+        except (AttributeError, TypeError):
+            pass
+        f = operator._sympy_init_()
+        import sympy
+
+        f_sympy = getattr(sympy, f, None)
+        if f_sympy:
+            return f_sympy(*sympy.sympify(g, evaluate=False))
+        else:
+            return sympy.Function(str(f))(*g, evaluate=False)
+
+    def symbol(self, ex):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()  # indirect doctest
+            sage: s.symbol(x)
+            <Symbol: System`x>
+            sage: type(_)
+            <class 'mathics.core.symbols.Symbol'>
+        """
+        # FIXME: we should figure out the context, e.g. System or Global.
+        return Mathics3Symbol(repr(ex))
+
+    def tuple(self, ex):
+        """
+        Conversion of tuples.
+
+        EXAMPLES::
+
+            sage: t = SR._force_pyobject((3, 4, e^x))
+            sage: t._sympy_()
+            (3, 4, e^x)
+            sage: t = SR._force_pyobject((cos(x),))
+            sage: t._sympy_()
+            (cos(x),)
+
+        TESTS::
+
+            sage: from sage.symbolic.expression_conversions import sympy_converter
+            sage: F = hypergeometric([1/3,2/3],[1,1],x)
+            sage: F._sympy_()
+            hyper((1/3, 2/3), (1, 1), x)
+
+            sage: F = hypergeometric([1/3,2/3],[1],x)
+            sage: F._sympy_()
+            hyper((1/3, 2/3), (1,), x)
+
+            sage: var('a,b,c,d')
+            (a, b, c, d)
+            sage: hypergeometric((a,b,),(c,),d)._sympy_()
+            hyper((a, b), (c,), d)
+        """
+        return tuple(ex.operands())
+
+
+def sage_to_python_int(val):
+    # Reject complex/Gaussian numbers upfront
+    if hasattr(val, "imag") and val.imag() != 0:
+        raise ValueError(
+            f"{val} is a complex/Gaussian integer and cannot become a Python int."
+        )
+
+    # Try direct Python int() conversion (Works for Standard, Modular, bounded Intervals)
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        pass
+
+    # Try lifting mathematical context (Works for p-adics, Algebraic Integers)
+    if hasattr(val, "lift"):
+        return int(val.lift())
+
+    # Fallback coerce through Sage's Integer Ring
+    return int(ZZ(val))
 
 
 mathics3_converter = Mathics3Converter()

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -15,7 +15,9 @@ Conversion of symbolic expressions to Mathics3
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from operator import add, eq, ge, gt, le, lt, mul, ne, neg, pow, truediv
+from operator import eq, ge, gt, le, lt, ne
+# Unused operators:
+# from operator import add, mul, neg, pow, truediv
 
 from mathics.core.atoms import IntegerM1
 from mathics.core.atoms.numerics import Complex as Mathics3Complex
@@ -56,7 +58,7 @@ SAGE_CONSTANT_TO_MATHICS3 = {
     value: key for key, value in MATHICS3_TO_SAGE_CONSTANT.items()
 }
 
-SAGE_OPS_TO_MATHICS3 = {
+SAGE_RELATION_TO_MATHICS3_SYMBOL = {
     eq: SymbolEqual,
     ne: SymbolUnequal,
     gt: SymbolGreater,
@@ -94,7 +96,7 @@ class Mathics3Converter(Converter):
         TESTS::
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()  # indirect doctest
+            sage: m3 = Mathics3Converter()  # indirect doctest
             sage: TestSuite(s).run(skip='_test_pickling')
         """
         self.mathics3 = Mathics3()
@@ -104,10 +106,10 @@ class Mathics3Converter(Converter):
         EXAMPLES::
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()  # indirect doctest
+            sage: m3 = Mathics3Converter()  # indirect doctest
             sage: f(x, y) = x^2 + y^2; f
             (x, y) |--> x^2 + y^2
-            sage: s(f)
+            sage: m(f)
             Function[{x, y}, x^ + y^2]
         """
         if isinstance(ex, Expression):
@@ -115,16 +117,17 @@ class Mathics3Converter(Converter):
             if ex.is_callable():
                 # FIXME should get the function name. And then run in Mathics3
                 # f[x, y] := f(x, y) = x^2 + y^2
-                arguments = ListExpression(
-                        *[self.convert_object_to_mathics3(argument) for argument in ex.arguments()]
-                        )
+                arguments = self.tuple(ex)
                 operator = self.convert_object_to_mathics3(ex.operator())
                 return Mathics3Expression(SymbolFunction, arguments, operator)
             elif (
-                (operator := ex.operator())
+                (operation := ex.operator())
                 and (operands := ex.operands())
                 and (sympy_func := ex._sympy_())
             ):
+                # FIXME: Figure out how to get function body.
+                # When this is corrected, it may be similar to
+                # composition. So use that when possible after correction.
                 if not sympy_to_mathics:
                     from mathics.core.load_builtin import import_and_load_builtins
 
@@ -150,24 +153,24 @@ class Mathics3Converter(Converter):
         EXAMPLES::
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()
+            sage: m3 = Mathics3Converter()
             sage: x = SR(2)
-            sage: s.pyobject(x, x.pyobject())
+            sage: m3.pyobject(x, x.pyobject())
             <Integer: 2>
             sage: type(_)
             <class 'mathics.core.atoms.numerics.Integer'>
             sage: x = SR(2.0)
-            sage: s.pyobject(x, x.pyobject())
+            sage: m3.pyobject(x, x.pyobject())
             <MachineReal: 2.0>
             sage: type(_)
             <class 'mathics.core.atoms.numerics.MachineReal'>>
             sage: x = SR(2/3)
-            sage: s.pyobject(x, x.pyobject())
+            sage: m3.pyobject(x, x.pyobject())
             <Rational: 2/3>
             sage: type(_)
             <class 'mathics.core.atoms.numerics.Rational'>
             sage: x = SR(2 + 3j))
-            sage: s.pyobject(x, x.pyobject())
+            sage: m3.pyobject(x, x.pyobject())
             <Complex: 2.0 + 3.0*I>
             sage: type(_)
             <class 'mathics.core.atoms.numerics.Complex'>
@@ -182,9 +185,9 @@ class Mathics3Converter(Converter):
         EXAMPLES::
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()
+            sage: m3 = Mathics3Converter()
             sage: f = x + 2
-            sage: s.arithmetic(f, f.operator())
+            sage: m3.arithmetic(f, f.operator())
             <Expression: <Symbol: System`Plus>[<Integer: 2>, <Symbol: System`x>]>
         """
         operator = arithmetic_operators[operator]
@@ -209,6 +212,43 @@ class Mathics3Converter(Converter):
                 raise NotImplementedError
         value = self.evaluate(mathics3_expr)
         return value
+
+    def composition(self, ex, operator):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: m3 = Mathics3Converter()  # indirect doctest
+            sage: f = sin(2)
+            sage: m3.composition(f, f.operator())
+            <Expression: <Symbol: System`Sin>[<Integer: 2>]>
+            sage: type(_)
+            <class 'mathics.core.expression.Expression'>
+            sage: f = arcsin(2)
+            sage: m3.composition(f, f.operator())
+            asin(2)
+        """
+        if not (sympy_func := ex._sympy_()):
+            raise NotImplementedError
+        if not sympy_to_mathics:
+            from mathics.core.load_builtin import import_and_load_builtins
+
+            import_and_load_builtins()
+
+        # Convert via SymPy. However in the future, we can contemplate
+        # Having Sage to Mathics3 correspondences listed, or for those
+        # that do not have Sage to SymPy correspondences.
+        sympy_name = sympy_func.__class__.__name__
+        if not sympy_name:
+            raise NotImplementedError
+        mathics3_class = sympy_to_mathics.get(sympy_name)
+        if not mathics3_class:
+            raise NotImplementedError
+        mathics3_name = mathics3_class.__class__.__name__
+
+        operands = ex.operands()
+        elements = [self.convert_object_to_mathics3(arg) for arg in operands]
+        return Mathics3Expression(Mathics3Symbol(mathics3_name), *elements)
 
     def convert_object_to_mathics3(self, obj):
 
@@ -340,56 +380,27 @@ class Mathics3Converter(Converter):
 
             sage: import operator
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()
-            sage: s.relation(x == 3, operator.eq)
+            sage: m3 = Mathics3Converter()
+            sage: m3.relation(x == 3, operator.eq)
             <Expression: <Symbol: System`Equal>[<Symbol: System`x>, <Integer: 3>]>Eq(x, 3)
-            sage: s.relation(pi < 3, operator.lt)
+            sage: m3.relation(pi < 3, operator.lt)
             <Expression: <Symbol: System`Less>[<Symbol: System`Pi>, <Integer: 3>]>
-            sage: s.relation(x != pi, operator.ne)
+            sage: m3.relation(x != pi, operator.ne)
             <Expression: <Symbol: System`Unequal>[<Symbol: System`x>, <Symbol: System`Pi>]>
-            sage: s.relation(x > 0, operator.gt)
+            sage: m3.relation(x > 0, operator.gt)
             <Expression: <Symbol: System`Greater>[<Symbol: System`x>, <Integer: 0>]>
         """
         lhs = self(ex.lhs())
         rhs = self(ex.rhs())
-        return Mathics3Expression(SAGE_OPS_TO_MATHICS3[op], lhs, rhs)
-
-    def composition(self, ex, operator):
-        """
-        EXAMPLES::
-
-            sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()  # indirect doctest
-            sage: f = sin(2)
-            sage: s.composition(f, f.operator())
-            sin(2)
-            sage: type(_)
-            sin
-            sage: f = arcsin(2)
-            sage: s.composition(f, f.operator())
-            asin(2)
-        """
-        g = ex.operands()
-        try:
-            return operator._sympy_(*g)
-        except (AttributeError, TypeError):
-            pass
-        f = operator._sympy_init_()
-        import sympy
-
-        f_sympy = getattr(sympy, f, None)
-        if f_sympy:
-            return f_sympy(*sympy.sympify(g, evaluate=False))
-        else:
-            return sympy.Function(str(f))(*g, evaluate=False)
+        return Mathics3Expression(SAGE_RELATION_TO_MATHICS3_SYMBOL[op], lhs, rhs)
 
     def symbol(self, ex):
         """
         EXAMPLES::
 
             sage: from sage.symbolic.expression_conversions import Mathics3Converter
-            sage: s = Mathics3Converter()  # indirect doctest
-            sage: s.symbol(x)
+            sage: m3 = Mathics3Converter()  # indirect doctest
+            sage: m3.symbol(x)
             <Symbol: System`x>
             sage: type(_)
             <class 'mathics.core.symbols.Symbol'>
@@ -399,35 +410,39 @@ class Mathics3Converter(Converter):
 
     def tuple(self, ex):
         """
-        Conversion of tuples.
+        Conversion of tuples to Mathics3 ListExpressions.
 
         EXAMPLES::
 
             sage: t = SR._force_pyobject((3, 4, e^x))
-            sage: t._sympy_()
+            sage: t._mathics3_()
             (3, 4, e^x)
             sage: t = SR._force_pyobject((cos(x),))
-            sage: t._sympy_()
+            sage: t._mathics3_()
             (cos(x),)
 
         TESTS::
 
-            sage: from sage.symbolic.expression_conversions import sympy_converter
+            sage: from sage.symbolic.expression_conversions import mathics3_converter
             sage: F = hypergeometric([1/3,2/3],[1,1],x)
-            sage: F._sympy_()
+            sage: F._mathics3_()
             hyper((1/3, 2/3), (1, 1), x)
 
             sage: F = hypergeometric([1/3,2/3],[1],x)
-            sage: F._sympy_()
+            sage: F._mathics3_()
             hyper((1/3, 2/3), (1,), x)
 
             sage: var('a,b,c,d')
             (a, b, c, d)
-            sage: hypergeometric((a,b,),(c,),d)._sympy_()
+            sage: hypergeometric((a,b,),(c,),d)._mathics3_()
             hyper((a, b), (c,), d)
         """
-        breakpoint()
-        return tuple(ex.operands())
+        return ListExpression(
+            *[
+                self.convert_object_to_mathics3(argument)
+                for argument in ex.arguments()
+             ]
+            )
 
 
 def sage_to_python_int(val):

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -416,10 +416,10 @@ class Mathics3Converter(Converter):
 
             sage: t = SR._force_pyobject((3, 4, e^x))
             sage: t._mathics3_()
-            (3, 4, e^x)
+            {3, 4, e^x}
             sage: t = SR._force_pyobject((cos(x),))
             sage: t._mathics3_()
-            (cos(x),)
+            {cos(x)}
 
         TESTS::
 
@@ -430,12 +430,12 @@ class Mathics3Converter(Converter):
 
             sage: F = hypergeometric([1/3,2/3],[1],x)
             sage: F._mathics3_()
-            hyper((1/3, 2/3), (1,), x)
+            hyper({1/3, 2/3}, {1}, x)
 
             sage: var('a,b,c,d')
             (a, b, c, d)
             sage: hypergeometric((a,b,),(c,),d)._mathics3_()
-            hyper((a, b), (c,), d)
+            hyper({a, b}, {c}, d)
         """
         return ListExpression(
             *[

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -1,0 +1,315 @@
+# sage_setup: distribution = sagemath-symbolics
+# sage.doctest: needs sympy
+r"""
+Conversion of symbolic expressions to Mathics3
+"""
+# ****************************************************************************
+#       Copyright (C) 2009 Mike Hansen
+#                     2011 D. S. McNeil
+#                     2011 Francois Bissey
+#                     2017 Ralf Stephan
+#                     2017 Marco Mancini
+#                     2017 Travis Scrimshaw
+#                     2026 Rocky Bernstein
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+
+from operator import eq, ne, gt, lt, ge, le, mul, pow, neg, add, truediv
+
+from sage.structure.element import Expression
+from sage.symbolic.expression_conversions import Converter
+from sage.symbolic.operators import arithmetic_operators
+
+#########
+# Sympy #
+#########
+
+
+class Mathics3Converter(Converter):
+    """
+    Convert any expression to Mathics3
+
+    EXAMPLES::
+
+        sage: import mathics3
+        sage: f = Exp(x^2) - ArcSin[pi+x]/y
+        sage: f._sympy_()
+        exp(x**2) - asin(x + pi)/y
+        sage: _._sage_()
+        -arcsin(pi + x)/y + e^(x^2)
+
+    TESTS:
+
+    Make sure we can convert I (:issue:`6424`)::
+
+        sage: bool(I._sympy_() == I)
+        True
+        sage: (x+I)._sympy_()
+        x + I
+    """
+    def __init__(self):
+        """
+        TESTS::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()  # indirect doctest
+            sage: TestSuite(s).run(skip='_test_pickling')
+        """
+        from sage.interfaces.mathics3 import mathics3_init
+        mathics3_init()
+
+    def __call__(self, ex=None):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()  # indirect doctest
+            sage: f(x, y) = x^2 + y^2; f
+            (x, y) |--> x^2 + y^2
+            sage: s(f)
+            Lambda((x, y), x**2 + y**2)
+        """
+        if isinstance(ex, Expression) and ex.is_callable():
+            # FIXME
+            from sympy import Symbol, Lambda
+            return Lambda(tuple(Symbol(str(arg)) for arg in ex.arguments()),
+                          super().__call__(ex))
+        return super().__call__(ex)
+
+    def pyobject(self, ex, obj):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()
+            sage: f = SR(2)
+            sage: s.pyobject(f, f.pyobject())
+            2
+            sage: type(_)
+            <class 'mathics.core.atoms.numerics.Integer'>
+        """
+        try:
+            return obj._mathics3_()
+        except AttributeError:
+            return obj
+
+    def arithmetic(self, ex, operator):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()
+            sage: f = x + 2
+            sage: s.arithmetic(f, f.operator())
+            x + 2
+        """
+        import mathics3
+        import sympy
+        operator = arithmetic_operators[operator]
+        ops = [sympy.sympify(self(a), evaluate=False) for a in ex.operands()]
+        if operator == "+":
+            return sympy.Add(*ops)
+        elif operator == "*":
+            return sympy.Mul(*ops)
+        elif operator == "-":
+            return sympy.Sub(*ops)
+        elif operator == "/":
+            return sympy.Div(*ops)
+        elif operator == "^":
+            return sympy.Pow(*ops)
+        else:
+            raise NotImplementedError
+
+    def symbol(self, ex):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()  # indirect doctest
+            sage: s.symbol(x)
+            x
+            sage: type(_)
+            <class 'sympy.core.symbol.Symbol'>
+        """
+        import sympy
+        return sympy.symbols(repr(ex))
+
+    def relation(self, ex, op):
+        """
+        EXAMPLES::
+
+            sage: import operator
+            sage: from sage.symbolic.expression_conversions import SympyConverter
+            sage: s = SympyConverter()
+            sage: s.relation(x == 3, operator.eq)
+            Eq(x, 3)
+            sage: s.relation(pi < 3, operator.lt)
+            pi < 3
+            sage: s.relation(x != pi, operator.ne)
+            Ne(x, pi)
+            sage: s.relation(x > 0, operator.gt)
+            x > 0
+        """
+        from sympy import Eq, Ne, Gt, Lt, Ge, Le
+        ops = {eq: Eq, ne: Ne, gt: Gt, lt: Lt, ge: Ge, le: Le}
+        return ops.get(op)(self(ex.lhs()), self(ex.rhs()), evaluate=False)
+
+    def composition(self, ex, operator):
+        """
+        EXAMPLES::
+
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()  # indirect doctest
+            sage: f = sin(2)
+            sage: s.composition(f, f.operator())
+            sin(2)
+            sage: type(_)
+            sin
+            sage: f = arcsin(2)
+            sage: s.composition(f, f.operator())
+            asin(2)
+        """
+        g = ex.operands()
+        try:
+            return operator._sympy_(*g)
+        except (AttributeError, TypeError):
+            pass
+        f = operator._sympy_init_()
+        import sympy
+
+        f_sympy = getattr(sympy, f, None)
+        if f_sympy:
+            return f_sympy(*sympy.sympify(g, evaluate=False))
+        else:
+            return sympy.Function(str(f))(*g, evaluate=False)
+
+    def tuple(self, ex):
+        """
+        Conversion of tuples.
+
+        EXAMPLES::
+
+            sage: t = SR._force_pyobject((3, 4, e^x))
+            sage: t._sympy_()
+            (3, 4, e^x)
+            sage: t = SR._force_pyobject((cos(x),))
+            sage: t._sympy_()
+            (cos(x),)
+
+        TESTS::
+
+            sage: from sage.symbolic.expression_conversions import sympy_converter
+            sage: F = hypergeometric([1/3,2/3],[1,1],x)
+            sage: F._sympy_()
+            hyper((1/3, 2/3), (1, 1), x)
+
+            sage: F = hypergeometric([1/3,2/3],[1],x)
+            sage: F._sympy_()
+            hyper((1/3, 2/3), (1,), x)
+
+            sage: var('a,b,c,d')
+            (a, b, c, d)
+            sage: hypergeometric((a,b,),(c,),d)._sympy_()
+            hyper((a, b), (c,), d)
+        """
+        return tuple(ex.operands())
+
+    def derivative(self, ex, operator):
+        """
+        Convert the derivative of ``self`` in sympy.
+
+        INPUT:
+
+        - ``ex`` -- a symbolic expression
+
+        - ``operator`` -- operator
+
+        TESTS::
+
+            sage: var('x','y')
+            (x, y)
+
+            sage: f_sage = function('f_sage')(x, y)
+            sage: f_sympy = f_sage._sympy_()
+
+            sage: df_sage = f_sage.diff(x, 2, y, 1); df_sage
+            diff(f_sage(x, y), x, x, y)
+            sage: df_sympy = df_sage._sympy_(); df_sympy
+            Derivative(f_sage(x, y), (x, 2), y)
+            sage: df_sympy == f_sympy.diff(x, 2, y, 1)
+            True
+
+        Check that :issue:`28964` is fixed::
+
+            sage: f = function('f')
+            sage: _ = var('x,t')
+            sage: diff(f(x, t), x)._sympy_(), diff(f(x, t), t)._sympy_()
+            (Derivative(f(x, t), x), Derivative(f(x, t), t))
+
+        Check differentiating by variables with multiple occurrences
+        (:issue:`28964`)::
+
+            sage: f = function('f')
+            sage: _ = var('x1,x2,x3,x,t')
+            sage: f(x, x, t).diff(x)._sympy_()._sage_()
+            D[0](f)(x, x, t) + D[1](f)(x, x, t)
+
+            sage: g = f(x1, x2, x3, t).diff(x1, 2, x2).subs(x1==x, x2==x, x3==x); g
+            D[0, 0, 1](f)(x, x, x, t)
+            sage: g._sympy_()
+            Subs(Derivative(f(_xi_1, _xi_2, x, t), (_xi_1, 2), _xi_2),
+                 (_xi_1, _xi_2), (x, x))
+            sage: assert g._sympy_()._sage_() == g
+
+        Check that the use of dummy variables does not cause a collision::
+
+            sage: f = function('f')
+            sage: _ = var('x1,x2,x,xi_1')
+            sage: g = f(x1, x2, xi_1).diff(x1).subs(x1==x, x2==x); g
+            D[0](f)(x, x, xi_1)
+            sage: assert g._sympy_()._sage_() == g
+        """
+        import sympy
+
+        # retrieve derivated function
+        f = operator.function()
+
+        # retrieve order
+        order = operator._parameter_set
+        # arguments
+        _args = [a._sympy_() for a in ex.operands()]
+
+        # when differentiating by a variable that occurs multiple times,
+        # substitute it by a dummy variable
+        subs_new = []
+        subs_old = []
+        sympy_arg = []
+        for idx in order:
+            a = _args[idx]
+            if _args.count(a) > 1:
+                D = sympy.Dummy('xi_%i' % (idx + 1))
+                # to avoid collisions with ordinary symbols when converting
+                # back to Sage, we pick an unused variable name for the dummy
+                while D._sage_() in ex.variables():
+                    D = sympy.Dummy(D.name + '_0')
+                subs_old.append(a)
+                subs_new.append(D)
+                _args[idx] = D
+                sympy_arg.append(D)
+            else:
+                sympy_arg.append(a)
+
+        f_sympy = f._sympy_()(*_args)
+        result = f_sympy.diff(*sympy_arg)
+        if subs_new:
+            return sympy.Subs(result, subs_new, subs_old)
+        else:
+            return result
+
+
+mathics3_converter = Mathics3Converter()

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -22,9 +22,26 @@ from mathics.core.atoms.numerics import Complex as Mathics3Complex
 from mathics.core.atoms.numerics import Rational as Mathics3Rational
 from mathics.core.atoms.numerics import Real as Mathics3Real
 from mathics.core.convert.python import from_python
+from mathics.core.convert.sympy import sympy_to_mathics
 from mathics.core.expression import Expression as Mathics3Expression
-from mathics.core.symbols import Symbol as Mathics3Symbol
-from mathics.core.symbols import SymbolDivide, SymbolPlus, SymbolPower, SymbolTimes
+from mathics.core.list import ListExpression
+from mathics.core.symbols import (
+    Symbol as Mathics3Symbol,
+    SymbolDivide,
+    SymbolPlus,
+    SymbolPower,
+    SymbolTimes,
+)
+from mathics.core.systemsymbols import (
+    SymbolEqual,
+    SymbolFunction,
+    SymbolGreater,
+    SymbolGreaterEqual,
+    SymbolLess,
+    SymbolLessEqual,
+    SymbolQuotient,
+    SymbolUnequal,
+)
 from sage.all import RDF, ZZ, Rational
 from sage.interfaces.mathics3 import MATHICS3_TO_SAGE_CONSTANT, Mathics3
 from sage.rings.complex_double import ComplexDoubleElement
@@ -37,6 +54,15 @@ from sage.symbolic.operators import arithmetic_operators
 
 SAGE_CONSTANT_TO_MATHICS3 = {
     value: key for key, value in MATHICS3_TO_SAGE_CONSTANT.items()
+}
+
+SAGE_OPS_TO_MATHICS3 = {
+    eq: SymbolEqual,
+    ne: SymbolUnequal,
+    gt: SymbolGreater,
+    lt: SymbolLess,
+    ge: SymbolGreaterEqual,
+    le: SymbolLessEqual,
 }
 
 
@@ -82,15 +108,42 @@ class Mathics3Converter(Converter):
             sage: f(x, y) = x^2 + y^2; f
             (x, y) |--> x^2 + y^2
             sage: s(f)
-            ??? Expression? Lambda((x, y), x**2 + y**2)
+            Function[{x, y}, x^ + y^2]
         """
-        if isinstance(ex, Expression) and ex.is_callable():
-            # FIXME should get the function name. And then run in Mathics3
-            # f[x, y] := f(x, y) = x^2 + y^2
-            elements = [self.convert_object_to_mathics3(arg) for arg in ex.arguments()]
-            # FIXME: not right.
-            return Mathics3Expression(elements[0], *elements[1:])
-        return super().__call__(ex)
+        if isinstance(ex, Expression):
+            breakpoint()
+            if ex.is_callable():
+                # FIXME should get the function name. And then run in Mathics3
+                # f[x, y] := f(x, y) = x^2 + y^2
+                arguments = ListExpression(
+                        *[self.convert_object_to_mathics3(argument) for argument in ex.arguments()]
+                        )
+                operator = self.convert_object_to_mathics3(ex.operator())
+                return Mathics3Expression(SymbolFunction, arguments, operator)
+            elif (
+                (operator := ex.operator())
+                and (operands := ex.operands())
+                and (sympy_func := ex._sympy_())
+            ):
+                if not sympy_to_mathics:
+                    from mathics.core.load_builtin import import_and_load_builtins
+
+                    import_and_load_builtins()
+
+                sympy_name = sympy_func.__class__.__name__
+                if not sympy_name:
+                    raise NotImplementedError
+                mathics3_class = sympy_to_mathics.get(sympy_name)
+                if not mathics3_class:
+                    raise NotImplementedError
+                mathics3_name = mathics3_class.__class__.__name__
+                elements = [self.convert_object_to_mathics3(arg) for arg in operands]
+                return Mathics3Expression(Mathics3Symbol(mathics3_name), *elements)
+
+        breakpoint()
+        if (value := self.convert_object_to_mathics3(ex)) is not None:
+            return value
+        raise NotImplementedError
 
     def pyobject(self, ex, obj):
         """
@@ -148,6 +201,8 @@ class Mathics3Converter(Converter):
                 )
             case "/":
                 mathics3_expr = Mathics3Expression(SymbolDivide, *elements)
+            case "//":
+                mathics3_expr = Mathics3Expression(SymbolQuotient, *elements)
             case "^":
                 mathics3_expr = Mathics3Expression(SymbolPower, *elements)
             case _:
@@ -179,7 +234,7 @@ class Mathics3Converter(Converter):
             )
         elif isinstance(obj, Constant):
             return SAGE_CONSTANT_TO_MATHICS3.get(obj.expression(), obj)
-        elif obj.is_symbol():
+        elif hasattr(obj, "is_symbol") and obj.is_symbol():
             return self.symbol(obj)
 
     def derivative(self, ex, operator):
@@ -284,21 +339,20 @@ class Mathics3Converter(Converter):
         EXAMPLES::
 
             sage: import operator
-            sage: from sage.symbolic.expression_conversions import SympyConverter
-            sage: s = SympyConverter()
+            sage: from sage.symbolic.expression_conversions import Mathics3Converter
+            sage: s = Mathics3Converter()
             sage: s.relation(x == 3, operator.eq)
-            Eq(x, 3)
+            <Expression: <Symbol: System`Equal>[<Symbol: System`x>, <Integer: 3>]>Eq(x, 3)
             sage: s.relation(pi < 3, operator.lt)
-            pi < 3
+            <Expression: <Symbol: System`Less>[<Symbol: System`Pi>, <Integer: 3>]>
             sage: s.relation(x != pi, operator.ne)
-            Ne(x, pi)
+            <Expression: <Symbol: System`Unequal>[<Symbol: System`x>, <Symbol: System`Pi>]>
             sage: s.relation(x > 0, operator.gt)
-            x > 0
+            <Expression: <Symbol: System`Greater>[<Symbol: System`x>, <Integer: 0>]>
         """
-        from sympy import Eq, Ge, Gt, Le, Lt, Ne
-
-        ops = {eq: Eq, ne: Ne, gt: Gt, lt: Lt, ge: Ge, le: Le}
-        return ops.get(op)(self(ex.lhs()), self(ex.rhs()), evaluate=False)
+        lhs = self(ex.lhs())
+        rhs = self(ex.rhs())
+        return Mathics3Expression(SAGE_OPS_TO_MATHICS3[op], lhs, rhs)
 
     def composition(self, ex, operator):
         """
@@ -372,6 +426,7 @@ class Mathics3Converter(Converter):
             sage: hypergeometric((a,b,),(c,),d)._sympy_()
             hyper((a, b), (c,), d)
         """
+        breakpoint()
         return tuple(ex.operands())
 
 

--- a/src/sage/symbolic/expression_conversion_mathics3.py
+++ b/src/sage/symbolic/expression_conversion_mathics3.py
@@ -167,7 +167,7 @@ class Mathics3Converter(Converter):
             sage: m3.pyobject(x, x.pyobject())
             <MachineReal: 2.0>
             sage: type(_)
-            <class 'mathics.core.atoms.numerics.MachineReal'>>
+            <class 'mathics.core.atoms.numerics.MachineReal'>
             sage: x = SR(2/3)
             sage: x = SR(2 + 3j)
             sage: m3.pyobject(x, x.pyobject())
@@ -236,7 +236,9 @@ class Mathics3Converter(Converter):
 
         elements = []
         for arg in ex.operands():
-            if isinstance(arg, Expression):
+            if arg.is_numeric():
+                element = self.convert_object_to_mathics3(arg)
+            elif isinstance(arg, Expression):
                 element = arg._mathics3_()
             else:
                 element = self.convert_object_to_mathics3(arg)

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -36,7 +36,7 @@ lazy_import('sage.rings.universal_cyclotomic_field', 'UniversalCyclotomicField')
 lazy_import('sage.symbolic.expression_conversion_sympy', ['SympyConverter', 'sympy_converter'])
 lazy_import('sage.symbolic.expression_conversion_algebraic', ['AlgebraicConverter', 'algebraic'])
 lazy_import('sage.symbolic.expression_conversion_fricas', ['FriCASConverter', 'fricas_converter'])
-lazy_import('sage.symbolic.expression_conversion_Mathics3', ['Mathics3Converter', 'mathics3_converter'])
+lazy_import('sage.symbolic.expression_conversion_mathics3', ['Mathics3Converter', 'mathics3_converter'])
 
 
 class FakeExpression:

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -36,6 +36,7 @@ lazy_import('sage.rings.universal_cyclotomic_field', 'UniversalCyclotomicField')
 lazy_import('sage.symbolic.expression_conversion_sympy', ['SympyConverter', 'sympy_converter'])
 lazy_import('sage.symbolic.expression_conversion_algebraic', ['AlgebraicConverter', 'algebraic'])
 lazy_import('sage.symbolic.expression_conversion_fricas', ['FriCASConverter', 'fricas_converter'])
+lazy_import('sage.symbolic.expression_conversion_Mathics3', ['Mathics3Converter', 'mathics3_converter'])
 
 
 class FakeExpression:


### PR DESCRIPTION
We start adding the ability to convert between Mathics3 expressions and Sage expressions. 

From Mathics3 to Sage:

```python
        sage: eqn = mathics3('3x + 5 == 14')
        sage: eqn
        5 + 3 x == 14
        sage: eqn.sage()
        3*x + 5 == 14
        sage: f = mathics3('E^x!')
        sage: f
        E ^ x!
        sage: f.sage()
        e^factorial(x)
```

From Sage to Mathics3: 

```python
            sage: from sage.symbolic.expression_conversions import Mathics3Converter
            sage: m3 = Mathics3Converter()
            sage: x = SR(2)
            sage: m3.pyobject(x, x.pyobject())
            <Integer: 2>
            sage: type(_)
            <class 'mathics.core.atoms.numerics.Integer'>
            sage: x = SR(2.0)
            sage: m3.pyobject(x, x.pyobject())
            <MachineReal: 2.0>
            sage: type(_)
            <class 'mathics.core.atoms.numerics.MachineReal'>>
            sage: x = SR(2/3)
            sage: x = SR(2 + 3j)
            sage: m3.pyobject(x, x.pyobject())
            <Complex: 2.0 + 3.0*I>
            sage: type(_)
            <class 'mathics.core.atoms.numerics.Complex'>
```

While the `algorithm=mathics3` parameter on certain Sage functions like `integrate` allows a way to implement certain Sage functions, this does the same thing in a more general and extensible way. 

There is more to do. But this is a big step in the right direction. This code has been hanging out for a while, and I think it best to get what I have now and do more later.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


