### PR TITLE
build/pkgs/freetype/spkg-configure.m4: Require >= 24.0.18

### DIFF
--- a/build/pkgs/freetype/spkg-configure.m4
+++ b/build/pkgs/freetype/spkg-configure.m4
@@ -1,7 +1,7 @@
 SAGE_SPKG_CONFIGURE([freetype], [
     SAGE_SPKG_DEPCHECK([gcc libpng], [
       dnl freetype versions are libtool's ones, cf trac #30014
-      PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 20.0], [], [sage_spkg_install_freetype=yes])
+      PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 24.0.18], [], [sage_spkg_install_freetype=yes])
     ])
 ], [], [], [
     if test x$sage_spkg_install_freetype = xyes; then


### PR DESCRIPTION
As seen on debian-bullseye-standard:
```
  [matplotlib-3.11.1]   [spkg-install] libraqm| Dependency freetype2 for host machine found: NO found 23.4.17 but need: '>= 24.0.18' (cached)
```
https://github.com/passagemath/passagemath/actions/runs/32433127240/job/96633117089?pr=2655#step:12:3521