### PR TITLE
build/pkgs/mongo_c_driver/spkg-install.in: Disable -Werror=discarded-qualifiers

### DIFF
--- a/build/pkgs/mongo_c_driver/spkg-install.in
+++ b/build/pkgs/mongo_c_driver/spkg-install.in
@@ -1,5 +1,8 @@
 cd src
 
+# https://github.com/passagemath/passagemath/issues/2518
+sed -i.bak /qualifiers/d build/cmake/MongoC-Warnings.cmake
+
 sdh_cmake -GNinja \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DBUILD_STATIC_LIBS=OFF \


### PR DESCRIPTION
- Fixes https://github.com/passagemath/passagemath/issues/2518