### PR TITLE
src/sage/doctest/control.py: Do not announce 'Features to be detected'

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -1474,7 +1474,6 @@ class DocTestController(SageObject):
             sage: DC.run()
             Running doctests with ID ...
             Using --optional=external,sage
-            Features to be detected: ...
             Doctesting 1 file.
             ....py
                 [0 tests, ...s wall]
@@ -1500,7 +1499,6 @@ class DocTestController(SageObject):
             sage: DC.run()
             Running doctests with ID ...
             Using --optional=sage...
-            Features to be detected: ...
             Doctesting 1 file.
             ....py
                 [4 tests, ...s wall]
@@ -1518,7 +1516,6 @@ class DocTestController(SageObject):
             sage: DC.run()
             Running doctests with ID ...
             Using --optional=sage
-            Features to be detected: ...
             Doctesting 1 file.
             ....py
                 [4 tests, ...s wall]
@@ -1536,7 +1533,6 @@ class DocTestController(SageObject):
             sage: DC.run()                              # optional - meataxe
             Running doctests with ID ...
             Using --optional=sage
-            Features to be detected: ...
             Doctesting 1 file.
             ....py
                 [4 tests, ...s wall]
@@ -1610,7 +1606,6 @@ class DocTestController(SageObject):
                 else:
                     available_software._seen[i] = -1
 
-            self.log("Features to be detected: " + ','.join(available_software.detectable()))
             if self.options.probe:
                 self.log("Features to be probed: " + ('all' if self.options.probe is True
                                                       else ','.join(self.options.probe)))


### PR DESCRIPTION
This output no longer serves a meaningful purpose:
```
Features to be detected: 32_bit,4ti2,SAGE_SRC,benzene,bliss,buckygen,cddexec,cddexec_gmp,conway_polynomials,coxeter3,csdp,cunningham_tables,cvxopt,cvxopt,cvxpy,database_cremona_ellcurve,database_cremona_mini_ellcurve,database_cubic_hecke,database_ellcurves,database_graphs,database_jones_numfield,database_knotinfo,database_mutation_class,database_symbolic_data,dot2tex,dvipng,ecl,eclib,ecm,flatter,fpylll,fricas,frobby,gap3,gap_package_atlasrep,gap_package_ctbllib,gap_package_design,gap_package_grape,gap_package_guava,gap_package_hap,gap_package_irredsol,gap_package_polenta,gap_package_polycyclic,gap_package_qpa,gap_package_quagroup,gap_package_semigroups,gap_package_tomlib,gap_package_transgrp,gfan,giac,glucose,graphviz,imagemagick,info,ipython,jmol,jupymake,jupyter_sphinx,kenzo,khoca,kissat,latte_int,lcalc,lrcalc_python,lrslib,macaulay2,mathics3,matroid_database,mcqd,meataxe,meson_editable,mpmath,msolve,nauty,networkx,numpy,palp,pandoc,pari_elldata,pari_galdata,pari_galpol,pari_nflistdata,pari_nftables,pari_seadata,pari_seadata_big,pari_seadata_small,pdf2svg,pdftocairo,pexpect,phitigra,pillow,planarity,plantri,polytopes_db,polytopes_db_4d,pplpy,primecountpy,ptyprocess,pycosat,pycryptosat,pynormaliz,pyparsing,pytest,python_igraph,qepcad,regina,requests,rpy2,rubiks,sage.all,sage.combinat,sage.geometry.polyhedron,sage.graphs,sage.groups,sage.libs.braiding,sage.libs.cmr,sage.libs.ecl,sage.libs.flint,sage.libs.gap,sage.libs.giac,sage.libs.gsl,sage.libs.homfly,sage.libs.iml,sage.libs.linbox,sage.libs.m4ri,sage.libs.maxima,sage.libs.ntl,sage.libs.pari,sage.libs.singular,sage.misc.cython,sage.modular,sage.modules,sage.numerical.mip,sage.plot,sage.rings.complex_double,sage.rings.complex_interval_field,sage.rings.finite_rings,sage.rings.function_field,sage.rings.number_field,sage.rings.padics,sage.rings.polynomial.pbori,sage.rings.real_double,sage.rings.real_interval_field,sage.rings.real_mpfr,sage.sat,sage.schemes,sage.symbolic,sage_numerical_backends_coin,sagemath_doc_html,scipy,singular,sirocco,sloane_database,sphinx,symengine_py,sympow,sympy,tachyon,tdlib,threejs,topcom
```