### PR TITLE
src/sage/interfaces/lie.py: Call lie script directly instead of using bash by @williamstein, cherry-picked

### DIFF
--- a/src/sage/interfaces/lie.py
+++ b/src/sage/interfaces/lie.py
@@ -339,7 +339,7 @@ class LiE(ExtraTabCompletion, Expect):
                         prompt='> ',
 
                         # This is the command that starts up your program
-                        command="bash lie",
+                        command="lie",
 
                         server=server,
                         script_subdirectory=script_subdirectory,
@@ -920,7 +920,7 @@ def lie_console():
     from sage.repl.rich_output.display_manager import get_display_manager
     if not get_display_manager().is_in_terminal():
         raise RuntimeError('Can use the console only in the terminal. Try %%lie magics instead.')
-    os.system('bash `which lie`')
+    os.system('lie')
 
 
 def lie_version():


### PR DESCRIPTION
Cherry-picked from
- https://github.com/sagemathinc/sagelite/commit/e2c775a0806637e621bc2240f61fab046f3c8e42 by @williamstein 
