### PR TITLE
src/sage/features/gap3.py (Gap3Package): New, replace `is_chevie_available`

### DIFF
--- a/src/sage/algebras/hecke_algebras/cubic_hecke_algebra.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_algebra.py
@@ -127,6 +127,7 @@ AUTHORS:
 from warnings import warn
 
 from sage.combinat.free_module import CombinatorialFreeModule
+from sage.features.gap3 import Gap3Package
 from sage.misc.cachefunc import cached_method
 from sage.misc.verbose import verbose
 from sage.groups.cubic_braid import CubicBraidGroup
@@ -1493,8 +1494,7 @@ class CubicHeckeAlgebra(CombinatorialFreeModule):
             sage: CHA3.chevie()                  # optional gap3
             Hecke(G4,[[a,b,c]])
         """
-        from sage.combinat.root_system.reflection_group_real import is_chevie_available
-        if not is_chevie_available():
+        if not Gap3Package('chevie').is_present():
             raise NotImplementedError('this functionality needs GAP3 with package CHEVIE')
 
         n = self._nstrands
@@ -1803,9 +1803,7 @@ class CubicHeckeAlgebra(CombinatorialFreeModule):
             test_matrix = self._tester(**options)
             test_matrix.assertEqual(m12mult, m12mat)
 
-        from sage.combinat.root_system.reflection_group_real import is_chevie_available
-
-        if is_chevie_available():
+        if Gap3Package('chevie').is_present():
             check_matrix(RepresentationType.SplitIrredChevie)
             if self.ngens() < 3:
                 check_matrix(RepresentationType.SplitIrredMarin)

--- a/src/sage/algebras/hecke_algebras/cubic_hecke_matrix_rep.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_matrix_rep.py
@@ -26,6 +26,7 @@ AUTHORS:
 # ###########################################################################
 from enum import Enum
 
+from sage.features.gap3 import Gap3Package
 from sage.misc.cachefunc import cached_method
 from sage.misc.verbose import verbose
 from sage.rings.integer import Integer
@@ -639,8 +640,7 @@ class CubicHeckeMatrixSpace(MatrixSpace):
             representation_type = RepresentationType.SplitIrredMarin
 
         if representation_type == RepresentationType.SplitIrredChevie:
-            from sage.combinat.root_system.reflection_group_real import is_chevie_available
-            if not is_chevie_available():
+            if not Gap3Package('chevie').is_present():
                 raise ValueError('CHEVIE is not available')
 
         base_ring = cubic_hecke_algebra.base_ring(generic=original)

--- a/src/sage/combinat/root_system/reflection_group_real.py
+++ b/src/sage/combinat/root_system/reflection_group_real.py
@@ -48,6 +48,7 @@ AUTHORS:
 
 from sage.misc.cachefunc import cached_function, cached_method, cached_in_parent_method
 from sage.combinat.root_system.cartan_type import CartanType, CartanType_abstract
+from sage.features.gap3 import Gap3Package
 from sage.interfaces.gap3 import gap3
 from sage.rings.integer_ring import ZZ
 from sage.combinat.root_system.reflection_group_complex import ComplexReflectionGroup, IrreducibleComplexReflectionGroup
@@ -123,7 +124,7 @@ def ReflectionGroup(*args, **kwds):
         sage: W = ReflectionGroup((4,2,2),4); W
         Reducible complex reflection group of rank 4 and type G(4,2,2) x ST4
     """
-    if not is_chevie_available():
+    if not Gap3Package('chevie').is_present():
         raise ImportError("the GAP3 package 'chevie' is needed to work with (complex) reflection groups")
 
     from sage.interfaces.gap3 import gap3
@@ -219,6 +220,7 @@ def ReflectionGroup(*args, **kwds):
                reflection_index_set=kwds.get('reflection_index_set', None))
 
 
+# Deprecated
 @cached_function
 def is_chevie_available():
     r"""
@@ -233,13 +235,7 @@ def is_chevie_available():
         sage: is_chevie_available() in [True, False]
         True
     """
-    try:
-        from sage.interfaces.gap3 import gap3
-        gap3._start()
-        gap3.load_package("chevie")
-        return True
-    except Exception:
-        return False
+    return bool(Gap3Package('chevie').is_present())
 
 #####################################################################
 ## Classes

--- a/src/sage/features/gap.py
+++ b/src/sage/features/gap.py
@@ -12,7 +12,7 @@ Features for testing the presence of the SageMath interfaces to ``gap`` and of G
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from . import Feature, FeatureTestResult, PythonModule
+from . import Feature, FeatureTestResult
 from .join_feature import JoinFeature
 from .sagemath import sage__libs__gap
 

--- a/src/sage/features/gap3.py
+++ b/src/sage/features/gap3.py
@@ -2,7 +2,7 @@ r"""
 Feature for testing the presence of ``gap3``.
 """
 
-from . import Executable
+from . import Executable, Feature, FeatureTestResult
 
 
 class Gap3(Executable):
@@ -31,6 +31,59 @@ class Gap3(Executable):
             spkg="gap3",
             type="optional",
         )
+
+
+class Gap3Package(Feature):
+    r"""
+    A :class:`~sage.features.Feature` describing the presence of a GAP3 package.
+
+    A GAP3 package is "present" if it *can be* loaded, not if it *has
+    been* loaded.
+
+    .. SEEALSO::
+
+        :class:`Feature sage.libs.gap <~sage.features.sagemath.sage__libs__gap>`
+
+    EXAMPLES::
+
+        sage: from sage.features.gap3 import Gap3Package
+        sage: Gap3Package("chevie", spkg='gap3')
+        Feature('gap3_package_chevie')
+    """
+    def __init__(self, package, check_command=None, **kwds):
+        r"""
+        TESTS::
+
+            sage: from sage.features.gap3 import Gap3Package
+            sage: isinstance(Gap3Package("chevie", spkg='gap3'), Gap3Package)
+            True
+        """
+        Feature.__init__(self, f"gap3_package_{package}", **kwds)
+        self.package = package
+        self.check_command = check_command
+
+    def _is_present(self):
+        r"""
+        Return whether or not the GAP3 package is present.
+
+        If the package is installed but not yet loaded, it is loaded
+        first. This does *not* check that the package is functional.
+
+        EXAMPLES::
+
+            sage: from sage.features.gap3 import Gap3Package
+            sage: Gap3Package("chevie", spkg='gap3')._is_present()  # optional - gap3_package_chevie
+            FeatureTestResult('gap3_package_chevie', True)
+        """
+        try:
+            from sage.interfaces.gap3 import gap3
+            gap3._start()
+            gap3.load_package(self.package)
+            return FeatureTestResult(self, True)
+        except Exception as exception:
+            return FeatureTestResult(self, False,
+                                     reason="Loading the GAP3 package raised an error: {exception}.".format(
+                                         exception=exception))
 
 
 def all_features():

--- a/src/sage/features/gap3.py
+++ b/src/sage/features/gap3.py
@@ -50,7 +50,7 @@ class Gap3Package(Feature):
         sage: Gap3Package("chevie", spkg='gap3')
         Feature('gap3_package_chevie')
     """
-    def __init__(self, package, check_command=None, **kwds):
+    def __init__(self, package, spkg='gap3', **kwds):
         r"""
         TESTS::
 
@@ -58,9 +58,8 @@ class Gap3Package(Feature):
             sage: isinstance(Gap3Package("chevie", spkg='gap3'), Gap3Package)
             True
         """
-        Feature.__init__(self, f"gap3_package_{package}", **kwds)
+        Feature.__init__(self, f"gap3_package_{package}", spkg=spkg, **kwds)
         self.package = package
-        self.check_command = check_command
 
     def _is_present(self):
         r"""

--- a/src/sage/groups/cubic_braid.py
+++ b/src/sage/groups/cubic_braid.py
@@ -88,6 +88,7 @@ import sage.rings.abc
 
 from sage.categories.groups import Groups
 from sage.categories.shephard_groups import ShephardGroups
+from sage.features.gap3 import Gap3Package
 from sage.groups.free_group import FreeGroup
 from sage.groups.finitely_presented import FinitelyPresentedGroup, FinitelyPresentedGroupElement
 from sage.groups.braid import BraidGroup
@@ -1019,8 +1020,7 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
             sage: CBG2._test_reflection_group()
         """
         if self._cbg_type == CubicBraidGroup.type.Coxeter and self.is_finite() and self.strands() > 2:
-            from sage.combinat.root_system.reflection_group_real import is_chevie_available
-            if is_chevie_available():
+            if Gap3Package('chevie').is_present():
                 tester = self._tester(**options)
                 reflgrp = self.as_reflection_group()
                 self._internal_test_attached_group(reflgrp, tester)
@@ -1796,8 +1796,7 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
         #    4 strands -> G25
         #    5 strands -> G32
         # -------------------------------------------------------------------------------
-        from sage.combinat.root_system.reflection_group_real import is_chevie_available
-        if not is_chevie_available():
+        if not Gap3Package('chevie').is_present():
             raise ImportError("the GAP3 package 'CHEVIE' is needed to obtain the corresponding reflection groups")
 
         if self._cbg_type != CubicBraidGroup.type.Coxeter or self.strands() > 5 or self.strands() < 2:


### PR DESCRIPTION
Fixes modularization bug
```
File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-standard/.tox/py314-norequirements/lib/python3.14/site-packages/sage/algebras/hecke_algebras/cubic_hecke_algebra.py", line 84, in sage.algebras.hecke_algebras.cubic_hecke_algebra
Failed example:
    try:
        sh = CHA3.schur_element(CHA3.irred_repr.W3_111)
    except NotImplementedError:    # for the case GAP3 / CHEVIE not available
        sh = ER(f/(2*w^2))
Exception raised:
    Traceback (most recent call last):
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-standard/.tox/py314-norequirements/lib/python3.14/site-packages/sage/doctest/forker.py", line 742, in _run
        self.compile_and_execute(example, compiler, test.globs)
        ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-standard/.tox/py314-norequirements/lib/python3.14/site-packages/sage/doctest/forker.py", line 1166, in compile_and_execute
        exec(compiled, globs)
        ~~~~^^^^^^^^^^^^^^^^^
      File "<doctest sage.algebras.hecke_algebras.cubic_hecke_algebra[13]>", line 2, in <module>
        sh = CHA3.schur_element(CHA3.irred_repr.W3_111)
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-standard/.tox/py314-norequirements/lib/python3.14/site-packages/sage/algebras/hecke_algebras/cubic_hecke_algebra.py", line 3459, in schur_element
        return self.schur_elements(generic=generic)[item.gap_index()]
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-standard/.tox/py314-norequirements/lib/python3.14/site-packages/sage/algebras/hecke_algebras/cubic_hecke_algebra.py", line 3421, in schur_elements
        gap3_result = self.chevie().SchurElements()
                      ~~~~~~~~~~~^^
      File "sage/misc/cachefunc.pyx", line 2354, in sage.misc.cachefunc.CachedMethodCallerNoArgs.__call__
        self.cache = f(self._instance)
      File "/home/runner/work/passagemath/passagemath/pkgs/sagemath-standard/.tox/py314-norequirements/lib/python3.14/site-packages/sage/algebras/hecke_algebras/cubic_hecke_algebra.py", line 1496, in chevie
        from sage.combinat.root_system.reflection_group_real import is_chevie_available
    ModuleNotFoundError: No module named 'sage.combinat.root_system.reflection_group_real'
```
https://github.com/passagemath/passagemath/actions/runs/32611315770/job/97229508597#step:9:961

FYI @stumpc5 @soehms @jmichel7