### PR TITLE
pyproject.toml: Relax ipython to >=7.13.0; Google colab requires ==7.34.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   'gmpy2 ~=2.1.b999',
   'gmpy2 ~=2.3.b1; sys_platform == "win32"',
   'ipykernel >=5.2.1',
-  'ipython >=8.9.0',
+  'ipython >=7.13.0',
   'ipywidgets >=7.5.1',
   'jupyter-client',
   'matplotlib >=3.7.0',


### PR DESCRIPTION
Reverting a gratuitous restriction introduced in
- https://github.com/sagemath/sage/pull/39268
