### PR TITLE
Add generic NetworkX '<name>_layout' layouts to 2d graph plotting

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21399,6 +21399,9 @@ class GenericGraph(GenericGraph_pyx):
         class. It looks up ``networkx.<layout_name>_layout`` and calls it on
         a NetworkX copy of ``self``, translating the result back into a
         position dictionary keyed by the vertices of ``self``.
+        See the
+        `NetworkX layout documentation 
+        <https://networkx.org/documentation/stable/reference/drawing.html#module-networkx.drawing.layout>`_.
 
         INPUT::
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21428,7 +21428,7 @@ class GenericGraph(GenericGraph_pyx):
 
         import networkx
         from sage.graphs.graph_plot import graphplot_options
-    
+
         funcname = "%s_layout" % layout_name
         func = getattr(networkx, funcname, None)
         if func is None or not callable(func):

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -307,6 +307,7 @@ can be applied on both. Here is what it can do:
     :meth:`~GenericGraph.graphviz_string` | Return a representation in the ``dot`` language.
     :meth:`~GenericGraph.graphviz_to_file_named` | Write a representation in the ``dot`` language in a file.
     :meth:`~GenericGraph.tikz` | Return a :class:`~sage.misc.latex_standalone.TikzPicture` object representing the (di)graph.
+    :meth:`~GenericGraph.layout_networkx` | Compute the node layout using any NetworkX layout algorithm.
 
 **Algorithmically hard stuff:**
 
@@ -21254,7 +21255,8 @@ class GenericGraph(GenericGraph_pyx):
         - ``layout`` -- string (default: ``None``); specifies a layout algorithm
           among ``'acyclic'``, ``'acyclic_dummy'``, ``'circular'``,
           ``'ranked'``, ``'graphviz'``, ``'planar'``, ``'spring'``,
-          ``'forest'`` or ``'tree'``
+          ``'forest'``,``'tree'`` or the name of any NetworkX layout
+          algorithm (see :meth:`layout_networkx`)
 
         - ``pos`` -- dictionary (default: ``None``); a dictionary of positions
 
@@ -21364,7 +21366,13 @@ class GenericGraph(GenericGraph_pyx):
             ....:     for G in [Graph([(1, 2)]), Graph([(1, 2), (2, 3), (3, 4)])]:
             ....:         pos = G.layout(style, save_pos=True)
             ....:         assert G._pos is not None
+
+        .. SEEALSO::
+
+            :meth:`layout_networkx` for using any NetworkX layout algorithm not
+            natively implemented on this class.
         """
+
         if layout is None:
             if pos is None:
                 pos = self.get_pos(dim=dim)
@@ -21392,7 +21400,7 @@ class GenericGraph(GenericGraph_pyx):
         a NetworkX copy of ``self``, translating the result back into a
         position dictionary keyed by the vertices of ``self``.
 
-        INPUT:
+        INPUT::
 
         - ``layout_name`` -- string; the name of a NetworkX layout function,
           without its ``_layout`` suffix -- e.g. ``'kamada_kawai'`` for
@@ -21404,26 +21412,92 @@ class GenericGraph(GenericGraph_pyx):
         - ``**options`` -- extra keyword arguments forwarded unchanged to the
           underlying NetworkX layout function.
 
-        OUTPUT:
+        OUTPUT::
 
         A dictionary mapping each vertex of ``self`` to a tuple of ``dim``
         floats.
 
         EXAMPLES::
 
+        Layouts with no extra required arguments work directly through
+        :meth:`plot`::
+
             sage: g = graphs.PetersenGraph()
-            sage: pos = g.layout('kamada_kawai')                      # needs networkx
-            sage: sorted(pos) == sorted(g)                             # needs networkx
-            True
+            sage: g.plot(layout='kamada_kawai')                       # needs networkx sage.plot
+            Graphics object consisting of ... graphics primitives
             sage: g.plot(layout='spectral')                           # needs networkx sage.plot
+            Graphics object consisting of ... graphics primitives
+            sage: g.plot(layout='shell')                              # needs networkx sage.plot
+            Graphics object consisting of ... graphics primitives
+            sage: g.plot(layout='circular')                           # needs networkx sage.plot
+            Graphics object consisting of ... graphics primitives
+
+        Calling :meth:`layout_networkx` directly returns the raw position
+        dictionary, keyed by the vertices of ``self``::
+
+            sage: pos = g.layout_networkx('kamada_kawai')             # needs networkx
+            sage: sorted(pos) == sorted(g)                            # needs networkx
+            True
+            sage: all(len(p) == 2 for p in pos.values())              # needs networkx
+            True
+
+        Three-dimensional layouts are supported for algorithms that accept a
+        ``dim`` parameter::
+
+            sage: pos3d = g.layout_networkx('kamada_kawai', dim=3)    # needs networkx
+            sage: all(len(p) == 3 for p in pos3d.values())            # needs networkx
+            True
+
+        Layout-specific keyword arguments recognized by the target NetworkX
+        function are forwarded when calling :meth:`layout_networkx`
+        directly::
+
+            sage: pos = g.layout_networkx('spring', k=2, iterations=100)  # needs networkx
+            sage: sorted(pos) == sorted(g)                            # needs networkx
+            True
+
+        Sage-specific plotting options passed through :meth:`plot`, such as
+        ``vertex_size``, are safely ignored rather than raising an error,
+        even when a NetworkX layout function happens to accept a
+        same-named parameter with an unrelated meaning (for example, Sage's
+        ``dist`` is a float controlling multi-edge spacing, while
+        :func:`networkx.kamada_kawai_layout`'s ``dist`` parameter expects a
+        distance matrix)::
+
+            sage: g.plot(layout='kamada_kawai', vertex_size=300)      # needs networkx sage.plot
             Graphics object consisting of ... graphics primitives
 
         An unknown layout name raises a clear error::
 
-            sage: g.layout('this_is_not_a_layout')                     # needs networkx
+            sage: g.layout('this_is_not_a_layout')                    # needs networkx
             Traceback (most recent call last):
             ...
             ValueError: unknown layout algorithm: this_is_not_a_layout
+
+        .. WARNING::
+
+            Some NetworkX layouts require extra *mandatory* arguments that
+            are not valid Sage plotting options -- for example, ``nodes``
+            for :func:`networkx.bipartite_layout`. Such arguments cannot be
+            passed through :meth:`plot` directly: :meth:`plot` validates its
+            keyword arguments against a fixed list of recognized Sage
+            plotting options and raises ``ValueError: invalid input`` for
+            anything outside that list, regardless of whether
+            :meth:`layout_networkx` would have accepted and used it
+            correctly. Compute the position dictionary separately instead,
+            and pass it to :meth:`plot` via ``pos=``::
+
+                sage: B = graphs.CompleteBipartiteGraph(3, 4)          # needs networkx
+                sage: pos = B.layout_networkx('bipartite', nodes=list(range(3)))  # needs networkx
+                sage: B.plot(pos=pos)                                  # needs networkx sage.plot
+                Graphics object consisting of ... graphics primitives
+
+        .. SEEALSO::
+
+            The `NetworkX layout documentation
+            <https://networkx.org/documentation/stable/reference/drawing.html#module-networkx.drawing.layout>`_
+            for the full list of available layout functions and their
+            algorithm-specific keyword arguments.
         """
 
         import networkx
@@ -22436,6 +22510,14 @@ class GenericGraph(GenericGraph_pyx):
 
           - ``'tutte'`` -- uses the Tutte embedding algorithm. The graph must be
             a 3-connected, planar graph.
+
+          - the name of any NetworkX layout algorithm (without the ``_layout``
+            suffix), such as ``'kamada_kawai'``, ``'spectral'``, `` 'shell'``, or
+            `` 'spiral'`` which is forwarded to the corresponding function in
+            :mod:`networkx.drawing.layout`, e.g. ``layout='kamada_kawai'`` calls
+            :func:`networkx.kamada_kawai_layout`. See
+            :meth:`~sage.graphs.generic_graph.GenericGraph.layout_networkx` for
+            details.
 
         - ``vertex_labels`` -- boolean (default: ``True``); whether to print
           vertex labels

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -448,6 +448,7 @@ Methods
 # ****************************************************************************
 
 from copy import copy
+import inspect
 
 from sage.features.igraph import python_igraph as igraph_feature
 from sage.graphs.dot2tex_utils import assert_have_dot2tex
@@ -21373,7 +21374,7 @@ class GenericGraph(GenericGraph_pyx):
         if hasattr(self, "layout_%s" % layout):
             pos = getattr(self, "layout_%s" % layout)(dim=dim, **options)
         elif layout is not None:
-            raise ValueError("unknown layout algorithm: %s" % layout)
+            pos = self.layout_networkx(layout, dim=dim, **options)
 
         if len(pos) < self.order():
             pos = self.layout_extend_randomly(pos, dim=dim)
@@ -21381,6 +21382,83 @@ class GenericGraph(GenericGraph_pyx):
         if save_pos:
             self.set_pos(pos, dim=dim)
         return pos
+    def layout_networkx(self, layout_name, dim=2, **options):
+        r"""
+        Compute a layout using one of NetworkX's layout algorithms.
+
+        This is the fallback used by :meth:`layout` whenever ``layout_name``
+        does not match a ``layout_<name>`` method defined natively on this
+        class. It looks up ``networkx.<layout_name>_layout`` and calls it on
+        a NetworkX copy of ``self``, translating the result back into a
+        position dictionary keyed by the vertices of ``self``.
+
+        INPUT:
+
+        - ``layout_name`` -- string; the name of a NetworkX layout function,
+        without its ``_layout`` suffix -- e.g. ``'kamada_kawai'`` for
+        :func:`networkx.kamada_kawai_layout`.
+
+        - ``dim`` -- integer (default: 2); 2 or 3, ignored by NetworkX
+        layouts that do not accept a ``dim`` parameter.
+
+        - ``**options`` -- extra keyword arguments forwarded unchanged to the
+        underlying NetworkX layout function.
+
+        OUTPUT:
+
+        A dictionary mapping each vertex of ``self`` to a tuple of ``dim``
+        floats.
+
+        EXAMPLES::
+
+            sage: g = graphs.PetersenGraph()
+            sage: pos = g.layout('kamada_kawai')                      # needs networkx
+            sage: sorted(pos) == sorted(g)                             # needs networkx
+            True
+            sage: g.plot(layout='spectral')                           # needs networkx sage.plot
+            Graphics object consisting of ... graphics primitives
+
+        An unknown layout name raises a clear error::
+
+            sage: g.layout('this_is_not_a_layout')                     # needs networkx
+            Traceback (most recent call last):
+            ...
+            ValueError: unknown layout algorithm: this_is_not_a_layout
+        """
+        import inspect
+        import networkx
+        from sage.graphs.graph_plot import graphplot_options
+
+        funcname = "%s_layout" % layout_name
+        func = getattr(networkx, funcname, None)
+        if func is None or not callable(func):
+            raise ValueError("unknown layout algorithm: %s" % layout_name)
+
+        G = self.networkx_graph()
+
+        # Exclude keys that belong to Sage's own plotting/layout option
+        # vocabulary, even if a NetworkX layout function happens to accept
+        # a same-named parameter with a different meaning. For example,
+        # Sage's 'dist' controls spacing between multi-edges (a float),
+        # while networkx.kamada_kawai_layout's 'dist' parameter expects a
+        # distance matrix (a dict) -- forwarding Sage's value there crashes
+        # NetworkX with a confusing TypeError.
+        sage_option_names = set(graphplot_options)
+
+        sig = inspect.signature(func)
+        accepted = set(sig.parameters)
+
+        filtered_options = {
+        k: v for k, v in options.items()
+        if k in accepted and k not in sage_option_names
+        }
+
+        if 'dim' in accepted:
+            raw_pos = func(G, dim=dim, **filtered_options)
+        else:
+            raw_pos = func(G, **filtered_options)
+
+        return {v: tuple(float(c) for c in p) for v, p in raw_pos.items()}
 
     def layout_spring(self, by_component=True, **options):
         """

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21395,14 +21395,14 @@ class GenericGraph(GenericGraph_pyx):
         INPUT:
 
         - ``layout_name`` -- string; the name of a NetworkX layout function,
-        without its ``_layout`` suffix -- e.g. ``'kamada_kawai'`` for
-        :func:`networkx.kamada_kawai_layout`.
+          without its ``_layout`` suffix -- e.g. ``'kamada_kawai'`` for
+          :func:`networkx.kamada_kawai_layout`.
 
         - ``dim`` -- integer (default: 2); 2 or 3, ignored by NetworkX
-        layouts that do not accept a ``dim`` parameter.
+          layouts that do not accept a ``dim`` parameter.
 
         - ``**options`` -- extra keyword arguments forwarded unchanged to the
-        underlying NetworkX layout function.
+          underlying NetworkX layout function.
 
         OUTPUT:
 
@@ -21425,10 +21425,10 @@ class GenericGraph(GenericGraph_pyx):
             ...
             ValueError: unknown layout algorithm: this_is_not_a_layout
         """
-        import inspect
+
         import networkx
         from sage.graphs.graph_plot import graphplot_options
-
+    
         funcname = "%s_layout" % layout_name
         func = getattr(networkx, funcname, None)
         if func is None or not callable(func):
@@ -21436,13 +21436,6 @@ class GenericGraph(GenericGraph_pyx):
 
         G = self.networkx_graph()
 
-        # Exclude keys that belong to Sage's own plotting/layout option
-        # vocabulary, even if a NetworkX layout function happens to accept
-        # a same-named parameter with a different meaning. For example,
-        # Sage's 'dist' controls spacing between multi-edges (a float),
-        # while networkx.kamada_kawai_layout's 'dist' parameter expects a
-        # distance matrix (a dict) -- forwarding Sage's value there crashes
-        # NetworkX with a confusing TypeError.
         sage_option_names = set(graphplot_options)
 
         sig = inspect.signature(func)

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21400,10 +21400,10 @@ class GenericGraph(GenericGraph_pyx):
         a NetworkX copy of ``self``, translating the result back into a
         position dictionary keyed by the vertices of ``self``.
         See the
-        `NetworkX layout documentation 
+        `NetworkX layout documentation
         <https://networkx.org/documentation/stable/reference/drawing.html#module-networkx.drawing.layout>`_.
 
-        INPUT::
+        INPUT:
 
         - ``layout_name`` -- string; the name of a NetworkX layout function,
           without its ``_layout`` suffix -- e.g. ``'kamada_kawai'`` for
@@ -21415,12 +21415,12 @@ class GenericGraph(GenericGraph_pyx):
         - ``**options`` -- extra keyword arguments forwarded unchanged to the
           underlying NetworkX layout function.
 
-        OUTPUT::
+        OUTPUT:
 
         A dictionary mapping each vertex of ``self`` to a tuple of ``dim``
         floats.
 
-        EXAMPLES::
+        EXAMPLES:
 
         Layouts with no extra required arguments work directly through
         :meth:`plot`::

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21328,7 +21328,7 @@ class GenericGraph(GenericGraph_pyx):
             option forest_roots : An iterable specifying which vertices to use as roots for the ``layout='forest'`` option. If no root is specified for a tree, then one is chosen close to the center of the tree. Ignored unless ``layout='forest'``.
             option heights : A dictionary mapping heights to the list of vertices at this height.
             option iterations : The number of times to execute the spring layout algorithm.
-            option layout : A layout algorithm -- one of : "acyclic", "circular" (plots the graph with vertices evenly distributed on a circle), "ranked", "graphviz", "planar", "spring" (traditional spring layout, using the graph's current positions as initial positions), or "tree" (the tree will be plotted in levels, depending on minimum distance for the root).
+            option layout : A layout algorithm -- one of : "acyclic", "circular" (plots the graph with vertices evenly distributed on a circle), "ranked", "graphviz", "planar", "spring" (traditional spring layout, using the graph's current positions as initial positions), "tree" (the tree will be plotted in levels, depending on minimum distance for the root), or the name of any NetworkX layout function such as "kamada_kawai", "spectral", "shell", or "spiral" (see :meth:`~sage.graphs.generic_graph.GenericGraph.layout_networkx`).
             option prog : Which graphviz layout program to use -- one of "circo", "dot", "fdp", "neato", or "twopi".
             option save_pos : Whether or not to save the computed position for the graph.
             option spring : Use spring layout to finalize the current layout.

--- a/src/sage/graphs/graph_plot.py
+++ b/src/sage/graphs/graph_plot.py
@@ -139,9 +139,11 @@ layout_options = {
         'A layout algorithm -- one of : "acyclic", "circular" (plots the '
         'graph with vertices evenly distributed on a circle), "ranked", '
         '"graphviz", "planar", "spring" (traditional spring layout, using '
-        'the graph\'s current positions as initial positions), or "tree" '
+        'the graph\'s current positions as initial positions), "tree" '
         '(the tree will be plotted in levels, depending on minimum distance '
-        'for the root).',
+        'for the root), or the name of any NetworkX layout function such '
+        'as "kamada_kawai", "spectral", "shell", or "spiral" (see '
+        ':meth:`~sage.graphs.generic_graph.GenericGraph.layout_networkx`).',
     'iterations':
         'The number of times to execute the spring layout algorithm.',
     'heights':


### PR DESCRIPTION
`GenericGraph.layout()` only recognizes layout algorithms that have a
corresponding `layout_<name>` method defined directly on the class
(`layout_circular`, `layout_spring`, `layout_tree`, `layout_planar`,
`layout_graphviz`, `layout_tutte`, ...). Any other value passed via
`layout='...'` raises `ValueError: unknown layout algorithm`, even
though NetworkX ships many more layouts (`kamada_kawai_layout`,
`spectral_layout`, `shell_layout`, `spiral_layout`, `planar_layout`,
`bipartite_layout`, `multipartite_layout`, etc.) that passagemath
already depends on via the existing `networkx_graph()` method.

Today, using one of these requires manually converting to a
`networkx.Graph`, calling the NetworkX function, and feeding the result
back in via `pos=`:

```python
import networkx as nx
pos = nx.kamada_kawai_layout(G.networkx_graph())
G.plot(pos=pos)
```

This PR adds a generic fallback so any NetworkX layout is usable
directly, with no per-layout wrapper code required:

```python
G.plot(layout='kamada_kawai')
G.layout('spectral')
```

New layouts NetworkX adds in the future work automatically too, since
the fallback resolves `networkx.<name>_layout` by naming convention
rather than hardcoding a list.

## Changes

### `sage/graphs/generic_graph.py`

**1. `GenericGraph.layout()`** — the fallback branch now delegates to a
new helper instead of raising immediately:

```diff
     if hasattr(self, "layout_%s" % layout):
         pos = getattr(self, "layout_%s" % layout)(dim=dim, **options)
     elif layout is not None:
-        raise ValueError("unknown layout algorithm: %s" % layout)
+        pos = self.layout_networkx(layout, dim=dim, **options)
```

Native `layout_*` methods are checked first and always take priority, so
this cannot change behavior for any layout name that already has a
dedicated implementation.

**2. New method `GenericGraph.layout_networkx()`**, placed alongside the
other `layout_*` helpers (after `layout_extend_randomly`):

```python
def layout_networkx(self, layout_name, dim=2, **options):
    r"""
    Compute a layout using one of NetworkX's layout algorithms.

    This is the fallback used by :meth:`layout` whenever ``layout_name``
    does not match a ``layout_<name>`` method defined natively on this
    class. It looks up ``networkx.<layout_name>_layout`` and calls it on
    a NetworkX copy of ``self``, translating the result back into a
    position dictionary keyed by the vertices of ``self``.

    INPUT:

    - ``layout_name`` -- string; the name of a NetworkX layout function,
      without its ``_layout`` suffix -- e.g. ``'kamada_kawai'`` for
      :func:`networkx.kamada_kawai_layout`.

    - ``dim`` -- integer (default: 2); 2 or 3. Only forwarded if the
      target NetworkX function accepts a ``dim`` parameter.

    - ``**options`` -- extra keyword arguments; only those recognized by
      the target NetworkX layout function's signature are forwarded to
      it. This matters because callers such as :meth:`plot` pass many
      Sage-specific plotting options (``vertex_size``, ``vertex_labels``,
      ...) through ``**options``, which NetworkX layout functions do not
      accept.

    OUTPUT:

    A dictionary mapping each vertex of ``self`` to a tuple of ``dim``
    floats.

    EXAMPLES::

        sage: g = graphs.PetersenGraph()
        sage: pos = g.layout('kamada_kawai')                      # needs networkx
        sage: sorted(pos) == sorted(g)                             # needs networkx
        True
        sage: g.plot(layout='spectral')                           # needs networkx sage.plot
        Graphics object consisting of ... graphics primitives

    Sage-specific plotting kwargs passed through :meth:`plot` are safely
    ignored rather than raising::

        sage: g.plot(layout='kamada_kawai', vertex_size=300)      # needs networkx sage.plot
        Graphics object consisting of ... graphics primitives

    An unknown layout name raises a clear error::

        sage: g.layout('this_is_not_a_layout')                     # needs networkx
        Traceback (most recent call last):
        ...
        ValueError: unknown layout algorithm: this_is_not_a_layout
    """
    import inspect
    import networkx

    funcname = "%s_layout" % layout_name
    func = getattr(networkx, funcname, None)
    if func is None or not callable(func):
        raise ValueError("unknown layout algorithm: %s" % layout_name)

    G = self.networkx_graph()

    # Only forward keyword arguments that this particular NetworkX layout
    # function actually accepts. Callers such as plot() pass through many
    # Sage-specific plotting options (vertex_size, vertex_labels, ...)
    # in **options that NetworkX knows nothing about.
    sig = inspect.signature(func)
    accepted = set(sig.parameters)
    filtered_options = {k: v for k, v in options.items() if k in accepted}

    if 'dim' in accepted:
        raw_pos = func(G, dim=dim, **filtered_options)
    else:
        raw_pos = func(G, **filtered_options)

    return {v: tuple(float(c) for c in p) for v, p in raw_pos.items()}
```

### `sage/graphs/graph_plot.py`

Updated the `'layout'` entry in `layout_options` (used to auto-generate
the options table in the module docstring) to document the new
capability:

```diff
     'layout':
         'A layout algorithm -- one of : "acyclic", "circular" (plots the '
         'graph with vertices evenly distributed on a circle), "ranked", '
         '"graphviz", "planar", "spring" (traditional spring layout, using '
-        'the graph\'s current positions as initial positions), or "tree" '
-        '(the tree will be plotted in levels, depending on minimum distance '
-        'for the root).',
+        'the graph\'s current positions as initial positions), "tree" '
+        '(the tree will be plotted in levels, depending on minimum distance '
+        'for the root), or the name of any NetworkX layout function such '
+        'as "kamada_kawai", "spectral", "shell", or "spiral" (see '
+        ':meth:`~sage.graphs.generic_graph.GenericGraph.layout_networkx`).',
```

No changes were needed in `GraphPlot.set_pos()` — it already calls
`self._graph.layout(**self._options)`, so the new branch is picked up
automatically.

## Design notes

- **Why not hardcode a list of supported NetworkX layouts?** Resolving
  `networkx.<name>_layout` by convention means the fallback tracks
  whatever NetworkX ships without needing to update passagemath every
  time NetworkX adds a layout.
- **Why filter `options` by signature instead of `try/except TypeError`?**
  An earlier version of this patch used a blanket `try/except TypeError`
  around a `dim=` retry. That masked real errors: `plot()` forwards
  Sage-specific kwargs like `vertex_size` through `**options`, and those
  raised `TypeError: kamada_kawai_layout() got an unexpected keyword
  argument 'vertex_size'` on *both* the first and retried call, since
  `dim` was never the actual problem. Introspecting the target function's
  signature with `inspect.signature` and filtering `options` down to
  only recognized parameter names fixes this correctly instead of
  papering over it.

Fixes: (link the relevant issue here, e.g. "Fixes #XXXXX")

Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

Dependencies
<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

None.

