### PR TITLE
pyproject.toml: Relax numpy to >=2.1 (Google colab has 2.1.3)

### DIFF
--- a/pkgs/sagemath-flint/VERSION.txt
+++ b/pkgs/sagemath-flint/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-gsl/VERSION.txt
+++ b/pkgs/sagemath-gsl/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-linbox/VERSION.txt
+++ b/pkgs/sagemath-linbox/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-m4ri-m4rie/VERSION.txt
+++ b/pkgs/sagemath-m4ri-m4rie/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-modules/VERSION.txt
+++ b/pkgs/sagemath-modules/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-plot/VERSION.txt
+++ b/pkgs/sagemath-plot/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-schemes/VERSION.txt
+++ b/pkgs/sagemath-schemes/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-standard-no-symbolics/VERSION.txt
+++ b/pkgs/sagemath-standard-no-symbolics/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pkgs/sagemath-symbolics/VERSION.txt
+++ b/pkgs/sagemath-symbolics/VERSION.txt
@@ -1,1 +1,1 @@
-../../VERSION.txt
+10.8.10.post1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = [
   'gmpy2 ~=2.3.b1; sys_platform == "win32"',
   'jinja2',
   'memory_allocator <0.2',
-  'numpy >=2.2.4',
+  'numpy >=2.1',
 ]
 [tool.meson-python.args]
 # Prevent meson from trying to install the autoconf subprojects
@@ -69,7 +69,7 @@ dependencies = [
   'memory_allocator <0.2',
   'mpmath >=1.1.0, <1.4',
   'networkx >=3.1',
-  'numpy >=1.25',
+  'numpy >=2.1',
   'passagemath-ppl; sys_platform != "win32"',
   'passagemath-primesieve-primecount; sys_platform != "win32"',
   'pexpect >=4.8.0',


### PR DESCRIPTION
The stricter version requirement came from:
- https://github.com/sagemath/sage/pull/39030

