### PR TITLE
src/sage/features/gap3.py: Make gap3 a JoinFeature

### DIFF
--- a/src/sage/combinat/root_system/reflection_group_complex.py
+++ b/src/sage/combinat/root_system/reflection_group_complex.py
@@ -49,7 +49,7 @@ Some special cases also occur, among them are::
     Irreducible real reflection group of rank 3 and type A3
 
 .. WARNING:: Uses the GAP3 package *Chevie* which is available as an
-             experimental package (installed by ``sage -i gap3``) or to
+             optional package (installed by ``sage -i gap3``) or to
              download by hand from `Jean Michel's website <http://webusers.imj-prg.fr/~jean.michel/gap3/>`_.
 
 A guided tour

--- a/src/sage/combinat/root_system/reflection_group_real.py
+++ b/src/sage/combinat/root_system/reflection_group_real.py
@@ -32,7 +32,7 @@ AUTHORS:
 .. WARNING::
 
     Uses the GAP3 package *Chevie* which is available as an
-    experimental package (installed by ``sage -i gap3``) or to
+    optional package (installed by ``sage -i gap3``) or to
     download by hand from `Jean Michel's website
     <http://webusers.imj-prg.fr/~jean.michel/gap3/>`_.
 """

--- a/src/sage/features/gap3.py
+++ b/src/sage/features/gap3.py
@@ -2,7 +2,8 @@ r"""
 Feature for testing the presence of ``gap3``.
 """
 
-from . import Executable, Feature, FeatureTestResult
+from . import Executable, Feature, FeatureTestResult, PythonModule
+from .join_feature import JoinFeature
 
 
 class Gap3(Executable):
@@ -22,11 +23,11 @@ class Gap3(Executable):
 
             sage: from sage.features.gap3 import Gap3
             sage: Gap3()
-            Feature('gap3')
+            Feature('gap3_executable')
         """
         Executable.__init__(
             self,
-            "gap3",
+            "gap3_executable",
             executable="gap3",
             spkg="gap3",
             type="optional",
@@ -86,4 +87,7 @@ class Gap3Package(Feature):
 
 
 def all_features():
-    return [Gap3()]
+    return [JoinFeature("gap3",
+                        (Gap3(),
+                         PythonModule('sage.combinat.root_system.reflection_group_real')),
+                        spkg="pypi/passagemath-gap3")]


### PR DESCRIPTION
So that doctests are properly conditionalized on the presence of the Python modules shipped in passagemath-gap3.