### PR TITLE
Render Sage formulas in plain Python notebooks

### DIFF
--- a/pkgs/sagemath-categories/tox.ini
+++ b/pkgs/sagemath-categories/tox.ini
@@ -69,6 +69,8 @@ commands =
     # Test that importing sage.categories.all initializes categories
     {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); from sage.categories.all import *; SimplicialComplexes(); FunctionFields()'
 
+    !notest:        {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); sys.modules["sage.repl"] = None; from IPython.core.formatters import DisplayFormatter; from sage.all__sagemath_categories import PolynomialRing, QQ; from sage.structure.sage_object import SageObject; R = PolynomialRing(QQ, "x"); less_than = type("LessThan", (SageObject,), {"_latex_": lambda self: "x < 1"})(); objects = (QQ(1) / 2, R.gen()**2 + 1, less_than, QQ); bundles = [DisplayFormatter().format(obj)[0] for obj in objects]; expected = (r"$\displaystyle \frac{1}{2}$", r"$\displaystyle x^{2} + 1$", r"$\displaystyle x < 1$"); assert all(set(bundle) == {"text/latex", "text/plain"} for bundle in bundles); assert tuple(bundle["text/latex"] for bundle in bundles[:3]) == expected; parent_latex = bundles[-1]["text/latex"]; assert parent_latex.startswith(r"$\displaystyle \newcommand{\Bold}[1]") and r"\mathbf" in parent_latex and parent_latex.endswith(r"\Bold{Q}$")'
+
     !notest:        bash -c 'cd $(python -c "import sys; \"\" in sys.path and sys.path.remove(\"\"); from sage.env import SAGE_LIB; print(SAGE_LIB)") \
     !notest:                 && sage-runtests -p --force-lib --initial --environment=sage.all__sagemath_categories --probe all --baseline-stats-path=$KNOWN_TEST_FAILURES --optional=sage $SAGE_DOCTEST_OPTIONS {posargs:--installed}'
 

--- a/pkgs/sagemath-objects/tox.ini
+++ b/pkgs/sagemath-objects/tox.ini
@@ -64,6 +64,8 @@ commands =
 
     {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); from sage.all__sagemath_objects import *'
 
+    {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); from sage.structure.sage_object import SageObject; obj = type("LatexObject", (SageObject,), {"_latex_": lambda self: "x"})(); sys.modules["sage.misc.html"] = None; assert obj._repr_latex_() is None'
+
     #bash -c 'cd {temp_dir} && SAGE_SRC=$(python -c "from sage.env import SAGE_SRC; print(SAGE_SRC)") && sage-runtests --environment=sage.all__sagemath_objects --initial --optional=sage $SAGE_DOCTEST_OPTIONS $SAGE_SRC/sage/structure || echo "(lots of doctest failures are expected)"'
 
 [testenv:.tox]

--- a/src/sage/repl/display/formatter.py
+++ b/src/sage/repl/display/formatter.py
@@ -69,6 +69,7 @@ from ipywidgets import Widget
 
 from sage.repl.display.pretty_print import SagePrettyPrinter
 from sage.misc.lazy_import import lazy_import
+from sage.structure.sage_object import SageObject
 
 IPYTHON_NATIVE_TYPES = (DisplayObject, Widget)
 
@@ -173,6 +174,35 @@ class SageDisplayFormatter(DisplayFormatter):
             sage: shell.run_cell('%display default')
             sage: shell.quit()
 
+        A Sage object's generic ``_repr_latex_`` exists for stock Python
+        Jupyter kernels and must not override ``%display default`` here
+        (:issue:`2236`)::
+
+            sage: from sage.structure.sage_object import SageObject
+            sage: from sage.repl.rich_output import get_display_manager
+            sage: from sage.repl.rich_output.backend_ipython import BackendIPythonNotebook
+            sage: class Formula(SageObject):
+            ....:     def _repr_(self):
+            ....:         return 'formula'
+            ....:     def _repr_latex_(self):
+            ....:         return r'$\displaystyle \frac{1}{2}$'
+            sage: shell = get_test_shell()
+            sage: dm = get_display_manager()
+            sage: previous = dm.switch_backend(BackendIPythonNotebook(), shell=shell)
+            sage: sorted(shell.display_formatter.format(Formula())[0])
+            ['text/plain']
+
+        Objects that are not Sage objects keep their own ``text/latex``, which
+        is how SymPy expressions render under a Sage kernel::
+
+            sage: class Foreign():
+            ....:     def _repr_latex_(self):
+            ....:         return r'$x$'
+            sage: sorted(shell.display_formatter.format(Foreign())[0])
+            ['text/latex', 'text/plain']
+            sage: _ = dm.switch_backend(previous, shell=shell)
+            sage: shell.quit()
+
         Test that ``__repr__`` is only called once when generating text output::
 
             sage: class Repper():
@@ -209,6 +239,14 @@ class SageDisplayFormatter(DisplayFormatter):
             exclude = list(exclude) + [PLAIN_TEXT]
         else:
             exclude = [PLAIN_TEXT]
+        if isinstance(obj, SageObject) and self.dm.preferences.text != 'latex':
+            # Sage objects carry a generic _repr_latex_ so that stock Python
+            # Jupyter kernels, which never install this formatter, can typeset
+            # formulas. Under a Sage kernel the text display preference makes
+            # that decision instead, so the hook must not quietly override
+            # "%display default". Objects that are not Sage objects, such as
+            # SymPy expressions, keep their own text/latex.
+            exclude.append(TEXT_LATEX)
         ipy_format, ipy_metadata = super().format(obj, include=include, exclude=exclude)
         if not ipy_format:
             return sage_format, sage_metadata

--- a/src/sage/structure/sage_object.pyx
+++ b/src/sage/structure/sage_object.pyx
@@ -220,6 +220,57 @@ cdef class SageObject:
             return super().__repr__()
         return reprfunc()
 
+    def _repr_latex_(self):
+        r"""
+        Return a LaTeX representation for IPython.
+
+        This standard display hook allows Sage objects to be typeset in a
+        stock Python Jupyter kernel without Sage's rich output system.
+
+        OUTPUT: a string containing a LaTeX display equation, or ``None`` if
+        no suitable representation is available
+
+        EXAMPLES::
+
+            sage: (1/2)._repr_latex_()
+            '$\\displaystyle \\frac{1}{2}$'
+            sage: QQ._repr_latex_()
+            '$\\displaystyle \\newcommand{\\Bold}[1]{\\mathbf{#1}}\\Bold{Q}$'
+
+        HTML escaping used by the MathJax renderer is removed from the LaTeX
+        payload::
+
+            sage: class LessThan(SageObject):
+            ....:     def _latex_(self):
+            ....:         return 'x < 1'
+            sage: LessThan()._repr_latex_()
+            '$\\displaystyle x < 1$'
+
+        Objects without a mathematical representation keep their plain text
+        output::
+
+            sage: SageObject()._repr_latex_() is None
+            True
+
+        Objects with a custom rich representation remain responsible for
+        their own display::
+
+            sage: from sage.misc.html import HtmlFragment
+            sage: HtmlFragment('<b>test</b>')._repr_latex_() is None
+            True
+        """
+        if hasattr(self, '_rich_repr_') or not hasattr(self, '_latex_'):
+            return None
+        try:
+            from sage.misc.html import MathJax
+        except ImportError:
+            return None
+        try:
+            latex = MathJax().eval(self, mode='plain')
+        except Exception:
+            return None
+        return '$\\displaystyle ' + str(latex).replace('&lt;', '<') + '$'
+
     def _ascii_art_(self):
         r"""
         Return an ASCII art representation.


### PR DESCRIPTION
Closes #2236.

Add `_repr_latex_()` to `SageObject` so stock Python Jupyter kernels publish MathJax-ready `text/latex` for Sage objects that implement `_latex_()`. The hook uses Sage's existing MathJax conversion, including macros. It falls back to text when optional categories support is unavailable, while objects with custom rich output keep their existing path.

Sage's formatter also runs standard IPython hooks when Sage output is plain text. Suppress the generic hook there unless `%display latex` is active. This preserves the default, plain, ASCII-art, and Unicode-art modes while leaving `text/latex` from non-Sage objects unchanged.

The plain-IPython repro covers a rational, polynomial, `QQ` parent macro, and `<` escaping. It fails against unpatched code and passes after a live rebuild with both `text/plain` and `text/latex`. The exact payloads, including `\Bold` and `x < 1`, also render in a stock Google Colab Python kernel.
