### PR TITLE
plot3d: free eval_grid() C arrays when evaluation raises

### DIFF
--- a/src/sage/plot/plot3d/parametric_surface.pyx
+++ b/src/sage/plot/plot3d/parametric_surface.pyx
@@ -520,6 +520,44 @@ cdef class ParametricSurface(IndexFaceSet):
             sage: P.triangulate()        # the retry redoes the work
             sage: len(P.face_list())
             81
+
+        C arrays used to evaluate subclasses and fast callable tuples are
+        released when evaluation raises an exception::
+
+            sage: import sys
+            sage: if sys.platform != 'win32':
+            ....:     import gc
+            ....:     import resource
+            ....:     class FailingSurface(ParametricSurface):
+            ....:         def eval(self, u, v):
+            ....:             raise ValueError("stop")
+            ....:     grid = (range(100_000), [0.0, 1.0])
+            ....:     def check(surface):
+            ....:         def fail():
+            ....:             try:
+            ....:                 surface.triangulate()
+            ....:             except ValueError:
+            ....:                 pass
+            ....:         fail()  # warm up allocations
+            ....:         fail()
+            ....:         gc.collect()
+            ....:         before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            ....:         for _ in range(50):
+            ....:             fail()
+            ....:         gc.collect()
+            ....:         after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            ....:         scale = 1 if sys.platform == 'darwin' else 1024
+            ....:         growth = (after - before) * scale
+            ....:         assert growth < 4_000_000, growth
+            ....:     check(FailingSurface(None, grid))
+            ....:     from sage.ext.fast_callable import ExpressionTreeBuilder, fast_callable
+            ....:     etb = ExpressionTreeBuilder(vars=('u', 'v'))
+            ....:     u, v = etb.var('u'), etb.var('v')
+            ....:     fast = fast_callable(u + v, domain=float)
+            ....:     def failing_function(u, v):
+            ....:         raise ValueError("stop")
+            ....:     check(ParametricSurface((fast, fast, failing_function), grid))
+            ....:     _ = gc.collect()
         """
         cdef double u, v
         if render_params is None:
@@ -704,82 +742,83 @@ cdef class ParametricSurface(IndexFaceSet):
         cdef double* vlist = NULL
         cdef bint fast_x, fast_y, fast_z
 
-        if self.f is None:
-            ulist = to_double_array(urange)
-            vlist = to_double_array(vrange)
-
-            res = self.vs
-            for i in range(m):
-                u = ulist[i]
-                for j in range(n):
-                    sig_check()
-                    v = vlist[j]
-                    self.eval_c(res, u, v)
-                    res += 1
-        elif isinstance(self.f, tuple):
-            fx, fy, fz = self.f
-
-            # First, deal with the fast functions (if any)
-            fast_x = isinstance(fx, Wrapper_rdf)
-            fast_y = isinstance(fy, Wrapper_rdf)
-            fast_z = isinstance(fz, Wrapper_rdf)
-            if fast_x or fast_y or fast_z:
+        try:
+            if self.f is None:
                 ulist = to_double_array(urange)
                 vlist = to_double_array(vrange)
 
                 res = self.vs
-                if fast_x:  # must be Wrapper_rdf
-                    for i in range(m):
-                        uv[0] = ulist[i]
-                        for j in range(n):
-                            sig_check()
-                            uv[1] = vlist[j]
-                            (<Wrapper_rdf>fx).call_c(uv, &res.x)
-                            res += 1
+                for i in range(m):
+                    u = ulist[i]
+                    for j in range(n):
+                        sig_check()
+                        v = vlist[j]
+                        self.eval_c(res, u, v)
+                        res += 1
+            elif isinstance(self.f, tuple):
+                fx, fy, fz = self.f
 
-                res = self.vs
-                if fast_y:  # must be Wrapper_rdf
-                    for i in range(m):
-                        uv[0] = ulist[i]
-                        for j in range(n):
-                            sig_check()
-                            uv[1] = vlist[j]
-                            (<Wrapper_rdf>fy).call_c(uv, &res.y)
-                            res += 1
+                # First, deal with the fast functions (if any)
+                fast_x = isinstance(fx, Wrapper_rdf)
+                fast_y = isinstance(fy, Wrapper_rdf)
+                fast_z = isinstance(fz, Wrapper_rdf)
+                if fast_x or fast_y or fast_z:
+                    ulist = to_double_array(urange)
+                    vlist = to_double_array(vrange)
 
-                res = self.vs
-                if fast_z:  # must be Wrapper_rdf
-                    for i in range(m):
-                        uv[0] = ulist[i]
-                        for j in range(n):
-                            sig_check()
-                            uv[1] = vlist[j]
-                            (<Wrapper_rdf>fz).call_c(uv, &res.z)
-                            res += 1
+                    res = self.vs
+                    if fast_x:  # must be Wrapper_rdf
+                        for i in range(m):
+                            uv[0] = ulist[i]
+                            for j in range(n):
+                                sig_check()
+                                uv[1] = vlist[j]
+                                (<Wrapper_rdf>fx).call_c(uv, &res.x)
+                                res += 1
 
-            # Finally, deal with the slow functions (if any)
-            if (not fast_x) or (not fast_y) or (not fast_z):
+                    res = self.vs
+                    if fast_y:  # must be Wrapper_rdf
+                        for i in range(m):
+                            uv[0] = ulist[i]
+                            for j in range(n):
+                                sig_check()
+                                uv[1] = vlist[j]
+                                (<Wrapper_rdf>fy).call_c(uv, &res.y)
+                                res += 1
+
+                    res = self.vs
+                    if fast_z:  # must be Wrapper_rdf
+                        for i in range(m):
+                            uv[0] = ulist[i]
+                            for j in range(n):
+                                sig_check()
+                                uv[1] = vlist[j]
+                                (<Wrapper_rdf>fz).call_c(uv, &res.z)
+                                res += 1
+
+                # Finally, deal with the slow functions (if any)
+                if (not fast_x) or (not fast_y) or (not fast_z):
+                    res = self.vs
+                    for uu in urange:
+                        for vv in vrange:
+                            sig_check()
+                            if not fast_x:
+                                res.x = fx(uu, vv)
+                            if not fast_y:
+                                res.y = fy(uu, vv)
+                            if not fast_z:
+                                res.z = fz(uu, vv)
+                            res += 1
+            else:
                 res = self.vs
                 for uu in urange:
                     for vv in vrange:
                         sig_check()
-                        if not fast_x:
-                            res.x = fx(uu, vv)
-                        if not fast_y:
-                            res.y = fy(uu, vv)
-                        if not fast_z:
-                            res.z = fz(uu, vv)
+                        res.x, res.y, res.z = self.f(uu, vv)
                         res += 1
-        else:
-            res = self.vs
-            for uu in urange:
-                for vv in vrange:
-                    sig_check()
-                    res.x, res.y, res.z = self.f(uu, vv)
-                    res += 1
-
-        sig_free(ulist)
-        sig_free(vlist)
+        finally:
+            sig_free(ulist)
+            sig_free(vlist)
 
     # One of the following two methods should be overridden in
     # derived classes.


### PR DESCRIPTION
Fixes #2777. Kept out of #2700, which was scoped to the `triangulate()` corruption.

`ParametricSurface.eval_grid()` allocates `ulist` and `vlist` through `to_double_array()` and reaches `sig_free()` only on the normal exit. Six `sig_check()` calls sit between the two, and `eval_c()`, `Wrapper_rdf.call_c()` and any Python component function can raise as well. A `KeyboardInterrupt` from a slow plot, or an error out of a user-supplied function, leaks both arrays.

Two of the three evaluation branches allocate: the one where `self.f` is None, which is the path the library's `ParametricSurface` subclasses take, and the fast tuple branch when at least one component is a `Wrapper_rdf`. A tuple of plain Python callables reaches neither `to_double_array()` call, so that branch is unaffected.

Both pointers are NULL-initialized before the `try`, and `sig_free(NULL)` is `free(NULL)`, so the finally is correct whichever branch ran, and correct when `to_double_array(vrange)` raises after `ulist` was already allocated. `git diff -w` reports 40 added lines and 1 removed; the rest of the diff is the indentation the `try` forces.

A doctest in `triangulate()` drives both allocating branches, a subclass whose `eval()` raises and a tuple of two `Wrapper_rdf` components with one raising callable, and asserts that the resident set high-water mark grows by under 4 MB across 50 failed triangulations. Under `sage -t --optional=sage,sage.symbolic src/sage/plot/plot3d/parametric_surface.pyx` the file goes from 117 doctests to 119. Against the unpatched extension the new test fails with `AssertionError: 35078144` on aarch64 Linux; against the patched one it passes.
