### PR TITLE
Obtain ThreeJS offline scripts from `jupyter_threejs_sage` Python package data

### DIFF
--- a/pkgs/sage-conf/_sage_conf/_conf.py.in
+++ b/pkgs/sage-conf/_sage_conf/_conf.py.in
@@ -56,7 +56,6 @@ SAGE_PKG_CONFIG_PATH = "@SAGE_PKG_CONFIG_PATH@".replace('$SAGE_LOCAL', SAGE_LOCA
 
 # Used in sage.repl.ipython_kernel.install
 MATHJAX_DIR = "@SAGE_MATHJAX_DIR@".replace('${prefix}', SAGE_LOCAL)
-THREEJS_DIR = SAGE_LOCAL + "/share/threejs-sage"
 
 # OpenMP flags, if available.
 OPENMP_CFLAGS = "@OPENMP_CFLAGS@"

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -57,7 +57,6 @@ SAGE_PKG_CONFIG_PATH = "@SAGE_PKG_CONFIG_PATH@".replace("$SAGE_LOCAL", SAGE_LOCA
 
 # Used in sage.repl.ipython_kernel.install
 MATHJAX_DIR = "@SAGE_MATHJAX_DIR@".replace("${prefix}", SAGE_LOCAL)
-THREEJS_DIR = SAGE_LOCAL + "/share/threejs-sage"
 
 # OpenMP flags, if available.
 OPENMP_CFLAGS = "@OPENMP_CFLAGS@"

--- a/src/sage/features/threejs.py
+++ b/src/sage/features/threejs.py
@@ -29,7 +29,21 @@ class Threejs(StaticFile):
         """
         from sage.env import sage_data_paths, THREEJS_DIR
 
-        threejs_search_path = THREEJS_DIR or list(sage_data_paths('jupyter/nbextensions/threejs-sage')) + list(sage_data_paths('threejs-sage')) + list(sage_data_paths('threejs'))
+        threejs_search_path = []
+
+        if THREEJS_DIR:
+            threejs_search_path.append(THREEJS_DIR)
+
+        try:
+            import jupyter_threejs_sage.static
+        except ImportError:
+            pass
+        else:
+            threejs_search_path.extend(jupyter_threejs_sage.static.__path__)
+
+        threejs_search_path.extend(
+            list(sage_data_paths('jupyter/nbextensions/threejs-sage')) + list(sage_data_paths('threejs-sage')) + list(sage_data_paths('threejs'))
+        )
 
         try:
             version = self.required_version()


### PR DESCRIPTION
We stop setting THREEJS_DIR in sage.config; it certainly should not be set to a subdirectory of `SAGE_LOCAL/share`, as we install threejs with pip.

It is installed in two places:
```
$ ls -l venv/lib/python3.14/site-packages/jupyter_threejs_sage/static/
drwxr-xr-x  3 mkoeppe  staff  96 Aug 31 17:27 r122
drwxr-xr-x  3 mkoeppe  staff  96 Aug 31 17:27 r123
drwxr-xr-x  3 mkoeppe  staff  96 Aug 31 17:27 r130
$ ls -l venv/share/jupyter/nbextensions/threejs-sage/
drwxr-xr-x  3 mkoeppe  staff  96 Aug 31 17:27 r122
drwxr-xr-x  3 mkoeppe  staff  96 Aug 31 17:27 r123
drwxr-xr-x  3 mkoeppe  staff  96 Aug 31 17:27 r130
```

We access the first one now, treating it as Python package data.

- Fixes #2710