### PR TITLE
HtmlFragment: use UserString for plain Jupyter display

### DIFF
--- a/src/sage/misc/html.py
+++ b/src/sage/misc/html.py
@@ -21,6 +21,7 @@ renderable in a browser-based notebook with the help of MathJax.
 # *****************************************************************************
 
 import re
+from collections import UserString
 
 from sage.misc.latex import latex
 from sage.structure.sage_object import SageObject
@@ -28,7 +29,7 @@ from sage.structure.sage_object import SageObject
 macro_regex = re.compile(r'\\newcommand{(?P<name>\\[a-zA-Z]+)}(\[.+\])?{(?P<definition>.+)}')
 
 
-class HtmlFragment(str, SageObject):
+class HtmlFragment(SageObject, UserString):
     r"""
     A HTML fragment.
 
@@ -39,11 +40,85 @@ class HtmlFragment(str, SageObject):
     EXAMPLES::
 
         sage: from sage.misc.html import HtmlFragment
-        sage: HtmlFragment('<b>test</b>')
+        sage: fragment = HtmlFragment('<b>test</b>')
+        sage: fragment
         <b>test</b>
+        sage: str(fragment)
+        '<b>test</b>'
+        sage: isinstance(fragment, str)
+        False
 
+    .. automethod:: _repr_
+    .. automethod:: _repr_html_
     .. automethod:: _rich_repr_
     """
+
+    # SageObject precedes UserString in the method resolution order so that
+    # _repr_ governs printing.  SageObject is unhashable, however, and HTML
+    # fragments are immutable strings, so take hashing from UserString.
+    __hash__ = UserString.__hash__
+
+    def _repr_(self):
+        r"""
+        Return the underlying HTML without quotes.
+
+        EXAMPLES::
+
+            sage: from sage.misc.html import HtmlFragment
+            sage: HtmlFragment('<b>test</b>')._repr_()
+            '<b>test</b>'
+        """
+        return self.data
+
+    def _repr_html_(self):
+        r"""
+        Return the HTML representation of this fragment.
+
+        This allows plain IPython and Jupyter frontends to display the
+        fragment as HTML without requiring Sage's rich output system.
+
+        EXAMPLES::
+
+            sage: from sage.misc.html import HtmlFragment
+            sage: fragment = HtmlFragment('<b>test</b>')
+            sage: fragment._repr_html_()
+            '<b>test</b>'
+            sage: type(fragment._repr_html_()) is str
+            True
+
+        TESTS::
+
+            sage: # needs ipython
+            sage: from IPython.core.formatters import DisplayFormatter
+            sage: formats, metadata = DisplayFormatter().format(fragment)
+            sage: formats['text/html'] == str(fragment)
+            True
+            sage: 'text/plain' in formats
+            True
+        """
+        return str(self)
+
+    def join(self, seq):
+        r"""
+        Return the items of ``seq`` joined by this fragment.
+
+        INPUT:
+
+        - ``seq`` -- iterable; each item is converted with ``str``
+
+        Unlike the inherited :meth:`collections.UserString.join`, this
+        accepts items that are not :class:`str` and returns a fragment
+        rather than a plain :class:`str`.
+
+        EXAMPLES::
+
+            sage: from sage.misc.html import HtmlFragment
+            sage: HtmlFragment('<br>').join(['<b>a</b>', HtmlFragment('<i>b</i>')])
+            <b>a</b><br><i>b</i>
+            sage: type(HtmlFragment('').join([]))
+            <class 'sage.misc.html.HtmlFragment'>
+        """
+        return self.__class__(self.data.join(str(item) for item in seq))
 
     def _rich_repr_(self, display_manager, **kwds):
         """
@@ -61,9 +136,9 @@ class HtmlFragment(str, SageObject):
         """
         OutputHtml = display_manager.types.OutputHtml
         if OutputHtml in display_manager.supported_output():
-            return OutputHtml(self)
+            return OutputHtml(str(self))
         else:
-            return display_manager.types.OutputPlainText(self)
+            return display_manager.types.OutputPlainText(str(self))
 
 
 def math_parse(s):
@@ -496,7 +571,7 @@ class HTMLFragmentFactory(SageObject):
             from sage.repl.user_globals import get_globals
             locals = get_globals()
         s = str(s)
-        s = math_parse(s)
+        s = str(math_parse(s))
         t = ''
         while s:
             i = s.find('<sage>')

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -2575,7 +2575,7 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
                                "An optimal solution: ${}$.").format(
                                latex(v), latex(d.basic_solution())))
         self._final_revised_dictionary = d
-        return HtmlFragment("\n".join(output))
+        return HtmlFragment("\n").join(output)
 
     def run_simplex_method(self):
         r"""
@@ -2703,7 +2703,7 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
                                "An optimal solution: ${}$.").format(
                                latex(v), latex(d.basic_solution())))
             self._final_dictionary = d
-        return HtmlFragment("\n".join(output))
+        return HtmlFragment("\n").join(output)
 
     def slack_variables(self):
         r"""
@@ -3689,7 +3689,7 @@ class LPAbstractDictionary(SageObject):
             self.update()
         if self.is_optimal():
             output.append(self._html_())
-        return HtmlFragment("\n".join(output))
+        return HtmlFragment("\n").join(output)
 
     def run_simplex_method(self):
         r"""
@@ -3769,7 +3769,7 @@ class LPAbstractDictionary(SageObject):
             self.update()
         if self.is_optimal():
             output.append(self._html_())
-        return HtmlFragment("\n".join(output))
+        return HtmlFragment("\n").join(output)
 
     @abstract_method
     def update(self):
@@ -4687,13 +4687,13 @@ class LPRevisedDictionary(LPAbstractDictionary):
             \end{array}\right)
             \end{equation*}
         """
-        return HtmlFragment("\n".join([
+        return HtmlFragment("\n").join([
             super()._preupdate_output(direction),
             r"\begin{equation*}",
             r"B_\mathrm{new}^{-1} = E^{-1} B_\mathrm{old}^{-1} = ",
             latex(self.E_inverse()),
             latex(self.B_inverse()),
-            r"\end{equation*}"]))
+            r"\end{equation*}"])
 
     def A(self, v):
         r"""

--- a/src/sage/repl/rich_output/backend_base.py
+++ b/src/sage/repl/rich_output/backend_base.py
@@ -467,7 +467,7 @@ class BackendBase(SageObject):
         concatenate = kwds.get('concatenate', False)
         from sage.misc.html import html
         from sage.repl.rich_output.output_browser import OutputHtml
-        return OutputHtml(html(obj, concatenate=concatenate, strict=True))
+        return OutputHtml(str(html(obj, concatenate=concatenate, strict=True)))
 
     def set_underscore_variable(self, obj):
         """


### PR DESCRIPTION
Addresses #2384.

`HtmlFragment` inherits from `str`, so Colab and other stock IPython frontends run their string formatter before consulting `_repr_html_`. This changes the base to `(SageObject, UserString)` and adds `_repr_html_`, so the `text/html` MIME type can be selected. The unquoted Sage representation, string conversion, equality, and hashing are unchanged.

The cost is that the class is no longer a `str`: `isinstance(html(x), str)` is now `False`, `str.join` rejects it, and non-empty format specs raise (python/cpython#60601). `join` is overridden to cover the common case, converting its items with `str` and returning a fragment rather than the plain `str` the inherited `UserString.join` returns (python/cpython#84125); the five simplex transcript sites use it. The three callers that need a real `str` convert at the call site: the rich output containers, `<sage>` evaluation, and `BackendBase.latex_formatter`. `latex_formatter` is the `%display latex` path for Sage's own kernel and gets no new test, because 6 of its existing doctests fail without the conversion.

`src/sage/misc/html.py` runs 80 doctests, `src/sage/misc/table.py` 58, and `src/sage/repl/rich_output/backend_base.py` 96, all passing. Across `sage/repl/`, `sage/misc/`, `sage/interacts/`, `sage/typeset/`, and `src/sage/numerical/interactive_simplex_method.py`, the set of failing files is identical with and without the patch; the 11 remaining simplex failures come from `sage.symbolic` and `cddexec` being absent locally.
