### PR TITLE
build/pkgs/{contourpy,cypari,cysignals,matplotlib,sagemath_doc_*,scipy}: Set build-dir for meson-python

### DIFF
--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -250,7 +250,7 @@ sdh_build_wheel() {
             --no-deps)
                 install_options="$install_options $1"
                 ;;
-            -C|--config-settings)
+            -C|--config-settings|--config-setting)
                 shift
                 # Per 'python -m build --help', options which begin with a hyphen
                 # must be in the form of "--config-setting=--opt(=value)" or "-C--opt(=value)"

--- a/build/pkgs/contourpy/spkg-install.in
+++ b/build/pkgs/contourpy/spkg-install.in
@@ -3,4 +3,4 @@ export CXX=$(echo "$CXX" | sed 's/-std=[a-z0-9+]*//g')
 
 cd src
 # --no-build-isolation because it has build dep on 'meson', which we don't have as a Python package
-sdh_pip_install --no-build-isolation .
+sdh_pip_install --config-setting build-dir=$(pwd)/build-meson --no-build-isolation .

--- a/build/pkgs/cypari/spkg-install.in
+++ b/build/pkgs/cypari/spkg-install.in
@@ -1,1 +1,1 @@
-cd src && sdh_pip_install --config-setting=setup-args="-Dpari-prefix=$SAGE_LOCAL" .
+cd src && sdh_pip_install --config-setting build-dir=$(pwd)/build-meson --config-setting=setup-args="-Dpari-prefix=$SAGE_LOCAL" .

--- a/build/pkgs/cysignals/spkg-install.in
+++ b/build/pkgs/cysignals/spkg-install.in
@@ -3,4 +3,4 @@ cd src
 # #29473: Override -Wp,-D_FORTIFY_SOURCE from Fedora's python3.
 export CPPFLAGS="$CPPFLAGS -Wp,-U_FORTIFY_SOURCE"
 
-sdh_pip_install .
+sdh_pip_install --config-setting build-dir=$(pwd)/build-meson .

--- a/build/pkgs/matplotlib/spkg-install.in
+++ b/build/pkgs/matplotlib/spkg-install.in
@@ -9,6 +9,6 @@ unset https_proxy
 # Finally install
 # https://matplotlib.org/stable/install/dependencies.html#use-system-libraries
 # --no-build-isolation is to avoid [matplotlib-3.10.3] [spkg-install] < ERROR: No matching distribution found for meson-python<0.17.0,>=0.13.1
-sdh_pip_install --no-build-isolation \
+sdh_pip_install --config-setting build-dir=$(pwd)/build-meson --no-build-isolation \
                 -C setup-args="-Dsystem-freetype=true" \
                 -C setup-args="-Dsystem-qhull=true" .

--- a/build/pkgs/numpy/spkg-install.in
+++ b/build/pkgs/numpy/spkg-install.in
@@ -27,4 +27,4 @@ fi
 ### http://scipy.github.io/devdocs/building/index.html
 
 
-sdh_pip_install .
+sdh_pip_install --config-setting build-dir=$(pwd)/build-meson .

--- a/build/pkgs/sagemath_doc_html/spkg-install.in
+++ b/build/pkgs/sagemath_doc_html/spkg-install.in
@@ -7,14 +7,14 @@ if [ "$SAGE_EDITABLE" = yes ]; then
     # Editables 0.5 does not map non-package data files
     # https://editables.readthedocs.io/en/latest/use-cases.html#mapping-non-python-directories-or-files
     mkdir -p ${SAGE_DESTDIR}${SAGE_INST_LOCAL}/share/doc/sage
-    sdh_pip_editable_install .
+    sdh_pip_editable_install --config-setting build-dir=$(pwd)/build-meson .
     # We expect a subdirectory like build/cp312.
     # Use 'find -newer' to use the one just created/modified by the editable build.
     find $(pwd -P)/build -maxdepth 1 -name "cp*" -newer ${SAGE_DESTDIR}${SAGE_INST_LOCAL} -exec \
          ln -svf {}/html {}/index.html ${SAGE_DESTDIR}${SAGE_INST_LOCAL}/share/doc/sage/ \;
     if [ "$SAGE_WHEELS" = yes ]; then
-        sdh_build_and_store_wheel --no-build-isolation .
+        sdh_build_and_store_wheel --config-setting build-dir=$(pwd)/build-meson --no-build-isolation .
     fi
 else
-    sdh_pip_install --no-build-isolation .
+    sdh_pip_install --config-setting build-dir=$(pwd)/build-meson --no-build-isolation .
 fi

--- a/build/pkgs/sagemath_doc_pdf/spkg-install.in
+++ b/build/pkgs/sagemath_doc_pdf/spkg-install.in
@@ -7,14 +7,14 @@ if [ "$SAGE_EDITABLE" = yes ]; then
     # Editables 0.5 does not map non-package data files
     # https://editables.readthedocs.io/en/latest/use-cases.html#mapping-non-python-directories-or-files
     mkdir -p ${SAGE_DESTDIR}${SAGE_INST_LOCAL}/share/doc/sage
-    sdh_pip_editable_install .
+    sdh_pip_editable_install --config-setting build-dir=$(pwd)/build-meson .
     # We expect a subdirectory like build/cp312.
     # Use 'find -newer' to use the one just created/modified by the editable build.
     find $(pwd -P)/build -maxdepth 1 -name "cp*" -newer ${SAGE_DESTDIR}${SAGE_INST_LOCAL} -exec \
          ln -svf {}/pdf ${SAGE_DESTDIR}${SAGE_INST_LOCAL}/share/doc/sage/ \;
     if [ "$SAGE_WHEELS" = yes ]; then
-        sdh_build_and_store_wheel --no-build-isolation .
+        sdh_build_and_store_wheel --config-setting build-dir=$(pwd)/build-meson --no-build-isolation .
     fi
 else
-    sdh_pip_install --no-build-isolation .
+    sdh_pip_install --config-setting build-dir=$(pwd)/build-meson --no-build-isolation .
 fi

--- a/build/pkgs/scipy/spkg-install.in
+++ b/build/pkgs/scipy/spkg-install.in
@@ -7,4 +7,4 @@ cd src/
 # even when --no-isolation (--no-build-isolation) is in used. We patch it out.
 sed -i.bak '/build-system/,/project/s/^ *"numpy.*/    "numpy",/' pyproject.toml
 
-sdh_pip_install --no-build-isolation .
+sdh_pip_install --config-setting build-dir=$(pwd)/build-meson --no-build-isolation .


### PR DESCRIPTION
To enable diagnostics on error.

The build-dir is set to a subdirectory of the source dir (in SAGE_VENV/var/tmp/sage/build/...), where it is preserved on error. (The default by meson-python is to create a temporary directory, which is already erased by the time that pip reports the error.)
