### PR TITLE
tox.ini (local-conda): Clear PKG_CONFIG_PATH

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -582,6 +582,7 @@ setenv =
     # conda
     local-conda:      CONDA_PREFIX={envdir}/conda
     local-conda:      PATH={env:CONDA_PREFIX}/bin:/usr/bin:/bin:/usr/sbin:/sbin
+    local-conda:      PKG_CONFIG_PATH=
     local-conda:      CONDA_PKGS_DIRS={env:SHARED_CACHE_DIR}/conda_pkgs
     local-conda:      CONDA_OS=$(uname | sed 's/^Darwin/MacOSX/;')
     local-conda:      CONDA_ARCH=$(uname -m)


### PR DESCRIPTION
So that harmful settings from `.homebrew-build-env` do not leak in, which break builds using meson-python

```
env[PKG_VER]: 2.4.6
env[PKG_NAME]: numpy-2.4.6
env[PKG_BASE]: numpy
env[PKG_CONFIG_LIBDIR]: /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/conda/lib/pkgconfig
env[PKG_CONFIG_PATH]: /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/local/lib/pkgconfig:/opt/homebrew/opt/sqlite/lib/pkgconfig:/opt/homebrew/opt/readline/lib/pkgconfig:/opt/homebrew/opt/openssl/lib/pkgconfig:/opt/homebrew/opt/openblas/lib/pkgconfig:/opt/homebrew/lib/pkgconfig
env[PKG_CONFIG]: /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/conda/bin/pkg-config
-----------
Called: `/Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/conda/bin/pkg-config --libs python-3.13` -> 0
stdout:
-L/opt/homebrew/lib
-----------
Run-time dependency python found: YES 3.13
Running compile:
Working directory:  /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/local/var/tmp/sage/build/numpy-2.4.6/src/build-meson/meson-private/tmp_nl6k6y4
Code:

        #ifdef __has_include
         #if !__has_include("Python.h")
          #error "Header 'Python.h' could not be found"
         #endif
        #else
         #include <Python.h>
        #endif
-----------
Command line: `arm64-apple-darwin20.0.0-clang -I/opt/homebrew/include/python3.13 /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/local/var/tmp/sage/build/numpy-2.4.6/src/build-meson/meson-private/tmp_nl6k6y4/testfile.c -E -P -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -isystem /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/conda/include -D_FORTIFY_SOURCE=2 -isystem /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/conda/include -P -O0 -Werror=implicit-function-declaration -std=c11` -> 1
stderr:
/Users/mkoeppe/s/sage/sage-rebasing/.tox/local-conda-forge-macos-standard/local/var/tmp/sage/build/numpy-2.4.6/src/build-meson/meson-private/tmp_nl6k6y4/testfile.c:4:12: error: "Header 'Python.h' could not be found"
    4 |           #error "Header 'Python.h' could not be found"
      |            ^
1 error generated.
-----------
Has header "Python.h" with dependency python-3.13: NO 

../meson.build:41:2: ERROR: Problem encountered: Cannot compile `Python.h`. Perhaps you need to install python-dev|python-devel
```
