### PR TITLE
build/pkgs/memory_allocator: Relax pin to a pre-meson version for non-Windows systems

### DIFF
--- a/build/pkgs/memory_allocator/version_requirements.txt
+++ b/build/pkgs/memory_allocator/version_requirements.txt
@@ -1,1 +1,1 @@
-memory_allocator < 0.2
+memory_allocator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ requires = [
   'gmpy2 ~=2.1.b999',
   'gmpy2 ~=2.3.b1; sys_platform == "win32"',
   'jinja2',
-  'memory_allocator <0.2',
+  'memory_allocator < 0.2; sys_platform == "win32"',
+  'memory_allocator',
   'numpy >=2.1',
 ]
 [tool.meson-python.args]
@@ -65,7 +66,8 @@ dependencies = [
   'ipywidgets >=7.5.1',
   'jupyter-client',
   'matplotlib >=3.7.0',
-  'memory_allocator <0.2',
+  'memory_allocator < 0.2; sys_platform == "win32"',
+  'memory_allocator',
   'mpmath >=1.1.0, <1.4',
   'networkx >=3.1',
   'numpy >=2.1',


### PR DESCRIPTION
The pin was introduced in
- https://github.com/passagemath/passagemath/pull/2012

because of breakage on Windows ARM.

Hopefully we are fine on non-Windows systems, at least after the following has been resolved:
- https://github.com/mesonbuild/meson/issues/15740
- https://github.com/passagemath/passagemath/issues/2852
