### PR TITLE
sage.features.pkg_systems: Fix for getting package info from passagemath-bootstrap 

### DIFF
--- a/build/pkgs/sagemath_environment/dependencies_check
+++ b/build/pkgs/sagemath_environment/dependencies_check
@@ -1,1 +1,1 @@
-tox
+tox sage_bootstrap

--- a/pkgs/sagemath-environment/pyproject.toml.m4
+++ b/pkgs/sagemath-environment/pyproject.toml.m4
@@ -19,14 +19,15 @@ dynamic = ["version"]
 include(`pyproject_toml_metadata_supports_windows.m4')dnl'
 
 [project.optional-dependencies]
-conf      = [SPKG_INSTALL_REQUIRES_sage_conf]           # sage.env can optionally use sage_conf
-docbuild  = [SPKG_INSTALL_REQUIRES_sage_docbuild]       # For "sage --docbuild"
-sage      = [SPKG_INSTALL_REQUIRES_sagelib]             # For "sage", "sage -t", ...
+conf      = [SPKG_INSTALL_REQUIRES_sage_conf]           # sage.env can optionally use passagemath-conf
 cython    = [SPKG_INSTALL_REQUIRES_cython]              # For "sage --cython"
+docbuild  = [SPKG_INSTALL_REQUIRES_sage_docbuild]       # For "sage --docbuild"
+package   = [SPKG_INSTALL_REQUIRES_sage_bootstrap]      # For "sage --package", package installation advice
 pytest    = [SPKG_INSTALL_REQUIRES_pytest]              # For "sage --pytest"
 rst2ipynb = [SPKG_INSTALL_REQUIRES_rst2ipynb]           # For "sage --rst2ipynb"
-tox       = [SPKG_INSTALL_REQUIRES_tox]                 # For "sage --tox"
+sage      = [SPKG_INSTALL_REQUIRES_sagelib]             # For "sage", "sage -t", ...
 sws2rst   = [SPKG_INSTALL_REQUIRES_sage_sws2rst]        # For "sage --sws2rst"
+tox       = [SPKG_INSTALL_REQUIRES_tox]                 # For "sage --tox"
 
 [project.readme]
 file = "README.rst"

--- a/pkgs/sagemath-environment/tox.ini
+++ b/pkgs/sagemath-environment/tox.ini
@@ -43,7 +43,7 @@ deps =
     !norequirements:         -rrequirements.txt
 
 extras =
-                             test
+                             package
 
 passenv =                    {[pkgenv]passenv}
                              SAGE_DOCTEST_OPTIONS
@@ -60,7 +60,7 @@ allowlist_externals =
 
 commands =
     # Beware of the treacherous non-src layout. "./sage/" shadows the installed sage package.
-    {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); from sage.features.all import all_features; print(sorted(all_features(), key=lambda x: x.name)); import sage.misc.package'
+    {envpython} -c 'import sys; "" in sys.path and sys.path.remove(""); from sage.features.all import all_features; print(sorted(all_features(), key=lambda x: x.name)); import sage.misc.package; from sage.features.ffmpeg import FFmpeg; print(FFmpeg().resolution())'
 
 [testenv:.tox]
 # Allow access to PyPI for auto-provisioning a suitable tox version

--- a/src/sage/features/pkg_systems.py
+++ b/src/sage/features/pkg_systems.py
@@ -69,15 +69,27 @@ class PackageSystem(Feature):
             sage: fedora.spkg_installation_hint('openblas')  # optional - SAGE_ROOT
             'To install openblas using the fedora package manager, you can try to run:\n!sudo yum install openblas-devel'
         """
+        import shlex
         from subprocess import run, CalledProcessError
         lines = []
         system = self.name
+        from sage.env import SAGE_ROOT
+        if not SAGE_ROOT:
+            try:
+                import sage_root
+            except ImportError:
+                pass
+            else:
+                for root in sage_root.__path__:
+                    SAGE_ROOT = root
+                    break
+        env = f'SAGE_ROOT={shlex.quote(SAGE_ROOT)} ' if SAGE_ROOT else ''
         try:
-            proc = run(f'sage-get-system-packages {system} {spkgs}',
+            proc = run(f'{env}sage-get-system-packages {system} {spkgs}',
                        shell=True, capture_output=True, text=True, check=True)
             system_packages = proc.stdout.strip()
             if system_packages:
-                print_sys = f'sage-print-system-package-command {system} --verbose --sudo --prompt="{prompt}"'
+                print_sys = f'{env}sage-print-system-package-command {system} --verbose --sudo --prompt="{prompt}"'
                 command = f'{print_sys} update && {print_sys} install {system_packages}'
                 proc = run(command, shell=True, capture_output=True, text=True, check=True)
                 command = proc.stdout.strip()


### PR DESCRIPTION
As noted in https://github.com/passagemath/passagemath/issues/2858#issuecomment-5642926879, the `sage-get-system-packages` shell script as shipped by **passagemath-bootstrap** does not work. The proper fix would be to write this script in Python, but here we do the simpler fix of setting `SAGE_ROOT` correctly before invoking the scripts.